### PR TITLE
docs: protected-main workflow + PR-based release runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,20 @@ go test ./internal/version/ -run TestResolve_LdflagsWin -v
 
 **Versioning is hybrid.** `internal/version` reads ldflags-injected `Version/Commit/Date` (set by Makefile + GoReleaser); when empty (bare `go install`) it falls back to `debug.ReadBuildInfo()`, final fallback `"dev"`. `main.go`'s `decide()` is a pure, tested function: a single `--version` short-circuits; a `ContinueOnError` FlagSet with discarded output ensures unknown flags / `-h` / `-v` / positional args fall through to the TUI (no `os.Exit(2)`, no usage dump). `-v` is intentionally unbound (reserved for a future `--verbose`).
 
+## Git Workflow (protected main — enforced)
+
+`main` is protected. **Never commit or push directly to `main`.** This is hard-enforced two ways: GitHub branch protection (PR required, direct push denied, `ci.yml` must pass, linear history) and a local PreToolUse hook that blocks `git commit`/`git push` to main in this repo.
+
+Every change — code, docs, config, release prep — follows:
+
+1. Branch off `main`: `feat/…`, `fix/…`, or `chore/…`.
+2. Commit on the branch (conventional commits, no AI references).
+3. Push the branch; open a PR to `main`.
+4. `ci.yml` must be green; **squash-merge** the PR (squash is the only enabled merge mode; branch auto-deletes).
+5. Tags are cut on `main` **only after** the PR is merged. Tag pushes are allowed by the hook/protection (only branch refs are protected).
+
+**Release runbook is now PR-based:** branch → commit phases → push branch → PR → squash-merge → `git tag` the merged commit on main → push tag → `release.yml`. The disposable-dry-run / fix-forward / never-re-tag invariants are unchanged (see `CONTRIBUTING.md`).
+
 ## Conventions & Constraints
 
 - **File size:** keep every Go file < 200 LOC. Split by concern (`screen_x.go` / `screen_x_view.go` / `screen_x_actions.go` / `screen_x_test.go`). Core logic uses `snake_case` filenames; small utility/output modules use `kebab-case`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,16 @@ make clean       # remove ./bin/
 All of `build`, `vet`, `gofmt -l` (empty), and `go test ./... -race -count=1`
 must pass before a change is merged — these are exactly what CI enforces.
 
-## Commit & PR conventions
+## Branch & PR workflow (protected main)
+
+`main` is protected — **no direct commits or pushes**. Enforced by GitHub
+branch protection (PR required, `ci.yml` must pass, linear history, admins
+included) and squash-only merges with automatic branch deletion.
+
+1. Branch off `main`: `feat/…`, `fix/…`, or `chore/…`.
+2. Commit on the branch; push it; open a PR to `main`.
+3. CI green → **squash-merge** the PR.
+4. Tags are cut on `main` only after the PR merges (see *Releasing* below).
 
 - **Conventional Commits**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`,
   `build:`, `ci:`, `chore:` (with optional scope). Use `!` / `BREAKING CHANGE:`
@@ -41,6 +50,21 @@ must pass before a change is merged — these are exactly what CI enforces.
 - **No AI / assistant references** in commit messages or PR descriptions.
 - Update `CHANGELOG.md` under `[Unreleased]` for any user-visible change.
 - One logical change per PR; keep the diff focused.
+
+## Releasing
+
+Releases are fix-forward and PR-based:
+
+1. Land all release changes via a branch → PR → squash-merge into `main`.
+2. From the merged `main` commit, run the disposable-tag dry-run (below),
+   verify, delete it.
+3. `git tag -a vX.Y.Z <merged-SHA> -m "Typeburn vX.Y.Z"` then
+   `git push origin vX.Y.Z` (separate push — never `git push --follow-tags`).
+4. `release.yml` self-gates (`ci.yml` does not run on tags) and publishes.
+
+Never delete-and-re-tag a version that reached the module proxy/sumdb (it is
+append-only — the version becomes permanently uninstallable). Fix forward to
+the next patch instead.
 
 ## Testing a release
 


### PR DESCRIPTION
Documents the now-enforced protected-main workflow.

- GitHub branch protection on main (PR required, ci.yml gate, linear history, admins enforced, squash-only, auto-delete branch)
- Local PreToolUse hook blocks git commit/push to main in this repo (tag pushes still allowed)
- CLAUDE.md: new Git Workflow section
- CONTRIBUTING.md: Branch & PR workflow + PR-based Releasing section

First change dogfooding the new flow (branch -> PR -> squash-merge).