### PR TITLE
v1.1.0 — theme packs + hygiene

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,16 +1,21 @@
-## [1.0.1] - 2026-05-18
+## [1.1.0] - 2026-05-19
 
-### Fixed
+### Added
 
-- **New-best precision:** the ★ personal-best badge compared rounded integer
-  WPM, so a strictly faster run that rounded to the same integer (e.g. 75.4 vs
-  75.0) did not earn the badge. New-best detection now compares the full-precision
-  net WPM. History records written by v1.0.0 (which lack the new field) fall
-  back to their stored rounded WPM, so existing personal bests are preserved.
+- **Theme packs:** six new color themes selectable in Settings —
+  `solarized-dark`, `solarized-light`, `dracula`, `nord`, `gruvbox-dark`,
+  `gruvbox-light` (bringing the total to eight, with `default` and `mono`).
+  `solarized-light` and `gruvbox-light` are the first light themes. `NO_COLOR`
+  behavior is unchanged.
+- **Persistence-failure notice:** if saving a result or settings to disk
+  fails, a dismissible one-line notice now appears instead of the failure
+  being silent. It never blocks input and clears on the next keypress.
 
-### Removed
+### Changed
 
-- **`missed` stat:** the result screen showed a `missed` counter that was always
-  `0` (the metrics package never received the target text to compute it). The
-  unusable field and its display were removed; no real metric is affected.
-[1.0.1]: https://github.com/bavanchun/Typeburn/releases/tag/v1.0.1
+- Documentation corrected post-1.0: removed the stale "badges 404 until the
+  first tag" note; the dependency-layering rule now describes the real
+  invariant (`config`/`theme` intentionally bridge to the TUI); the word
+  stream's wrap comment now matches the actual character-cell behavior.
+
+[1.1.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-19
+
 ### Added
 
 - **Theme packs:** six new color themes selectable in Settings —
@@ -83,6 +85,7 @@ terminal typing test built with Go and Bubble Tea v2.
   HTTPS transport and the pipeline-generated `checksums.txt`. See
   [SECURITY.md](./SECURITY.md).
 
-[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.1.0
 [1.0.1]: https://github.com/bavanchun/Typeburn/releases/tag/v1.0.1
 [1.0.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+### Added
+
+- **Theme packs:** six new color themes selectable in Settings —
+  `solarized-dark`, `solarized-light`, `dracula`, `nord`, `gruvbox-dark`,
+  `gruvbox-light` (bringing the total to eight, with `default` and `mono`).
+  `solarized-light` and `gruvbox-light` are the first light themes. `NO_COLOR`
+  behavior is unchanged.
+- **Persistence-failure notice:** if saving a result or settings to disk
+  fails, a dismissible one-line notice now appears instead of the failure
+  being silent. It never blocks input and clears on the next keypress.
+
+### Changed
+
+- Documentation corrected post-1.0: removed the stale "badges 404 until the
+  first tag" note; the dependency-layering rule now describes the real
+  invariant (`config`/`theme` intentionally bridge to the TUI); the word
+  stream's wrap comment now matches the actual character-cell behavior.
+
 ## [1.0.1] - 2026-05-18
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,11 @@ go test ./internal/version/ -run TestResolve_LdflagsWin -v
 
 ## Architecture
 
-**Strict dependency layering — do not violate.** The core packages are UI-free and must stay that way (no `bubbletea`/`lipgloss` imports in them):
+**Strict dependency layering — do not violate.** The *pure-logic* packages are UI-free and must stay that way (no `bubbletea`/`lipgloss` imports):
 
-- Pure core: `internal/typing` (keystroke state machine), `internal/metrics` (WPM/accuracy/consistency formulas), `internal/words` (embedded wordlist + quote pack), `internal/config` (settings, keymap, XDG paths), `internal/storage` (atomic JSON persistence), `internal/theme` (semantic colors), `internal/version` (build stamp).
-- `internal/ui` depends on the core packages and implements the five screen sub-models + reusable components.
+- Pure logic (no UI deps): `internal/typing` (keystroke state machine), `internal/metrics` (WPM/accuracy/consistency formulas), `internal/words` (embedded wordlist + quote pack), `internal/storage` (atomic JSON persistence), `internal/version` (build stamp).
+- Styling/input boundary (intentionally not reusable-core): `internal/config` binds Bubble Tea key types for its keymap, and `internal/theme` returns Lip Gloss styles/colors by design. These two depend on `charm.land` libs deliberately — they are the seam between pure logic and the TUI, not general-purpose libraries. Do not "fix" this by removing the imports; do not add new UI deps to the pure-logic packages above.
+- `internal/ui` depends on the packages above and implements the five screen sub-models + reusable components.
 - `internal/app` is the root Bubble Tea Elm model that wires everything together.
 
 **Elm message flow.** `app.Model` owns a `Screen` enum and five sub-models. Screen sub-models in `internal/ui` emit *domain* messages — `StartTestMsg`, `ResultMsg`, `AbortMsg`, `NavHistoryMsg` (defined in `internal/ui/messages.go`). The root model's `Update` routes them, owns screen transitions, and is the *only* place that persists results (`AppendHistory`) and computes new-best. Sub-models never touch storage directly. To add a screen interaction, emit a message from the sub-model and handle routing/side-effects in `internal/app`.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/bavanchun/Typeburn.svg)](https://pkg.go.dev/github.com/bavanchun/Typeburn)
 [![License](https://img.shields.io/github/license/bavanchun/Typeburn)](./LICENSE)
 
-> Release/pkg.go.dev badges 404 until the first tag is published — expected pre-`v1.0.0`.
-
 A Monkeytype-style terminal typing test built with Go and Bubble Tea v2.
 Distraction-free, keyboard-driven, and works on any ANSI terminal.
 

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -56,12 +56,24 @@ Slate-dark base + green accent ("code dark + run green"), red error, amber warni
 
 > Rule: any text the user must read *right now* ≥ 4.5:1. Deliberately receded text (`text-faint`) may go lower **only** when it is not yet actionable and will brighten before it matters.
 
-### 2.2 Future themes (names reserved, not fully specced)
+### 2.2 Theme packs (shipped v1.1.0)
 
-- `mono` — single-hue greyscale; accent = bold white, error = underline-only. For strict/mono terminals & purists.
-- `solarized-dark` — map roles onto Solarized base03..base3 + green/red/yellow accents.
+`mono` — single-hue greyscale; accent = bold white, error = underline-only. For strict/mono terminals & purists.
 
-Theme contract: a theme = a `map[Role]lipgloss.Color`. Screens reference **roles only**, never literals. Adding a theme = one map.
+Six community palettes mapped onto the 16 roles (one `internal/theme/<name>-theme.go` file each). Role order below: Bg · Surface · SurfaceAlt · TextPrimary · TextMuted · TextFaint · Accent · AccentDim · Error · ErrorBg · Warning · Success · CursorBg · CursorFg · Border · BorderFocus.
+
+| Theme | Bg | Surface | SurfaceAlt | TextPrimary | TextMuted | TextFaint | Accent | AccentDim | Error | ErrorBg | Warning | Success | CursorBg | CursorFg | Border | BorderFocus |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `solarized-dark` | `#002b36` | `#073642` | `#094d5c` | `#93a1a1` | `#839496` | `#586e75` | `#268bd2` | `#1f6a9e` | `#dc322f` | `#4a1715` | `#b58900` | `#859900` | `#268bd2` | `#002b36` | `#586e75` | `#268bd2` |
+| `solarized-light` | `#fdf6e3` | `#eee8d5` | `#ded8c5` | `#586e75` | `#657b83` | `#93a1a1` | `#268bd2` | `#3a7ca5` | `#dc322f` | `#f5d0cd` | `#b58900` | `#859900` | `#268bd2` | `#fdf6e3` | `#93a1a1` | `#268bd2` |
+| `dracula` | `#282a36` | `#343746` | `#44475a` | `#f8f8f2` | `#c9c9d1` | `#6272a4` | `#bd93f9` | `#7d5bbe` | `#ff5555` | `#5c1a1a` | `#f1fa8c` | `#50fa7b` | `#bd93f9` | `#282a36` | `#6272a4` | `#bd93f9` |
+| `nord` | `#2e3440` | `#3b4252` | `#434c5e` | `#eceff4` | `#d8dee9` | `#4c566a` | `#88c0d0` | `#5e81ac` | `#bf616a` | `#4a2326` | `#ebcb8b` | `#a3be8c` | `#88c0d0` | `#2e3440` | `#4c566a` | `#88c0d0` |
+| `gruvbox-dark` | `#282828` | `#3c3836` | `#504945` | `#ebdbb2` | `#a89984` | `#665c54` | `#fabd2f` | `#b57614` | `#fb4934` | `#4a1f1c` | `#fe8019` | `#b8bb26` | `#fabd2f` | `#282828` | `#665c54` | `#fabd2f` |
+| `gruvbox-light` | `#fbf1c7` | `#ebdbb2` | `#d5c4a1` | `#3c3836` | `#7c6f64` | `#bdae93` | `#b57614` | `#79740e` | `#9d0006` | `#f2d0cd` | `#af3a03` | `#79740e` | `#b57614` | `#fbf1c7` | `#bdae93` | `#b57614` |
+
+Sources: Solarized (ethanschoonover.com/solarized), Dracula (draculatheme.com), Nord (nordtheme.com), Gruvbox (github.com/morhetz/gruvbox). `solarized-light` / `gruvbox-light` are the first light themes — their Bg/Surface/Text roles are intentionally inverted vs the dark default; `palette_luminance_test.go` guards against accidental inversion, and per-screen contrast was reviewed manually.
+
+Theme contract: a theme = a `map[Role]lipgloss.Color`. Screens reference **roles only**, never literals. Adding a theme = one map. `theme.Available()` is the single display-order source; `config.Settings.Normalize` duplicates the accepted-name set (core layering forbids importing `theme`) and `theme_available_sync_test.go` keeps them in lockstep.
 
 ---
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -73,17 +73,19 @@
 - **Dependencies:** Settings addition (keybinding style selector)
 - **Scope:** Centralized keymap already supports easy extension
 
-#### Solarized-Dark Theme
-- **Description:** Map roles to Solarized base03/base2 + accent colors
-- **Effort:** ~2 hours (theme = one color map)
-- **Dependencies:** None (theme system already extensible)
-- **Status:** Name reserved in v1; awaiting color palette confirmation
+#### Theme Packs — ✅ SHIPPED (v1.1.0)
+- **Description:** Six community palettes mapped onto the 16 roles —
+  `solarized-dark`, `solarized-light`, `dracula`, `nord`, `gruvbox-dark`,
+  `gruvbox-light`. First light themes; `palette_luminance_test.go` guards
+  against inverted palettes; `theme_available_sync_test.go` keeps the
+  `config.Normalize` accepted-set in lockstep with `theme.Available()`.
+- **Status:** Shipped in v1.1.0 (2026-05-19). Palettes documented in
+  `design-guidelines.md` §2.2.
 
-#### Additional Themes
-- Dracula
-- Nord
-- Gruvbox
+#### Additional Themes (future, if requested)
 - One Dark Pro
+- Catppuccin
+- Tokyo Night
 
 ### Lower Priority (Nice-to-Have)
 
@@ -167,10 +169,14 @@
 - ✅ README + design-guidelines + system-architecture docs complete
 - ✅ Code review SHIP verdict; M1 fixed in v1.0 (d6369de), M2 accepted as documented v1 decision
 
-### Next 30 Days (Optional Post-1.0)
-1. **Evaluate M2 fix** (new-best precision): accepted v1 trade-off; revisit only if user feedback shows it matters → v1.1
-3. **Gather user feedback** on missing features (Code mode? Vim motions? More themes?)
-4. **Consider theme pipeline:** if multiple theme requests → prioritize Solarized > others
+### Shipped Post-1.0
+- ✅ **v1.0.1:** M2 new-best sub-WPM precision fixed; always-zero `missed` stat removed.
+- ✅ **v1.1.0:** Six theme packs (Solarized D/L, Dracula, Nord, Gruvbox D/L);
+  non-blocking persistence-failure notice; post-1.0 doc corrections.
+
+### Next (Optional)
+1. **Gather user feedback** on missing features (Code mode? Vim motions? more themes?)
+2. **Code mode / custom text input** — next-most-valuable product upgrade if requested.
 
 ### v2.0 Planning (Future)
 - M4: Add target delivery mechanism; remove MissedChars 0-stub or make it meaningful

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -38,6 +38,12 @@ type Model struct {
 	// quitPrompt is non-nil when the esc-on-Home quit confirmation overlay is
 	// active. ctrl+c always hard-quits regardless of this field.
 	quitPrompt *quitPromptModel
+
+	// persistErr holds a transient, user-visible message when a history or
+	// settings disk write failed. Empty = nothing to show. It is set at the
+	// failing persist site and cleared on the next keypress (any key) so the
+	// notice behaves like a dismissible toast; it never blocks input.
+	persistErr string
 }
 
 // New builds the root model loading persisted settings from disk.

--- a/internal/app/model_history.go
+++ b/internal/app/model_history.go
@@ -36,8 +36,11 @@ func (m Model) handleResultMsg(msg ui.ResultMsg) Model {
 	rec := buildRecord(msg)
 	hist := storage.LoadHistory()
 	isBest := storage.IsNewBest(hist, rec)
-	// Persist regardless of IsNewBest result; ignore write errors (non-fatal).
-	_, _ = storage.AppendHistory(rec)
+	// Persist regardless of IsNewBest result. A write failure is non-fatal to
+	// the session but must not be silent — surface a dismissible notice.
+	if _, err := storage.AppendHistory(rec); err != nil {
+		m.persistErr = "Couldn't save result to disk"
+	}
 
 	m.result = ui.NewResult(msg, m.theme, m.keys).WithBest(isBest).SetSize(m.w, m.h)
 	m.screen = ScreenResult

--- a/internal/app/model_key_handler.go
+++ b/internal/app/model_key_handler.go
@@ -18,6 +18,11 @@ func (m Model) handleKey(key tea.Key) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 
+	// Any other key dismisses the persistence-failure toast (it is purely
+	// informational). The keystroke still proceeds to its normal handling
+	// below; m is a value receiver so this cleared copy propagates out.
+	m.persistErr = ""
+
 	// Quit-prompt overlay: route keys into the prompt; dismiss or quit as needed.
 	// ctrl+c (above) already bypasses this, so only esc/enter/y/n/arrows reach here.
 	if m.quitPrompt != nil && m.screen == ScreenHome {

--- a/internal/app/model_settings.go
+++ b/internal/app/model_settings.go
@@ -20,8 +20,11 @@ func NewFromDisk() Model {
 // so that theme swap, blink toggle, and default mode/length apply live.
 func (m *Model) onSettingsChange(s config.Settings) {
 	m.settings = s
-	// Persist best-effort; ignore error to avoid crashing the UI on disk issues.
-	_ = storage.SaveSettings(s)
+	// Persist best-effort: a disk failure must not crash the UI, but it must
+	// not be silent either — surface a dismissible notice.
+	if err := storage.SaveSettings(s); err != nil {
+		m.persistErr = "Couldn't save settings to disk"
+	}
 	// Rebuild theme from the new name, then propagate to every sub-model.
 	m.theme = theme.Load(s.Theme, theme.EnvNoColor())
 	m.home = ui.NewHome(s, m.theme, m.keys).SetSize(m.w, m.h)

--- a/internal/app/model_view.go
+++ b/internal/app/model_view.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"strings"
+
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -27,41 +29,44 @@ func (m Model) View() tea.View {
 		return tea.NewView(m.quitPrompt.view(m.w, m.h, m.theme))
 	}
 
-	var body string
+	// Compute the final frame string in one place (single return) so the
+	// persistence notice can be overlaid uniformly. Home/Result/Settings/
+	// History self-place to w×h inside their own View(); Typing and the
+	// placeholder are placed here. With no notice this yields byte-identical
+	// output to the previous per-branch returns.
+	var out string
 	switch m.screen {
 	case ScreenHome:
-		// HomeModel.View() calls lipgloss.Place internally.
-		body = m.home.View()
-		if m.w > 0 && m.h > 0 {
-			return tea.NewView(body)
-		}
-	case ScreenTyping:
-		body = m.typing.View()
+		out = m.home.View() // self-placed
 	case ScreenResult:
-		// ResultModel.View() calls lipgloss.Place internally.
-		body = m.result.View()
-		if m.w > 0 && m.h > 0 {
-			return tea.NewView(body)
-		}
+		out = m.result.View() // self-placed
 	case ScreenSettings:
-		// SettingsModel.View() calls lipgloss.Place internally.
-		body = m.sett.View()
-		if m.w > 0 && m.h > 0 {
-			return tea.NewView(body)
-		}
+		out = m.sett.View() // self-placed
 	case ScreenHistory:
-		// HistoryModel.View() calls lipgloss.Place internally.
-		body = m.hist.View()
+		out = m.hist.View() // self-placed
+	case ScreenTyping:
+		out = m.typing.View()
 		if m.w > 0 && m.h > 0 {
-			return tea.NewView(body)
+			out = lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, out)
 		}
 	default:
-		body = placeholderView(m.screen, m.theme)
+		out = placeholderView(m.screen, m.theme)
+		if m.w > 0 && m.h > 0 {
+			out = lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, out)
+		}
 	}
 
-	content := body
-	if m.w > 0 && m.h > 0 {
-		content = lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, body)
+	// Transient persistence-failure toast: overlay onto the frame's last row
+	// (normally blank padding) so the line count — and thus every other
+	// screen's layout — is unchanged. Cleared on the next keypress.
+	if m.persistErr != "" && m.w > 0 && m.h > 0 {
+		lines := strings.Split(out, "\n")
+		notice := lipgloss.PlaceHorizontal(
+			m.w, lipgloss.Center, ui.PersistenceNotice(m.persistErr, m.theme),
+		)
+		lines[len(lines)-1] = notice
+		out = strings.Join(lines, "\n")
 	}
-	return tea.NewView(content)
+
+	return tea.NewView(out)
 }

--- a/internal/app/persistence_notice_test.go
+++ b/internal/app/persistence_notice_test.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/ui"
+)
+
+// blockedXDG points an XDG_* path at a location under a regular file so
+// os.MkdirAll fails (ENOTDIR) — a real write failure, no mocking.
+func blockedXDG(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	blocker := filepath.Join(tmp, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(blocker, "xdg") // a dir under a file → unwritable
+}
+
+// TestPersistNotice_HistoryFailureShownThenDismissed exercises the full path:
+// a failed AppendHistory sets persistErr, the View shows it, and any key
+// clears it while still routing normally.
+func TestPersistNotice_HistoryFailureShownThenDismissed(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", blockedXDG(t))
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	m := tea.Model(New(theme.Default(), config.Defaults()))
+	m = sm_sendSize(m, 80, 24)
+
+	m, _ = m.Update(ui.ResultMsg{
+		Result: sampleResult(),
+		Mode:   config.ModeWords,
+		Length: 10,
+	})
+	rm := m.(Model)
+	if rm.persistErr != "Couldn't save result to disk" {
+		t.Fatalf("want persistErr set after failed AppendHistory, got %q", rm.persistErr)
+	}
+	if v := rm.View().Content; !strings.Contains(v, "Couldn't save result to disk") {
+		t.Fatalf("View should show the persistence notice; got:\n%s", v)
+	}
+
+	// Any key dismisses the toast; the keystroke still routes (here: nav Home).
+	m2, _ := sm_sendKey(m, '1', 0)
+	cleared := m2.(Model)
+	if cleared.persistErr != "" {
+		t.Errorf("persistErr should clear on keypress, got %q", cleared.persistErr)
+	}
+	if v := cleared.View().Content; strings.Contains(v, "Couldn't save result to disk") {
+		t.Errorf("notice should be gone after dismiss; got:\n%s", v)
+	}
+}
+
+// TestPersistNotice_SettingsFailureSetsError verifies the settings persist
+// path surfaces the notice on a real write failure.
+func TestPersistNotice_SettingsFailureSetsError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", blockedXDG(t))
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	m := New(theme.Default(), config.Defaults())
+	s := m.settings
+	s.BlinkCursor = !s.BlinkCursor
+	m.onSettingsChange(s) // pointer receiver mutates m
+
+	if m.persistErr != "Couldn't save settings to disk" {
+		t.Fatalf("want persistErr set after failed SaveSettings, got %q", m.persistErr)
+	}
+}
+
+// TestPersistNotice_NoFailureNoNotice guards the no-error path: a writable
+// sandbox must not show any notice (layout/golden-neutral).
+func TestPersistNotice_NoFailureNoNotice(t *testing.T) {
+	m := tea.Model(sandboxedModel(t))
+	m = sm_sendSize(m, 80, 24)
+	m, _ = m.Update(ui.ResultMsg{
+		Result: sampleResult(),
+		Mode:   config.ModeWords,
+		Length: 10,
+	})
+	rm := m.(Model)
+	if rm.persistErr != "" {
+		t.Fatalf("writable sandbox: persistErr must stay empty, got %q", rm.persistErr)
+	}
+	if v := rm.View().Content; strings.Contains(v, "press any key to dismiss") {
+		t.Errorf("no notice expected on success path; got:\n%s", v)
+	}
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -28,7 +28,7 @@ func LengthsFor(m Mode) []int {
 // Settings is the persisted user configuration. v1 exposes exactly these four
 // controls; nothing else is configurable.
 type Settings struct {
-	Theme         string `json:"theme"`          // "default" | "mono"
+	Theme         string `json:"theme"`          // one of theme.Available()
 	DefaultMode   Mode   `json:"default_mode"`   // seeds the Home screen
 	DefaultLength int    `json:"default_length"` // valid for DefaultMode
 	BlinkCursor   bool   `json:"blink_cursor"`   // typing-screen cursor blink
@@ -48,8 +48,14 @@ func Defaults() Settings {
 // Normalize repairs out-of-range or unknown values in place, keeping a loaded
 // (possibly hand-edited or stale) settings file safe to use.
 func (s *Settings) Normalize() {
+	// Intentional duplication of theme.Available(): the core layering rule
+	// forbids importing internal/theme here. theme_available_sync_test.go
+	// asserts this accepted set stays in lockstep with theme.Available().
 	switch s.Theme {
-	case "default", "mono":
+	case "default", "mono",
+		"solarized-dark", "solarized-light",
+		"dracula", "nord",
+		"gruvbox-dark", "gruvbox-light":
 	default:
 		s.Theme = "default"
 	}

--- a/internal/config/theme_available_sync_test.go
+++ b/internal/config/theme_available_sync_test.go
@@ -1,0 +1,32 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+// TestThemeAvailableStaysInSyncWithNormalize guards the intentional
+// duplication between theme.Available() and config.Settings.Normalize's
+// accepted theme set (the core layering rule forbids config importing theme,
+// so the list cannot be shared directly). External test package can import
+// both. If a theme is added to Available() but not to Normalize's switch,
+// Normalize would reset it to "default" and this test fails.
+func TestThemeAvailableStaysInSyncWithNormalize(t *testing.T) {
+	for _, name := range theme.Available() {
+		s := config.Settings{Theme: name}
+		s.Normalize()
+		if s.Theme != name {
+			t.Errorf("theme %q is in theme.Available() but Normalize() reset it "+
+				"to %q — add it to the switch in config/settings.go", name, s.Theme)
+		}
+	}
+
+	// Unknown names must still fall back to the default.
+	s := config.Settings{Theme: "definitely-not-a-real-theme"}
+	s.Normalize()
+	if s.Theme != "default" {
+		t.Errorf("unknown theme: want fallback to \"default\", got %q", s.Theme)
+	}
+}

--- a/internal/storage/settings_store_test.go
+++ b/internal/storage/settings_store_test.go
@@ -82,7 +82,7 @@ func TestUnknownThemeNormalized(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	raw := `{"theme":"solarized-dark","default_mode":"time","default_length":30,"blink_cursor":false}`
+	raw := `{"theme":"totally-unknown-theme","default_mode":"time","default_length":30,"blink_cursor":false}`
 	if err := os.WriteFile(path, []byte(raw), 0600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/theme/dracula-theme.go
+++ b/internal/theme/dracula-theme.go
@@ -1,0 +1,34 @@
+package theme
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Dracula is the official Dracula palette (https://draculatheme.com/contribute)
+// mapped onto the 16 roles: #282a36 ground, purple accent, pink/green/yellow
+// signal colors. Hex values pinned; see docs/design-guidelines.md §2.1.
+func Dracula() Theme {
+	return Theme{
+		name: "dracula",
+		colors: map[Role]color.Color{
+			RoleBg:          lipgloss.Color("#282a36"),
+			RoleSurface:     lipgloss.Color("#343746"),
+			RoleSurfaceAlt:  lipgloss.Color("#44475a"),
+			RoleTextPrimary: lipgloss.Color("#f8f8f2"),
+			RoleTextMuted:   lipgloss.Color("#c9c9d1"),
+			RoleTextFaint:   lipgloss.Color("#6272a4"),
+			RoleAccent:      lipgloss.Color("#bd93f9"),
+			RoleAccentDim:   lipgloss.Color("#7d5bbe"),
+			RoleError:       lipgloss.Color("#ff5555"),
+			RoleErrorBg:     lipgloss.Color("#5c1a1a"),
+			RoleWarning:     lipgloss.Color("#f1fa8c"),
+			RoleSuccess:     lipgloss.Color("#50fa7b"),
+			RoleCursorBg:    lipgloss.Color("#bd93f9"),
+			RoleCursorFg:    lipgloss.Color("#282a36"),
+			RoleBorder:      lipgloss.Color("#6272a4"),
+			RoleBorderFocus: lipgloss.Color("#bd93f9"),
+		},
+	}
+}

--- a/internal/theme/gruvbox-dark-theme.go
+++ b/internal/theme/gruvbox-dark-theme.go
@@ -1,0 +1,35 @@
+package theme
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
+
+// GruvboxDark is the Pavel Pertsev Gruvbox dark palette
+// (https://github.com/morhetz/gruvbox) mapped onto the 16 roles: bg0 ground,
+// yellow accent, retro warm signal colors. Hex pinned; see
+// docs/design-guidelines.md §2.1.
+func GruvboxDark() Theme {
+	return Theme{
+		name: "gruvbox-dark",
+		colors: map[Role]color.Color{
+			RoleBg:          lipgloss.Color("#282828"),
+			RoleSurface:     lipgloss.Color("#3c3836"),
+			RoleSurfaceAlt:  lipgloss.Color("#504945"),
+			RoleTextPrimary: lipgloss.Color("#ebdbb2"),
+			RoleTextMuted:   lipgloss.Color("#a89984"),
+			RoleTextFaint:   lipgloss.Color("#665c54"),
+			RoleAccent:      lipgloss.Color("#fabd2f"),
+			RoleAccentDim:   lipgloss.Color("#b57614"),
+			RoleError:       lipgloss.Color("#fb4934"),
+			RoleErrorBg:     lipgloss.Color("#4a1f1c"),
+			RoleWarning:     lipgloss.Color("#fe8019"),
+			RoleSuccess:     lipgloss.Color("#b8bb26"),
+			RoleCursorBg:    lipgloss.Color("#fabd2f"),
+			RoleCursorFg:    lipgloss.Color("#282828"),
+			RoleBorder:      lipgloss.Color("#665c54"),
+			RoleBorderFocus: lipgloss.Color("#fabd2f"),
+		},
+	}
+}

--- a/internal/theme/gruvbox-light-theme.go
+++ b/internal/theme/gruvbox-light-theme.go
@@ -1,0 +1,35 @@
+package theme
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
+
+// GruvboxLight is the Gruvbox light palette (https://github.com/morhetz/gruvbox)
+// mapped onto the 16 roles: bg0 light ground, dark-yellow accent. Light-bg
+// role contrast reviewed across all screens; see docs/design-guidelines.md
+// §2.1.
+func GruvboxLight() Theme {
+	return Theme{
+		name: "gruvbox-light",
+		colors: map[Role]color.Color{
+			RoleBg:          lipgloss.Color("#fbf1c7"),
+			RoleSurface:     lipgloss.Color("#ebdbb2"),
+			RoleSurfaceAlt:  lipgloss.Color("#d5c4a1"),
+			RoleTextPrimary: lipgloss.Color("#3c3836"),
+			RoleTextMuted:   lipgloss.Color("#7c6f64"),
+			RoleTextFaint:   lipgloss.Color("#bdae93"),
+			RoleAccent:      lipgloss.Color("#b57614"),
+			RoleAccentDim:   lipgloss.Color("#79740e"),
+			RoleError:       lipgloss.Color("#9d0006"),
+			RoleErrorBg:     lipgloss.Color("#f2d0cd"),
+			RoleWarning:     lipgloss.Color("#af3a03"),
+			RoleSuccess:     lipgloss.Color("#79740e"),
+			RoleCursorBg:    lipgloss.Color("#b57614"),
+			RoleCursorFg:    lipgloss.Color("#fbf1c7"),
+			RoleBorder:      lipgloss.Color("#bdae93"),
+			RoleBorderFocus: lipgloss.Color("#b57614"),
+		},
+	}
+}

--- a/internal/theme/nord-theme.go
+++ b/internal/theme/nord-theme.go
@@ -1,0 +1,34 @@
+package theme
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Nord is the official Nord palette (https://www.nordtheme.com/) mapped onto
+// the 16 roles: nord0 polar-night ground, nord8 frost accent, aurora signal
+// colors. Hex values pinned; see docs/design-guidelines.md §2.1.
+func Nord() Theme {
+	return Theme{
+		name: "nord",
+		colors: map[Role]color.Color{
+			RoleBg:          lipgloss.Color("#2e3440"),
+			RoleSurface:     lipgloss.Color("#3b4252"),
+			RoleSurfaceAlt:  lipgloss.Color("#434c5e"),
+			RoleTextPrimary: lipgloss.Color("#eceff4"),
+			RoleTextMuted:   lipgloss.Color("#d8dee9"),
+			RoleTextFaint:   lipgloss.Color("#4c566a"),
+			RoleAccent:      lipgloss.Color("#88c0d0"),
+			RoleAccentDim:   lipgloss.Color("#5e81ac"),
+			RoleError:       lipgloss.Color("#bf616a"),
+			RoleErrorBg:     lipgloss.Color("#4a2326"),
+			RoleWarning:     lipgloss.Color("#ebcb8b"),
+			RoleSuccess:     lipgloss.Color("#a3be8c"),
+			RoleCursorBg:    lipgloss.Color("#88c0d0"),
+			RoleCursorFg:    lipgloss.Color("#2e3440"),
+			RoleBorder:      lipgloss.Color("#4c566a"),
+			RoleBorderFocus: lipgloss.Color("#88c0d0"),
+		},
+	}
+}

--- a/internal/theme/palette_luminance_test.go
+++ b/internal/theme/palette_luminance_test.go
@@ -1,0 +1,41 @@
+package theme
+
+import "testing"
+
+// perceivedLuminance returns 0..1 luminance from a role's color using the
+// Rec.601 weights. color.Color.RGBA() yields 16-bit premultiplied channels;
+// theme colors are fully opaque so premultiplication is a no-op here.
+func perceivedLuminance(th Theme, r Role) float64 {
+	c := th.Color(r)
+	if c == nil {
+		return -1
+	}
+	rr, gg, bb, _ := c.RGBA()
+	return (0.299*float64(rr) + 0.587*float64(gg) + 0.114*float64(bb)) / 65535.0
+}
+
+// TestPalettes_LightVsDarkNotInverted is an objective guard against an
+// accidentally inverted palette: a light theme must have a light background
+// and dark primary text; a dark theme the inverse. Subjective per-screen
+// contrast review is still the real gate (see docs/design-guidelines.md),
+// but this catches the gross failure cheaply.
+func TestPalettes_LightVsDarkNotInverted(t *testing.T) {
+	light := map[string]bool{"solarized-light": true, "gruvbox-light": true}
+	for _, name := range packThemes {
+		if name == "mono" {
+			continue // mono is a fixed near-monochrome ramp, not bg/text paired
+		}
+		th := Load(name, false)
+		bg := perceivedLuminance(th, RoleBg)
+		fg := perceivedLuminance(th, RoleTextPrimary)
+		if light[name] {
+			if bg <= fg || bg < 0.5 {
+				t.Errorf("light theme %q: want light bg (>0.5) brighter than text; got bg=%.2f fg=%.2f", name, bg, fg)
+			}
+		} else {
+			if bg >= fg || bg > 0.5 {
+				t.Errorf("dark theme %q: want dark bg (<0.5) darker than text; got bg=%.2f fg=%.2f", name, bg, fg)
+			}
+		}
+	}
+}

--- a/internal/theme/solarized-dark-theme.go
+++ b/internal/theme/solarized-dark-theme.go
@@ -1,0 +1,35 @@
+package theme
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
+
+// SolarizedDark is the Ethan Schoonover Solarized dark palette mapped onto the
+// 16 semantic roles. Source: https://ethanschoonover.com/solarized/ (base03
+// ground, blue accent). Hex values are pinned; see docs/design-guidelines.md
+// §2.1 for the role rationale.
+func SolarizedDark() Theme {
+	return Theme{
+		name: "solarized-dark",
+		colors: map[Role]color.Color{
+			RoleBg:          lipgloss.Color("#002b36"),
+			RoleSurface:     lipgloss.Color("#073642"),
+			RoleSurfaceAlt:  lipgloss.Color("#094d5c"),
+			RoleTextPrimary: lipgloss.Color("#93a1a1"),
+			RoleTextMuted:   lipgloss.Color("#839496"),
+			RoleTextFaint:   lipgloss.Color("#586e75"),
+			RoleAccent:      lipgloss.Color("#268bd2"),
+			RoleAccentDim:   lipgloss.Color("#1f6a9e"),
+			RoleError:       lipgloss.Color("#dc322f"),
+			RoleErrorBg:     lipgloss.Color("#4a1715"),
+			RoleWarning:     lipgloss.Color("#b58900"),
+			RoleSuccess:     lipgloss.Color("#859900"),
+			RoleCursorBg:    lipgloss.Color("#268bd2"),
+			RoleCursorFg:    lipgloss.Color("#002b36"),
+			RoleBorder:      lipgloss.Color("#586e75"),
+			RoleBorderFocus: lipgloss.Color("#268bd2"),
+		},
+	}
+}

--- a/internal/theme/solarized-light-theme.go
+++ b/internal/theme/solarized-light-theme.go
@@ -1,0 +1,35 @@
+package theme
+
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
+
+// SolarizedLight is the Solarized light palette (base3 ground, blue accent),
+// the first light theme. Source: https://ethanschoonover.com/solarized/.
+// Light-bg role contrast reviewed across all screens; see
+// docs/design-guidelines.md §2.1.
+func SolarizedLight() Theme {
+	return Theme{
+		name: "solarized-light",
+		colors: map[Role]color.Color{
+			RoleBg:          lipgloss.Color("#fdf6e3"),
+			RoleSurface:     lipgloss.Color("#eee8d5"),
+			RoleSurfaceAlt:  lipgloss.Color("#ded8c5"),
+			RoleTextPrimary: lipgloss.Color("#586e75"),
+			RoleTextMuted:   lipgloss.Color("#657b83"),
+			RoleTextFaint:   lipgloss.Color("#93a1a1"),
+			RoleAccent:      lipgloss.Color("#268bd2"),
+			RoleAccentDim:   lipgloss.Color("#3a7ca5"),
+			RoleError:       lipgloss.Color("#dc322f"),
+			RoleErrorBg:     lipgloss.Color("#f5d0cd"),
+			RoleWarning:     lipgloss.Color("#b58900"),
+			RoleSuccess:     lipgloss.Color("#859900"),
+			RoleCursorBg:    lipgloss.Color("#268bd2"),
+			RoleCursorFg:    lipgloss.Color("#fdf6e3"),
+			RoleBorder:      lipgloss.Color("#93a1a1"),
+			RoleBorderFocus: lipgloss.Color("#268bd2"),
+		},
+	}
+}

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -19,9 +19,17 @@ type Theme struct {
 // Name returns the theme identifier ("default", "mono", or "no-color").
 func (t Theme) Name() string { return t.name }
 
-// Available lists the user-selectable theme names in v1 order.
-// "solarized-dark" is reserved but not implemented in v1.
-func Available() []string { return []string{"default", "mono"} }
+// Available lists the user-selectable theme names in display order.
+// config.Settings.Normalize duplicates this set (core layering forbids it
+// from importing theme); theme_available_sync_test.go guards them in lockstep.
+func Available() []string {
+	return []string{
+		"default", "mono",
+		"solarized-dark", "solarized-light",
+		"dracula", "nord",
+		"gruvbox-dark", "gruvbox-light",
+	}
+}
 
 // EnvNoColor reports whether the NO_COLOR convention is active. Any non-empty
 // value disables color (https://no-color.org).
@@ -36,6 +44,18 @@ func Load(name string, noColor bool) Theme {
 	switch name {
 	case "mono":
 		return Mono()
+	case "solarized-dark":
+		return SolarizedDark()
+	case "solarized-light":
+		return SolarizedLight()
+	case "dracula":
+		return Dracula()
+	case "nord":
+		return Nord()
+	case "gruvbox-dark":
+		return GruvboxDark()
+	case "gruvbox-light":
+		return GruvboxLight()
 	default:
 		return Default()
 	}

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -2,16 +2,46 @@ package theme
 
 import "testing"
 
-// TestAvailable_ContainsExpectedThemes verifies Available returns the two v1 themes.
+// packThemes is the set of named, fully-colored themes (excludes the
+// attribute-only no-color theme, which is selected via the noColor flag).
+var packThemes = []string{
+	"default", "mono",
+	"solarized-dark", "solarized-light",
+	"dracula", "nord",
+	"gruvbox-dark", "gruvbox-light",
+}
+
+// TestAvailable_ContainsExpectedThemes verifies Available returns exactly the
+// selectable theme set in the expected order.
 func TestAvailable_ContainsExpectedThemes(t *testing.T) {
 	got := Available()
-	want := map[string]bool{"default": true, "mono": true}
-	if len(got) != len(want) {
-		t.Fatalf("Available: want %d entries, got %d: %v", len(want), len(got), got)
+	if len(got) != len(packThemes) {
+		t.Fatalf("Available: want %d entries, got %d: %v", len(packThemes), len(got), got)
 	}
-	for _, name := range got {
-		if !want[name] {
-			t.Errorf("unexpected theme name %q", name)
+	for i, name := range packThemes {
+		if got[i] != name {
+			t.Errorf("Available[%d]: want %q, got %q", i, name, got[i])
+		}
+	}
+}
+
+// TestPacks_NameRoundTripAndAllRolesResolve verifies every selectable theme
+// loads by name and resolves all 16 roles to a non-nil color (colored mode)
+// and to a non-panicking style; under noColor the same name yields no-color.
+func TestPacks_NameRoundTripAndAllRolesResolve(t *testing.T) {
+	for _, name := range packThemes {
+		th := Load(name, false)
+		if th.Name() != name {
+			t.Errorf("Load(%q,false): Name()=%q, want %q", name, th.Name(), name)
+		}
+		for _, r := range allRoles() {
+			if c := th.Color(r); c == nil {
+				t.Errorf("theme %q: Color(role %d) is nil; every role must map", name, r)
+			}
+			_ = th.Style(r) // must not panic
+		}
+		if nc := Load(name, true); nc.Name() != "no-color" {
+			t.Errorf("Load(%q,true): Name()=%q, want no-color", name, nc.Name())
 		}
 	}
 }

--- a/internal/ui/persistence-notice.go
+++ b/internal/ui/persistence-notice.go
@@ -1,0 +1,22 @@
+package ui
+
+import (
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+// PersistenceNotice renders a single-line, dismissible toast shown when a
+// disk write (history or settings) failed. It is a transient overlay on the
+// frame's last row — RoleWarning message + RoleTextFaint dismiss hint — so it
+// is legible under NO_COLOR (attribute-only) without shifting any layout.
+//
+// The caller is responsible for horizontal placement; this returns the bare
+// styled line. Empty msg yields an empty string (caller should not invoke it
+// in that case, but guard anyway).
+func PersistenceNotice(msg string, th theme.Theme) string {
+	if msg == "" {
+		return ""
+	}
+	warn := th.Style(theme.RoleWarning).Render("⚠ " + msg)
+	hint := th.Style(theme.RoleTextFaint).Render("  ·  press any key to dismiss")
+	return warn + hint
+}

--- a/internal/ui/persistence-notice_test.go
+++ b/internal/ui/persistence-notice_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+func TestPersistenceNotice_ContainsMessageAndHint(t *testing.T) {
+	th := theme.Load("default", false)
+	got := PersistenceNotice("Couldn't save result to disk", th)
+	if !strings.Contains(got, "Couldn't save result to disk") {
+		t.Errorf("notice missing message; got %q", got)
+	}
+	if !strings.Contains(got, "dismiss") {
+		t.Errorf("notice missing dismiss hint; got %q", got)
+	}
+}
+
+func TestPersistenceNotice_EmptyMsgYieldsEmpty(t *testing.T) {
+	th := theme.Load("default", false)
+	if got := PersistenceNotice("", th); got != "" {
+		t.Errorf("empty msg: want empty string, got %q", got)
+	}
+}
+
+func TestPersistenceNotice_NoColorStillLegible(t *testing.T) {
+	th := theme.Load("default", true) // no-color (attribute-only)
+	got := PersistenceNotice("disk full", th)
+	if !strings.Contains(got, "disk full") {
+		t.Errorf("no-color notice must still carry the message text; got %q", got)
+	}
+}

--- a/internal/ui/screen_settings_test.go
+++ b/internal/ui/screen_settings_test.go
@@ -65,34 +65,42 @@ func TestDownClampsAtLastRow(t *testing.T) {
 	}
 }
 
-// TestThemeCyclesRightAndWraps verifies → cycles Theme {default→mono→default}.
+// TestThemeCyclesRightAndWraps verifies → advances through every theme in
+// theme.Available() order and wraps back to the first. Asserted generically
+// so adding/removing a theme pack does not require touching this test.
 func TestThemeCyclesRightAndWraps(t *testing.T) {
 	m, _ := newTestSettings(nil)
-	// sel=0 = Theme; initial = "default"
-	if m.rows[rowTheme].values[m.rows[rowTheme].idx] != "default" {
-		t.Fatalf("initial theme should be 'default'")
+	vals := m.rows[rowTheme].values
+	if len(vals) < 2 {
+		t.Fatalf("expected ≥2 themes, got %v", vals)
+	}
+	if vals[m.rows[rowTheme].idx] != vals[0] {
+		t.Fatalf("initial theme should be the first entry %q", vals[0])
 	}
 
-	// → once → "mono"
+	// → once → second theme.
 	m, _ = m.Update(pressSettKey(tea.KeyRight))
-	if got := m.rows[rowTheme].values[m.rows[rowTheme].idx]; got != "mono" {
-		t.Fatalf("after 1 →: want 'mono', got %q", got)
+	if got := m.rows[rowTheme].values[m.rows[rowTheme].idx]; got != vals[1] {
+		t.Fatalf("after 1 →: want %q, got %q", vals[1], got)
 	}
 
-	// → again → wraps to "default"
-	m, _ = m.Update(pressSettKey(tea.KeyRight))
-	if got := m.rows[rowTheme].values[m.rows[rowTheme].idx]; got != "default" {
-		t.Fatalf("after 2 →: want 'default' (wrap), got %q", got)
+	// → the remaining len-1 times → wraps back to the first.
+	for range len(vals) - 1 {
+		m, _ = m.Update(pressSettKey(tea.KeyRight))
+	}
+	if got := m.rows[rowTheme].values[m.rows[rowTheme].idx]; got != vals[0] {
+		t.Fatalf("after a full cycle →: want %q (wrap), got %q", vals[0], got)
 	}
 }
 
-// TestThemeCyclesLeft verifies ← wraps from first to last.
+// TestThemeCyclesLeft verifies ← from the first entry wraps to the last.
 func TestThemeCyclesLeft(t *testing.T) {
 	m, _ := newTestSettings(nil)
-	// Default is index 0; ← should wrap to "mono".
+	vals := m.rows[rowTheme].values
+	last := vals[len(vals)-1]
 	m, _ = m.Update(pressSettKey(tea.KeyLeft))
-	if got := m.rows[rowTheme].values[m.rows[rowTheme].idx]; got != "mono" {
-		t.Fatalf("← from 'default': want 'mono', got %q", got)
+	if got := m.rows[rowTheme].values[m.rows[rowTheme].idx]; got != last {
+		t.Fatalf("← from first: want %q (wrap to last), got %q", last, got)
 	}
 }
 

--- a/internal/ui/word_stream_renderer.go
+++ b/internal/ui/word_stream_renderer.go
@@ -13,9 +13,12 @@ import (
 // RenderWordStream renders the typing word-stream as a multi-line string.
 //
 // Each rune in target is styled according to its CharState. Extra typed runes
-// (past the target length) are appended at the end. Hard-wrapping happens at
-// width columns using word-aware boundaries: words are never split mid-rune
-// unless a single word exceeds the full width.
+// (past the target length) are appended at the end. Wrapping is a hard
+// character-cell wrap at `width`: when the next rune would overflow the line
+// it starts a new line, so a word longer than `width` IS split between runes
+// (never within a multi-byte rune). A space landing at/after the boundary
+// also flushes so the following word begins on a fresh line. This is not a
+// word-aware (scan-back) wrap.
 //
 // Rendering is rune-safe: all iteration uses []rune, not byte slices.
 func RenderWordStream(
@@ -81,15 +84,15 @@ func RenderWordStream(
 		tokens[i] = st.Render(ch)
 	}
 
-	// Word-aware hard-wrap at width columns.
-	// We wrap on rune counts because styled strings have ANSI escapes that
-	// inflate byte length. We track the raw rune count of current line.
+	// Hard character-cell wrap at width columns. We wrap on rune counts (not
+	// byte length) because styled tokens carry ANSI escapes that inflate bytes;
+	// the raw rune count of the current line is tracked instead.
 	return wrapTokens(tokens, states, target, typed, width)
 }
 
-// wrapTokens assembles the styled rune tokens into wrapped lines.
-// Word boundaries are determined from the raw runes so wrapping is correct
-// regardless of ANSI escape inflation.
+// wrapTokens assembles the styled rune tokens into wrapped lines using a hard
+// per-cell wrap. Width is accounted from the raw runes (one cell each) so the
+// ANSI escapes in the styled tokens do not distort line length.
 func wrapTokens(
 	tokens []string,
 	states []typing.CharState,
@@ -121,13 +124,13 @@ func wrapTokens(
 		if runeW < 0 {
 			runeW = 1
 		}
-		// Terminal width = 1 per standard ASCII/Latin rune; use 1 for simplicity
-		// (full CJK double-width support deferred to Phase 9).
+		// One terminal cell per rune (ASCII/Latin). CJK double-width is not
+		// handled — deferred (roadmap m5, "CJK width support if quotes added").
 		cellW := 1
 
-		// Word-aware wrap: if this rune would exceed the line width and the
-		// rune is NOT a space, scan back to find the last space in the current
-		// line and break there.
+		// Hard wrap: if this rune would overflow the line, break before it.
+		// There is no scan-back to the last space, so a word wider than the
+		// line is split between runes here.
 		if lineWidth+cellW > width && lineWidth > 0 {
 			flush()
 		}

--- a/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/brainstorm-summary.md
+++ b/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/brainstorm-summary.md
@@ -1,0 +1,88 @@
+# Brainstorm Summary — v1.1.0: Theme Packs + Hygiene
+
+Date: 2026-05-18 · Status: agreed, ready for `/ck:plan`
+
+## Problem statement
+
+Typeburn is publicly released (v1.0.0/v1.0.1), production-ready. A project
+audit surfaced cheap correctness/doc-hygiene gaps plus a product-upgrade
+backlog. Decision: bundle hygiene fixes with ONE product feature into the next
+milestone. Feature chosen: **theme packs**. Semver: new feature ⇒ **v1.1.0**
+(minor), NOT a v1.0.2 patch.
+
+## Audit validation (verified against live code, not accepted blindly)
+
+| Claim | Verdict | Evidence |
+|---|---|---|
+| Stale README badge note | TRUE, real | `README.md:9` says badges "404 until first tag … pre-v1.0.0"; tags are live |
+| `config`/`theme` import bubbletea/lipgloss | TRUE, doc-vs-reality drift not a bug | `config/keymap.go:3`, `theme/mono-theme.go:6`; no 2nd consumer (YAGNI) |
+| Persistence errors silently swallowed | TRUE, real UX gap | `model_history.go:40` `_,_=AppendHistory`; `model_settings.go:24` `_=SaveSettings` |
+| Word-wrap not word-aware; CJK `cellW:=1` | PARTLY | `word_stream_renderer.go:84` comment claims scan-back; impl hard-wraps. CJK = roadmap-accepted deferral (m5) |
+| Atomic write skips parent-dir fsync | TRUE, already accepted | `atomic_write.go`; roadmap-accepted, no new data ⇒ do NOT reverse |
+
+## Scope (agreed)
+
+### Feature: 6 theme packs
+Solarized Dark, Solarized Light, Dracula, Nord, Gruvbox Dark, Gruvbox Light.
+Total 8 selectable (+ `default` + `mono`).
+
+Architecture (verified): theme = `Theme{name, colors map[Role]color.Color,
+noColor}` (`theme.go:13`), 16 Roles (`roles.go:12-27`). `Load()` is a
+`switch name` (`theme.go:36`); **NO_COLOR short-circuits before the switch**
+⇒ packs auto-inert under NO_COLOR, zero extra work. Settings picker
+auto-derives from `theme.Available()` (`settings_rows.go:30`) ⇒ **no UI code
+touched**.
+
+Per pack: one new `internal/theme/<name>-theme.go` with `func <Name>() Theme`
+returning the 16-Role map (mirror `default-theme.go:12-34`). Extend `Load()`
+switch + `Available()` slice. Add palettes to `design-guidelines.md §2.1`
+(documented color source of truth).
+
+### DRY decision (the one real architectural choice) — Approach A
+Keep `config/settings.go:51` hardcoded valid-theme switch (core layering
+forbids `config`→`theme` import). Add a sync **test** asserting the Normalize
+switch and `theme.Available()` stay in lockstep + a code comment explaining
+the intentional duplication. KISS, zero layering risk, drift-proof.
+
+### Hygiene bundled in
+- IN: README/docs staleness (`README.md:9` + roadmap badge notes);
+  silent-persistence-failure non-blocking UI notice
+  (`model_history.go:40`, `model_settings.go:24`); fix the misleading
+  word-wrap comment (`word_stream_renderer.go:84`); update the core-import
+  doc rule (CLAUDE.md / architecture docs) to match reality.
+- DEFER: real word-aware wrap implementation (bigger than hygiene; only bites
+  Quote mode on words longer than line width); parent-dir fsync
+  (roadmap-accepted, no new data → not reversed).
+
+## Risks
+
+- **Light themes (Solarized Light, Gruvbox Light):** the 16 Roles were
+  palette-tuned for dark backgrounds. Each light pack needs explicit per-Role
+  contrast review — esp. `RoleBg`, `RoleSurface`, `RoleSurfaceAlt`,
+  `RoleTextPrimary/Muted/Faint`, `RoleCursorFg`, `RoleErrorBg`. Mitigation:
+  dedicate a phase step to eyeball each light theme across all 5 screens.
+- **Picker UX with 8 themes:** cycle-through row may feel long. Acceptable for
+  v1.1; revisit only if user feedback.
+- **Persistence-notice surface:** must be non-blocking and not break NO_COLOR
+  layout (attribute-only). Reuse the existing degraded-notice pattern
+  (`internal/ui/degraded-notice.go`).
+
+## Success criteria
+
+- 8 themes selectable; each resolves all 16 Roles non-nil; unknown→default;
+  NO_COLOR unaffected.
+- Sync test fails if `Available()` and `Normalize()` lists diverge.
+- Disk-write failure shows a visible, non-blocking notice; no crash.
+- README/roadmap/CLAUDE.md no longer carry stale/false statements.
+- `gofmt`, `go vet`, `go test ./... -race -count=1` green; prod files <200 LOC.
+- Ships via protected-main flow: branch → per-phase commits → PR →
+  squash-merge → tag `v1.1.0` on merged SHA (CONTRIBUTING release runbook).
+
+## Out of scope (v1.1.0)
+
+Code/custom-text mode, custom wordlists, history import/export, real
+word-aware wrap, CJK width, parent-dir fsync, online sync. (Roadmap backlog.)
+
+## Open questions
+
+None — both architectural decisions locked with the user.

--- a/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-01-branch-setup.md
+++ b/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-01-branch-setup.md
@@ -1,0 +1,42 @@
+---
+phase: 1
+title: "Branch Setup"
+status: pending
+priority: P1
+effort: "5m"
+dependencies: []
+---
+
+# Phase 1: Branch Setup
+
+## Overview
+Create the protected-main feature branch all subsequent phases commit to.
+Gate phase — no code, no commit of its own; just branch creation.
+
+## Requirements
+- Functional: feature branch exists locally, based on latest `main`.
+- Non-functional: respects hard-enforced protected-main workflow (the local
+  PreToolUse hook blocks commit/push on `main`).
+
+## Architecture
+Single shared branch `feat/v1.1.0-theme-packs-hygiene`. Parallel phases 2/3/4
+each add their own commit on this branch (file-disjoint → no conflicts).
+
+## Related Code Files
+- Create: none
+- Modify: none
+- Delete: none
+
+## Implementation Steps
+1. `git -C /Users/vchun/Codes/My-projects/Typeburn fetch origin`
+2. `git -C ... switch main && git -C ... pull --ff-only origin main`
+3. `git -C ... switch -c feat/v1.1.0-theme-packs-hygiene`
+4. Confirm `git rev-parse --abbrev-ref HEAD` == `feat/v1.1.0-theme-packs-hygiene`.
+
+## Success Criteria
+- [ ] On branch `feat/v1.1.0-theme-packs-hygiene`, up to date with `origin/main`.
+- [ ] Working tree clean.
+
+## Risk Assessment
+- Hook blocks commits on main: expected; this phase deliberately creates the
+  branch first. No commit happens here.

--- a/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-02-theme-packs.md
+++ b/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-02-theme-packs.md
@@ -1,0 +1,132 @@
+---
+phase: 2
+title: "Theme Packs"
+status: pending
+priority: P1
+effort: "4h"
+dependencies: [1]
+---
+
+# Phase 2: Theme Packs
+
+## Overview
+Add 6 theme packs as pure 16-Role data files; wire into `Load()` +
+`Available()`; keep `config.Normalize()` valid-list DRY via Approach A
+(documented duplication + sync test). One commit.
+
+## Requirements
+- Functional: 8 themes selectable (`default`, `mono`, + 6 packs). Settings
+  picker auto-lists them (no UI code change — derives from `theme.Available()`).
+- Functional: each pack resolves **all 16 Roles** to non-nil colors.
+- Functional: unknown name → `default`; `NO_COLOR` unaffected (Load
+  short-circuits before name switch — verify, do not modify).
+- Non-functional: every new prod file < 200 LOC; `gofmt`/`vet` clean;
+  `theme` package retains 100% coverage.
+
+## Architecture
+Theme = `Theme{name, colors map[Role]color.Color, noColor}` (`theme.go:13`).
+16 Roles in `roles.go:12-27`. Each pack mirrors `default-theme.go:12-34`
+exactly (one constructor func returning the role map). `Load()` switch
+(`theme.go:36`) + `Available()` slice (`theme.go:24`) extended.
+
+**Approach A (locked):** `config/settings.go:51` Normalize switch stays
+hardcoded (core layering forbids `config`→`theme` import). Add:
+(a) a code comment on that switch explaining the intentional duplication and
+pointing at the sync test; (b) a sync test in `internal/config` (or
+`internal/theme`, wherever it can import both legitimately — the test package
+may import both) asserting the Normalize-accepted set == `theme.Available()`.
+
+## Related Code Files
+- Create: `internal/theme/solarized-dark-theme.go`,
+  `internal/theme/solarized-light-theme.go`,
+  `internal/theme/dracula-theme.go`, `internal/theme/nord-theme.go`,
+  `internal/theme/gruvbox-dark-theme.go`,
+  `internal/theme/gruvbox-light-theme.go`
+- Create: `internal/theme/theme_available_sync_test.go` (sync test)
+- Modify: `internal/theme/theme.go` (`Load` switch + `Available` slice + drop
+  the stale "solarized-dark reserved" comment), `internal/config/settings.go`
+  (`Normalize` switch + explanatory comment), `internal/theme/theme_test.go`
+  (table-extend: all-16-roles-non-nil per pack, name round-trip),
+  `internal/config/settings_test.go` (Normalize accepts new names),
+  `docs/design-guidelines.md` §2.1 (add 6 palettes)
+
+## Palette spec (16 Roles each — apply verbatim)
+
+Roles order: Bg, Surface, SurfaceAlt, TextPrimary, TextMuted, TextFaint,
+Accent, AccentDim, Error, ErrorBg, Warning, Success, CursorBg, CursorFg,
+Border, BorderFocus.
+
+- **Solarized Dark:** `#002b36 #073642 #094d5c #93a1a1 #839496 #586e75
+  #268bd2 #1f6a9e #dc322f #4a1715 #b58900 #859900 #268bd2 #002b36 #586e75
+  #268bd2`
+- **Solarized Light:** `#fdf6e3 #eee8d5 #ded8c5 #586e75 #657b83 #93a1a1
+  #268bd2 #3a7ca5 #dc322f #f5d0cd #b58900 #859900 #268bd2 #fdf6e3 #93a1a1
+  #268bd2`
+- **Dracula:** `#282a36 #343746 #44475a #f8f8f2 #c9c9d1 #6272a4 #bd93f9
+  #7d5bbe #ff5555 #5c1a1a #f1fa8c #50fa7b #bd93f9 #282a36 #6272a4 #bd93f9`
+- **Nord:** `#2e3440 #3b4252 #434c5e #eceff4 #d8dee9 #4c566a #88c0d0
+  #5e81ac #bf616a #4a2326 #ebcb8b #a3be8c #88c0d0 #2e3440 #4c566a #88c0d0`
+- **Gruvbox Dark:** `#282828 #3c3836 #504945 #ebdbb2 #a89984 #665c54
+  #fabd2f #b57614 #fb4934 #4a1f1c #fe8019 #b8bb26 #fabd2f #282828 #665c54
+  #fabd2f`
+- **Gruvbox Light:** `#fbf1c7 #ebdbb2 #d5c4a1 #3c3836 #7c6f64 #bdae93
+  #b57614 #79740e #9d0006 #f2d0cd #af3a03 #79740e #b57614 #fbf1c7 #bdae93
+  #b57614`
+
+Names (for `Available()` / `Normalize`): `solarized-dark`,
+`solarized-light`, `dracula`, `nord`, `gruvbox-dark`, `gruvbox-light`.
+`Available()` order: `default, mono, solarized-dark, solarized-light,
+dracula, nord, gruvbox-dark, gruvbox-light`.
+
+## Implementation Steps
+1. Create 6 `*-theme.go` files, each `func <Name>() Theme` returning the
+   16-Role map (mirror `default-theme.go`). Use `lipgloss.Color("#…")`.
+2. `theme.go`: add 6 `case` arms to `Load()`; extend `Available()`; remove
+   the obsolete "solarized-dark reserved but not implemented" comment.
+3. `settings.go` `Normalize()`: add 6 names to the switch; add comment
+   "Intentional duplication of theme.Available() — core layering forbids
+   importing theme here; theme_available_sync_test.go guards drift."
+4. Sync test (`package config_test` or `theme_test` — external test pkg may
+   import both without violating layering; no new exported API on `config`):
+   for each `name` in `theme.Available()`, construct
+   `s := config.Settings{Theme: name}`, call `s.Normalize()`, assert
+   `s.Theme == name` (every Available theme is accepted by Normalize); then
+   `s := config.Settings{Theme: "definitely-bogus"}; s.Normalize();` assert
+   `s.Theme == "default"` (unknown resets). This proves the two lists stay in
+   lockstep WITHOUT config exposing its internal set.
+5. Extend `theme_test.go`: per pack, assert `Load(name,false).Name()==name`
+   and every Role in `roles.go` resolves non-nil; assert
+   `Load("bogus",false)` == default; assert `Load(name,true)` == no-color.
+6. Extend `settings_test.go`: Normalize keeps each new valid name; unknown
+   → `default`.
+7. **Light-theme contrast review:** run `make run`, switch to
+   `solarized-light` and `gruvbox-light`, eyeball all 5 screens (Home,
+   Typing, Result, History, Settings). Check Bg/Surface/SurfaceAlt vs
+   TextPrimary/Muted/Faint legibility, CursorFg over CursorBg, ErrorBg
+   marker. Adjust hex only if a pair fails contrast; record any change in
+   `design-guidelines.md`.
+8. Add the 6 palettes to `docs/design-guidelines.md` §2.1.
+9. `make fmt && make lint && make test-race`. Commit:
+   `feat(theme): add Solarized/Dracula/Nord/Gruvbox theme packs`.
+
+## Success Criteria
+- [ ] 8 themes selectable; picker lists all (manual `make run`).
+- [ ] Each pack: 16/16 Roles non-nil; name round-trips; unknown→default;
+  NO_COLOR unaffected — all asserted by tests.
+- [ ] Sync test fails if Normalize list and `Available()` diverge (verify by
+  temporarily removing one entry, see red, restore).
+- [ ] Light themes legible on all 5 screens.
+- [ ] `gofmt`/`vet`/`test -race` green; new files < 200 LOC; coverage ≥ prior.
+- [ ] One commit on the feature branch.
+
+## Risk Assessment
+- **Light themes designed for dark bg:** mitigated by step 7 explicit review.
+  Optional cheap guard: a test asserting relative luminance of `RoleBg` vs
+  `RoleTextPrimary` is "light bg / dark text" for `*-light` and inverse for
+  dark themes — catches an accidentally inverted palette without subjective
+  judgement. Add only if trivial; visual review remains the real gate.
+- **Palette drift from official sources:** hex values pinned in this spec;
+  cite sources in `design-guidelines.md`.
+- **Sync-test placement:** must live where importing both `config` and
+  `theme` is legal (a `_test.go` in either package's external test package
+  `package theme_test` / `package config_test` can import both).

--- a/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-03-persistence-notice.md
+++ b/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-03-persistence-notice.md
@@ -1,0 +1,97 @@
+---
+phase: 3
+title: "Persistence Notice"
+status: pending
+priority: P1
+effort: "3h"
+dependencies: [1]
+---
+
+# Phase 3: Persistence Notice
+
+## Overview
+Surface a **non-blocking** notice when saving history/settings to disk fails,
+instead of silently swallowing the error. One commit.
+
+## Requirements
+- Functional: on `AppendHistory` error (`model_history.go:40`) or
+  `SaveSettings` error (`model_settings.go:24`), show a transient
+  user-visible notice; do **not** crash, do **not** block input.
+- Functional: notice auto-dismisses on next successful persist OR next
+  screen navigation/keypress (no timers — KISS, deterministic).
+- Non-functional: NO_COLOR-safe (uses theme Roles → attribute-only fallback
+  automatically); layout unchanged when absent; new prod file < 200 LOC.
+
+## Architecture
+Elm flow. Add a transient field to `app.Model` (`model.go:26`), e.g.
+`persistErr string` ("" = none). Capture the currently-discarded errors:
+- `model_history.go`: `_, err := storage.AppendHistory(rec)` → on err set
+  `m.persistErr = "Couldn't save result to disk"`.
+- `model_settings.go`: `err := storage.SaveSettings(s)` → on err set
+  `m.persistErr = "Couldn't save settings to disk"`.
+New `ui.PersistenceNotice(msg string, th theme.Theme) string` mirrors the
+`degraded-notice.go` pattern (RoleWarning headline + RoleTextFaint hint
+"press any key to dismiss"). Root `View()` (`model_view.go:18`) renders it as
+a single appended line (footer-adjacent) when `persistErr != ""`. Clear
+`persistErr` in the key handler (`model_key_handler.go`) on any key and on
+screen transition (`routing.go`/wherever screen changes) — set to "" when a
+later persist succeeds too.
+
+`SaveSettings`/`AppendHistory` signatures already return errors
+(`history_store.go:57`, `settings_store.go:52`) — no storage change.
+
+## Related Code Files
+- Create: `internal/ui/persistence-notice.go`,
+  `internal/ui/persistence-notice_test.go`
+- Modify: `internal/app/model.go` (field), `internal/app/model_history.go`
+  (capture err), `internal/app/model_settings.go` (capture err),
+  `internal/app/model_view.go` (render line),
+  `internal/app/model_key_handler.go` (clear on key) + app test file
+- Delete: none
+
+## Implementation Steps
+1. `model.go`: add `persistErr string` to `Model` struct (documented).
+2. `model_history.go`: change `_, _ = storage.AppendHistory(rec)` to
+   `_, err := storage.AppendHistory(rec)` (first return stays discarded — do
+   NOT introduce an unused `recs` var); `if err != nil { m.persistErr =
+   "Couldn't save result to disk" }`. `handleResultMsg` is a value-receiver
+   returning `Model` — the mutated `m` is already returned, so the notice
+   propagates; just ensure the existing `return m` carries it. Drop the
+   "ignore write errors" comment.
+3. `model_settings.go`: `if err := storage.SaveSettings(s); err != nil {
+   m.persistErr = "Couldn't save settings to disk" }`. Update comment.
+   On success path elsewhere, leave persistErr untouched (cleared on key).
+4. `internal/ui/persistence-notice.go`: `PersistenceNotice(msg, th)` →
+   `RoleWarning` msg + `RoleTextFaint` "press any key to dismiss", joined.
+5. `model_view.go`: when `m.persistErr != ""`, append the notice line to the
+   composed view (below footer, never overlapping the typing area; must not
+   shift layout when empty).
+6. `model_key_handler.go`: at top of key handling, if `m.persistErr != ""`
+   set it to "" (any key dismisses; the keystroke still processes normally).
+   Confirm the handler's mutated/returned `Model` is the one propagated back
+   through `Update` (value-receiver pattern) so the cleared state sticks.
+7. Test (`persistence-notice_test.go`): notice contains the message text;
+   empty msg → callers never invoke it. App-level test: inject a failing
+   storage path (XDG dir pointed at an unwritable location via env/temp) so
+   `AppendHistory`/`SaveSettings` error → assert `m.persistErr` set →
+   simulate a key → assert cleared. Reuse existing storage test helpers for
+   the unwritable-dir setup.
+8. `make fmt && make lint && make test-race`. Commit:
+   `feat(app): surface non-blocking notice on persistence failure`.
+
+## Success Criteria
+- [ ] Forced disk-write failure shows a visible notice; app does not crash.
+- [ ] Notice clears on next keypress and on a subsequent successful save.
+- [ ] Absent notice → byte-identical layout vs before (golden tests pass).
+- [ ] NO_COLOR: notice still legible (attribute-only), layout unchanged.
+- [ ] `gofmt`/`vet`/`test -race` green; new file < 200 LOC.
+- [ ] One commit on the feature branch.
+
+## Risk Assessment
+- **Layout shift / golden test breakage:** notice must be additive only when
+  present; verify `teatest` goldens unaffected in the no-error path.
+- **Forcing a write failure in tests:** use a read-only temp dir or invalid
+  XDG path; reuse `internal/storage` test helpers, do not mock the storage
+  API (real failure path per development-rules).
+- **Cross-screen leakage:** ensure clear-on-nav so the notice doesn't persist
+  forever; covered by step 6 + test.

--- a/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-04-docs-hygiene.md
+++ b/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-04-docs-hygiene.md
@@ -1,0 +1,93 @@
+---
+phase: 4
+title: "Docs Hygiene"
+status: pending
+priority: P2
+effort: "1.5h"
+dependencies: [1]
+---
+
+# Phase 4: Docs Hygiene
+
+## Overview
+Fix stale/false statements now that the app is publicly released; correct the
+misleading word-wrap comment; reconcile the core-import architecture rule with
+reality. Doc + one comment only — no behavior change. One commit.
+
+## Requirements
+- Functional: no doc claims a pre-v1.0.0 state; the core-import rule matches
+  actual code; the word-wrap comment describes what the code does.
+- Non-functional: zero code-behavior change (comment-only in `.go`);
+  `gofmt`/`vet`/`test -race` still green (sanity, nothing should change).
+
+## Architecture
+Pure documentation/comment edits. The core-import rule is **doc-vs-reality
+drift** (audit finding #2): `config/keymap.go:3` imports bubbletea,
+`theme/mono-theme.go:6` imports lipgloss. Per the locked decision, **relax the
+doc to match reality** (no second consumer ⇒ YAGNI; do not refactor working
+code). Word-wrap: `word_stream_renderer.go:84-92` comment claims a scan-back
+"word-aware" wrap; impl hard-wraps at the cell boundary. Correct the comment
+to state the actual behavior (char-cell hard-wrap with post-space flush);
+keep CJK `cellW:=1` deferral note pointing to roadmap m5.
+
+## Related Code Files
+- Modify: `README.md` (line ~9 stale badge note; any other pre-tag wording),
+  `docs/project-roadmap.md` (badge/pre-1.0 notes; mark v1.1.0 scope),
+  `docs/system-architecture.md` (core-import rule wording),
+  `CLAUDE.md` (Architecture section "no bubbletea/lipgloss imports" → reflect
+  that `config` binds tea key types and `theme` returns lipgloss styles
+  by design; reusability is aspirational, not enforced),
+  `CHANGELOG.md` (author one `[Unreleased]` block covering ALL of v1.1.0's
+  user-visible changes: theme packs, persistence-failure notice, doc
+  corrections — Phase 4 is the sole parallel-set owner of this file; Phases
+  2 & 3 must NOT touch it),
+  `internal/ui/word_stream_renderer.go` (comment lines ~84-92, 124-126 only)
+- Create / Delete: none
+
+## Implementation Steps
+1. `README.md:9`: remove/replace "Release/pkg.go.dev badges 404 until the
+   first tag is published — expected pre-`v1.0.0`." with accurate current
+   wording (badges resolve; note the ~1h proxy lag already documented at
+   lines 39-41 stays). Scan the rest of README for other pre-tag phrasing.
+2. `docs/project-roadmap.md`: drop pre-1.0 badge caveats; add a short
+   v1.1.0 entry (theme packs + hygiene) under the post-1.0 section; keep the
+   parent-dir-fsync and CJK items as **accepted/deferred** (do NOT reopen —
+   roadmap-accepted, no new data).
+3. `docs/system-architecture.md` + `CLAUDE.md`: reword the "core packages
+   must not import Bubble Tea/Lip Gloss" rule to the truthful invariant:
+   pure-logic packages (`typing`, `metrics`, `words`, `storage`, `version`)
+   stay UI-free; `config` may reference tea key types for keymaps and
+   `theme` returns lipgloss styles by design — these are the styling/input
+   boundary, not reusable-core. State it as intentional, not a violation.
+4. `word_stream_renderer.go`: rewrite the doc comment to describe actual
+   behavior — "hard-wrap at `width` cells; a word longer than the line is
+   split; a trailing space at/after the boundary flushes the line" — and the
+   `cellW := 1` comment to reference roadmap m5 (CJK deferral) without
+   claiming word-awareness. **No logic edits.**
+5. `CHANGELOG.md`: add a single `[Unreleased]` section (Keep a Changelog
+   style) with the v1.1.0 user-visible changes — Added: 6 theme packs
+   (Solarized Dark/Light, Dracula, Nord, Gruvbox Dark/Light); Added:
+   non-blocking notice on persistence failure; Fixed/Docs: post-1.0 status,
+   core-import rule, word-wrap comment. Phase 6 later renames this to
+   `[1.1.0]`.
+6. `make fmt && make lint && make test-race` (must be unchanged-green —
+   proves the comment edit is behavior-neutral).
+7. Commit: `docs: correct post-1.0 status, core-import rule, word-wrap
+   comment; changelog [Unreleased] for v1.1.0`.
+
+## Success Criteria
+- [ ] No doc states a pre-v1.0.0 / "until first tag" condition as current.
+- [ ] Architecture rule matches actual imports (no false "violation").
+- [ ] Word-wrap comment matches code behavior; CJK note → m5.
+- [ ] `CHANGELOG.md` has one `[Unreleased]` block covering all 3 phases'
+  user-visible changes.
+- [ ] `gofmt`/`vet`/`test -race` green and unchanged (behavior-neutral).
+- [ ] One commit on the feature branch.
+
+## Risk Assessment
+- **Accidental logic edit in word_stream_renderer.go:** restrict to comment
+  lines; step 5 green-unchanged proves neutrality.
+- **Reopening accepted decisions:** explicitly keep parent-dir fsync + CJK as
+  accepted/deferred per review-audit discipline (no new data → no reversal).
+- **CLAUDE.md is user-owned guidance:** reword the technical invariant only;
+  do not alter workflow/rules sections.

--- a/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-05-integration-verify.md
+++ b/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-05-integration-verify.md
@@ -1,0 +1,66 @@
+---
+phase: 5
+title: "Integration Verify"
+status: pending
+priority: P1
+effort: "1h"
+dependencies: [2, 3, 4]
+---
+
+# Phase 5: Integration Verify
+
+## Overview
+Join the three parallel phases on the feature branch; prove the whole module
+is green and side-effect-free before opening the PR. Read + test only — no
+new feature commit (a fixup commit only if a defect is found).
+
+## Requirements
+- Functional: all of phase 2/3/4 commits present on
+  `feat/v1.1.0-theme-packs-hygiene`; full suite green together.
+- Non-functional: no regression in any package; CI-equivalent gates pass.
+
+## Architecture
+File ownership across phases 2/3/4 is disjoint (theme/config vs app/ui-notice
+vs docs/word-wrap-comment) → commits land sequentially with no merge
+conflict. This phase runs the exact CI gate locally and a manual smoke of
+every theme on every screen.
+
+## Related Code Files
+- Modify: none (defect fixup only, on the owning phase's files, if needed)
+
+## Implementation Steps
+1. Confirm 3 commits on branch (theme packs, persistence notice, docs).
+2. `make fmt` (no diff), `make lint` (`gofmt -l` empty + `go vet ./...`),
+   `make test-race` (`go test ./... -race -count=1`) — the exact CI gate.
+3. Coverage check: `go test ./internal/theme/ ./internal/config/
+   ./internal/app/ ./internal/ui/ -cover` ≥ pre-change baselines
+   (theme was 100%, ui 87.4%).
+4. Manual smoke (`make run`): cycle all 8 themes in Settings; for each,
+   visit Home/Typing/Result/History; confirm legibility (esp. the 2 light
+   themes) and that the picker lists 8.
+5. Force a persistence failure (unwritable XDG dir) once in a real run;
+   confirm the notice appears, input still works, notice clears on key.
+6. Side-effect sweep: `git diff main...HEAD --stat` — confirm only expected
+   files changed; no public API/signature change except the intended
+   `AppendHistory` error now consumed (callers unchanged externally).
+7. If any defect: fix on the owning phase's files, amend/add a fixup commit
+   with a clear message, re-run step 2.
+8. Spawn `code-reviewer` (done by cook): acceptance criteria met, no
+   regression in touchpoints, no unintended contract change, patterns
+   followed, no new lint/type errors.
+
+## Success Criteria
+- [ ] `gofmt -l` empty, `go vet ./...` clean, `go test ./... -race -count=1`
+  100% pass.
+- [ ] Coverage ≥ baseline for theme/config/app/ui.
+- [ ] All 8 themes legible on all screens (manual).
+- [ ] Persistence notice verified in a real run.
+- [ ] `git diff` shows only intended files; no unintended contract change.
+- [ ] code-reviewer: no critical findings (or all addressed).
+
+## Risk Assessment
+- **Parallel commit ordering:** disjoint ownership makes order irrelevant;
+  if a phase touched a shared file unexpectedly, this gate catches it via
+  the diff-stat sweep (step 6).
+- **Coverage regression from new untested code:** step 3 enforces baseline;
+  add tests on the owning phase if below.

--- a/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-06-release-v1-1-0.md
+++ b/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/phase-06-release-v1-1-0.md
@@ -1,0 +1,75 @@
+---
+phase: 6
+title: "Release v1.1.0"
+status: pending
+priority: P1
+effort: "1h"
+dependencies: [5]
+---
+
+# Phase 6: Release v1.1.0
+
+## Overview
+Ship v1.1.0 via the PR-based, fix-forward release runbook. Protected-main:
+PR → squash-merge → disposable dry-run → annotate + push the real tag.
+
+## Requirements
+- Functional: GitHub Release `v1.1.0` published with 7 assets
+  (6 archives + `checksums.txt`) and curated notes (non-empty body).
+- Non-functional: never delete-and-re-tag a pushed version (sumdb
+  append-only); tag pushed in a separate push (never `--follow-tags`).
+
+## Architecture
+Release notes come from `CHANGELOG.md` → extracted to
+`.github/release-notes.md`, passed to GoReleaser `--release-notes`.
+`.goreleaser.yaml` keeps the `changelog.filters.exclude: ['.*']` filter
+(NOT `disable: true` — that silences `--release-notes`). `ci.yml` does NOT
+run on tags; `release.yml` self-gates with its own test job. GoReleaser
+pinned `v2.15.4` (lockstep: `.goreleaser.yaml`, `release.yml`,
+`CONTRIBUTING.md`) — unchanged this release.
+
+## Related Code Files
+- Modify: `CHANGELOG.md` (**promote** the existing `[Unreleased]` block
+  authored by Phase 4 → `[1.1.0] - 2026-05-18`; do not re-author content),
+  `.github/release-notes.md` (mirror the `[1.1.0]` body),
+  `docs/project-roadmap.md` (mark v1.1.0 shipped — if not already in phase 4)
+- Create / Delete: none (no version constant — version is ldflags/tag
+  injected per CONTRIBUTING)
+
+## Implementation Steps
+1. On the feature branch, rename `CHANGELOG.md` `[Unreleased]` (authored in
+   Phase 4) → `[1.1.0] - 2026-05-18`; regenerate `.github/release-notes.md`
+   from that section. Commit: `docs: changelog + release notes for v1.1.0`.
+2. Push branch: `git push -u origin feat/v1.1.0-theme-packs-hygiene`
+   (hook allows non-main branch push).
+3. Open PR → `main`: `gh pr create` (no AI references in title/body).
+   Wait for `ci.yml` green (required check).
+4. **Squash-merge** the PR (squash is the only enabled mode; branch
+   auto-deletes). Record the merged `main` SHA.
+5. Disposable dry-run: `git tag v0.0.0-rc.test <merged-SHA>` →
+   `git push origin v0.0.0-rc.test` → watch `release.yml` → verify **7
+   assets**, non-empty notes, checksums cross-check →
+   `gh release delete v0.0.0-rc.test --yes --cleanup-tag`.
+6. Real tag on the **same** SHA: `git tag -a v1.1.0 <merged-SHA>
+   -m "Typeburn v1.1.0"` → `git push origin v1.1.0` (separate push, NEVER
+   `--follow-tags`).
+7. Verify the published `v1.1.0` release: 7 assets, notes, checksums; `go
+   install …@v1.1.0` resolves (allow ~1h proxy lag).
+8. Run `/ck:journal` for the release entry.
+
+## Success Criteria
+- [ ] PR squash-merged into `main` with `ci.yml` green.
+- [ ] Disposable dry-run proved 7 assets + non-empty notes, then deleted.
+- [ ] `v1.1.0` tag on the dry-run-proven SHA; pushed separately.
+- [ ] GitHub Release `v1.1.0` live with 7 assets + curated notes.
+- [ ] Roadmap marks v1.1.0 shipped.
+
+## Risk Assessment
+- **Empty release body:** mitigated — keep exclude-all changelog filter;
+  dry-run asserts non-empty before the real tag.
+- **Re-tag temptation on defect:** forbidden — fix forward to v1.1.1. Only
+  `v0.0.0-rc.test` may be deleted/re-pushed.
+- **`--follow-tags` accident:** push branch and tag in distinct commands;
+  the protect-main hook allows tag pushes but not main branch pushes.
+- **Asset count drift:** `release.yml` asserts expected=7; investigate before
+  the real tag if it differs.

--- a/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/plan.md
+++ b/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/plan.md
@@ -1,0 +1,71 @@
+---
+title: "v1.1.0 — Theme Packs + Hygiene"
+description: "6 theme packs + bundled hygiene fixes; parallel phases, per-phase commits, protected-main PR flow"
+status: pending
+priority: P2
+branch: "feat/v1.1.0-theme-packs-hygiene"
+tags: [theme, hygiene, release]
+blockedBy: []
+blocks: []
+created: "2026-05-18T16:50:50.539Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# v1.1.0 — Theme Packs + Hygiene
+
+## Overview
+
+Minor release: 6 new theme packs (Solarized Dark/Light, Dracula, Nord,
+Gruvbox Dark/Light) + bundled hygiene fixes (stale docs, silent-persistence
+notice, misleading word-wrap comment, core-import doc rule). New feature ⇒
+**v1.1.0** (semver minor), not a patch.
+
+Source of truth: [brainstorm-summary.md](./brainstorm-summary.md) (audit
+validation, architecture, locked decisions: 6 packs + DRY Approach A).
+
+## Execution model
+
+Protected-main (hard-enforced): all phases commit to feature branch
+`feat/v1.1.0-theme-packs-hygiene` → PR → squash-merge → tag on merged SHA.
+**Each phase = its own commit.** Phases 2/3/4 are **independent disjoint work
+units** developed in parallel but **committed sequentially** onto the single
+shared branch — file ownership is disjoint so sequential commits are
+conflict-free; do NOT run concurrent writers in one working tree (no
+worktrees needed; the task is small and disjoint). 5 joins them; 6 releases.
+
+**CHANGELOG.md ownership:** among the parallel set, only **Phase 4** writes
+`CHANGELOG.md` (it authors a single `[Unreleased]` block covering theme
+packs + persistence notice + doc fixes). Phases 2 and 3 do **not** touch
+`CHANGELOG.md`. Phase 6 (sequential, after 5) promotes `[Unreleased]` →
+`[1.1.0]` — no parallel conflict since 6 runs after 4.
+
+| Phase | Name | Status | Parallel group | Owns (file ownership) |
+|-------|------|--------|----------------|----------------------|
+| 1 | [Branch Setup](./phase-01-branch-setup.md) | Pending | — (gate) | branch only |
+| 2 | [Theme Packs](./phase-02-theme-packs.md) | Pending | A ∥ | `internal/theme/*`, `internal/config/settings.go`, theme/settings tests, `docs/design-guidelines.md` |
+| 3 | [Persistence Notice](./phase-03-persistence-notice.md) | Pending | A ∥ | `internal/app/model_history.go`, `internal/app/model_settings.go`, `internal/ui/persistence-notice.go` (new) + its test |
+| 4 | [Docs Hygiene](./phase-04-docs-hygiene.md) | Pending | A ∥ | `README.md`, `docs/project-roadmap.md`, `docs/system-architecture.md`, `CLAUDE.md`, `CHANGELOG.md` (`[Unreleased]` block), `internal/ui/word_stream_renderer.go` (comment only) |
+| 5 | [Integration Verify](./phase-05-integration-verify.md) | Pending | join | none (read+test only) |
+| 6 | [Release v1.1.0](./phase-06-release-v1-1-0.md) | Pending | release | `CHANGELOG.md` (promote `[Unreleased]`→`[1.1.0]`), `.github/release-notes.md`, `docs/project-roadmap.md` (shipped), tag/PR (sequential after 5 — no parallel conflict) |
+
+**Dependency:** 1 → {2 ∥ 3 ∥ 4} → 5 → 6.
+
+## Key locked decisions
+
+- 6 packs, total 8 selectable (+ `default` + `mono`).
+- **DRY Approach A:** keep `config/settings.go` hardcoded valid-theme switch
+  (core layering forbids config→theme import); add a sync test asserting it
+  matches `theme.Available()` + a code comment.
+- NO_COLOR auto-inert (Load short-circuits before name switch) — no work.
+- Light themes need explicit per-Role contrast review (Phase 2 step).
+
+## Out of scope
+
+Code mode, custom wordlists, history import/export, real word-aware wrap, CJK
+width, parent-dir fsync (roadmap-accepted), online sync.
+
+## Dependencies
+
+No cross-plan deps — prior plans (`260518-1454`, `-2110`, `-2232`) all
+completed.


### PR DESCRIPTION
## Summary

Minor release **v1.1.0**: 6 theme packs + bundled hygiene fixes.

- **feat(theme):** 6 new 16-role palettes — `solarized-dark`, `solarized-light`, `dracula`, `nord`, `gruvbox-dark`, `gruvbox-light` (8 selectable total). DRY sync test keeps `config.Normalize` ↔ `theme.Available()` in lockstep without breaking core layering; luminance guard prevents inverted light palettes. NO_COLOR unaffected.
- **feat(app):** previously-discarded `AppendHistory`/`SaveSettings` errors now surface a non-blocking, dismissible last-row notice (NO_COLOR-safe). `View()` refactored to a single return; byte-identical to before on the no-error path.
- **docs:** removed stale pre-1.0 README note; layering rule reworded to the real invariant; word-stream wrap comment corrected to actual behavior; CHANGELOG `[1.1.0]`.

## Verification

- `gofmt -l` empty, `go vet ./...` clean, `go test ./... -race -count=1` 100% pass.
- Coverage: theme 100% (held), ui +0.1%, metrics/typing at baseline.
- Code review: 9.5/10, 0 critical, all acceptance criteria pass; 3 low/non-blocking observations.
- All exported-symbol changes additive; no breaking contract change.

## Out of scope

Code mode, custom wordlists, history import/export, real word-aware wrap, CJK width, parent-dir fsync (roadmap-accepted), online sync.