### PR TITLE
v1.2.0 — Code mode (custom text input)

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,21 +1,18 @@
-## [1.1.0] - 2026-05-19
+## [1.2.0] - 2026-05-19
 
 ### Added
 
-- **Theme packs:** six new color themes selectable in Settings —
-  `solarized-dark`, `solarized-light`, `dracula`, `nord`, `gruvbox-dark`,
-  `gruvbox-light` (bringing the total to eight, with `default` and `mono`).
-  `solarized-light` and `gruvbox-light` are the first light themes. `NO_COLOR`
-  behavior is unchanged.
-- **Persistence-failure notice:** if saving a result or settings to disk
-  fails, a dismissible one-line notice now appears instead of the failure
-  being silent. It never blocks input and clears on the next keypress.
+- **Code mode:** practice typing on your own text or code. Supply it with
+  `typeburn --text <file>` or pipe via `typeburn --text -`. The snippet is
+  rendered with full-literal layout — real line breaks, tabs shown as two
+  columns, and you type every space and indentation exactly; the test
+  completes on an exact full-text match. Long snippets scroll with a
+  caret-following viewport. Code mode is always listed in the mode tabs;
+  without `--text` it shows a hint and is disabled (in-app paste is planned).
+  `NO_COLOR` behavior is unchanged.
+- Code runs are saved to History but never count toward the ★ personal
+  best (custom text is not comparable run-to-run). Oversized
+  (>10k runes / >500 lines), empty, or non-text input is rejected with a
+  clear reason instead of starting.
 
-### Changed
-
-- Documentation corrected post-1.0: removed the stale "badges 404 until the
-  first tag" note; the dependency-layering rule now describes the real
-  invariant (`config`/`theme` intentionally bridge to the TUI); the word
-  stream's wrap comment now matches the actual character-cell behavior.
-
-[1.1.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.1.0
+[1.2.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-19
+
+### Added
+
+- **Code mode:** practice typing on your own text or code. Supply it with
+  `typeburn --text <file>` or pipe via `typeburn --text -`. The snippet is
+  rendered with full-literal layout — real line breaks, tabs shown as two
+  columns, and you type every space and indentation exactly; the test
+  completes on an exact full-text match. Long snippets scroll with a
+  caret-following viewport. Code mode is always listed in the mode tabs;
+  without `--text` it shows a hint and is disabled (in-app paste is planned).
+  `NO_COLOR` behavior is unchanged.
+- Code runs are saved to History but never count toward the ★ personal
+  best (custom text is not comparable run-to-run). Oversized
+  (&gt;10k runes / &gt;500 lines), empty, or non-text input is rejected with
+  a clear reason instead of starting.
+
 ## [1.1.0] - 2026-05-19
 
 ### Added
@@ -85,7 +102,8 @@ terminal typing test built with Go and Bubble Tea v2.
   HTTPS transport and the pipeline-generated `checksums.txt`. See
   [SECURITY.md](./SECURITY.md).
 
-[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.2.0
 [1.1.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.1.0
 [1.0.1]: https://github.com/bavanchun/Typeburn/releases/tag/v1.0.1
 [1.0.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ go test ./internal/version/ -run TestResolve_LdflagsWin -v
 
 **Strict dependency layering — do not violate.** The *pure-logic* packages are UI-free and must stay that way (no `bubbletea`/`lipgloss` imports):
 
-- Pure logic (no UI deps): `internal/typing` (keystroke state machine), `internal/metrics` (WPM/accuracy/consistency formulas), `internal/words` (embedded wordlist + quote pack), `internal/storage` (atomic JSON persistence), `internal/version` (build stamp).
+- Pure logic (no UI deps): `internal/typing` (keystroke state machine), `internal/metrics` (WPM/accuracy/consistency formulas), `internal/words` (embedded wordlist + quote pack), `internal/codetext` (Code-mode `--text` file/stdin loader + normalization — the ONLY file/stdin I/O boundary; keeps words/typing I/O-free), `internal/storage` (atomic JSON persistence), `internal/version` (build stamp).
 - Styling/input boundary (intentionally not reusable-core): `internal/config` binds Bubble Tea key types for its keymap, and `internal/theme` returns Lip Gloss styles/colors by design. These two depend on `charm.land` libs deliberately — they are the seam between pure logic and the TUI, not general-purpose libraries. Do not "fix" this by removing the imports; do not add new UI deps to the pure-logic packages above.
 - `internal/ui` depends on the packages above and implements the five screen sub-models + reusable components.
 - `internal/app` is the root Bubble Tea Elm model that wires everything together.
@@ -38,7 +38,7 @@ go test ./internal/version/ -run TestResolve_LdflagsWin -v
 
 **Storage is defensive.** Atomic temp-file + rename; any corrupt/missing file returns safe defaults and never panics; history is capped at the 200 newest records. Settings load once at startup (`app.NewFromDisk()`); history loads on demand and after each test.
 
-**Versioning is hybrid.** `internal/version` reads ldflags-injected `Version/Commit/Date` (set by Makefile + GoReleaser); when empty (bare `go install`) it falls back to `debug.ReadBuildInfo()`, final fallback `"dev"`. `main.go`'s `decide()` is a pure, tested function: a single `--version` short-circuits; a `ContinueOnError` FlagSet with discarded output ensures unknown flags / `-h` / `-v` / positional args fall through to the TUI (no `os.Exit(2)`, no usage dump). `-v` is intentionally unbound (reserved for a future `--verbose`).
+**Versioning is hybrid.** `internal/version` reads ldflags-injected `Version/Commit/Date` (set by Makefile + GoReleaser); when empty (bare `go install`) it falls back to `debug.ReadBuildInfo()`, final fallback `"dev"`. `main.go`'s `decide()` is a pure, tested function returning `(printVersion bool, textPath string)`: `--version` short-circuits to the banner; `--text <file>`/`-` selects Code mode (loaded via `internal/codetext`, errors → Code shown disabled with a reason, never a crash); a `ContinueOnError` FlagSet with discarded output ensures unknown flags / `-h` / `-v` / positional args fall through to the TUI (no `os.Exit(2)`, no usage dump). `-v` is intentionally unbound (reserved for a future `--verbose`).
 
 ## Git Workflow (protected main — enforced)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Distraction-free, keyboard-driven, and works on any ANSI terminal.
 
 ## Features
 
-- **Three test modes**: Time (15/30/60/120 s), Words (10/25/50/100 words), Quote (short/medium/long/epic)
+- **Four test modes**: Time (15/30/60/120 s), Words (10/25/50/100 words), Quote (short/medium/long/epic), Code (your own text via `--text`)
 - **Live stats**: WPM, raw WPM, accuracy, and consistency updated every keystroke
 - **Result screen**: big-digit WPM, sparkline chart, full char breakdown
 - **History**: scrollable table of all past tests with per-mode best marker (★)
@@ -62,7 +62,14 @@ make run               # run without installing (or: go run .)
 ./bin/typeburn            # from `make build`
 Typeburn                  # from `go install` / release archive
 Typeburn --version        # print version, commit, build date, toolchain; then exit
+Typeburn --text snippet.go # Code mode: type your own file
+cat snippet.go | Typeburn --text -   # Code mode: read the snippet from stdin
 ```
+
+In **Code mode** you type the supplied text exactly — every space, tab, and
+line break — and the test finishes on an exact match. Without `--text`, the
+Code tab is shown but disabled (in-app paste is planned). Code runs appear in
+History but never set a ★ personal best.
 
 The minimum usable terminal size is **60 columns × 20 rows**. If the terminal is
 too small the app shows a resize prompt and resumes automatically once you resize.
@@ -84,7 +91,7 @@ too small the app shows a resize prompt and resumes automatically once you resiz
 
 | Key | Action |
 |---|---|
-| `tab` / `shift+tab` | Cycle mode forward / backward (Time → Words → Quote) |
+| `tab` / `shift+tab` | Cycle mode forward / backward (Time → Words → Quote → Code) |
 | `←` `→` / `h` `l` | Change length option |
 | `enter` / `space` | Start test |
 

--- a/decide_test.go
+++ b/decide_test.go
@@ -3,31 +3,67 @@ package main
 import "testing"
 
 func TestDecide_VersionFlag(t *testing.T) {
-	if !decide([]string{"--version"}) {
+	pv, _ := decide([]string{"--version"})
+	if !pv {
 		t.Fatal("--version must request the version banner")
 	}
 }
 
 func TestDecide_UnknownFlag_FallsThrough(t *testing.T) {
-	if decide([]string{"--bogus"}) {
+	pv, _ := decide([]string{"--bogus"})
+	if pv {
 		t.Fatal("unknown flag must fall through to the TUI, not print version")
 	}
 }
 
 func TestDecide_DashH_FallsThrough(t *testing.T) {
-	if decide([]string{"-h"}) {
+	pv, _ := decide([]string{"-h"})
+	if pv {
 		t.Fatal("-h must fall through to the TUI (no usage dump, no exit 2)")
 	}
 }
 
 func TestDecide_NoArgs_FallsThrough(t *testing.T) {
-	if decide(nil) {
+	pv, _ := decide(nil)
+	if pv {
 		t.Fatal("no args must launch the TUI")
 	}
 }
 
 func TestDecide_NoShortV(t *testing.T) {
-	if decide([]string{"-v"}) {
+	pv, _ := decide([]string{"-v"})
+	if pv {
 		t.Fatal("-v must NOT be bound to version (reserved for future --verbose)")
+	}
+}
+
+// TestDecide_TextFlag_SetsPath verifies --text <path> populates textPath and
+// leaves printVersion false.
+func TestDecide_TextFlag_SetsPath(t *testing.T) {
+	pv, path := decide([]string{"--text", "myfile.go"})
+	if pv {
+		t.Fatal("--text must not trigger the version banner")
+	}
+	if path != "myfile.go" {
+		t.Fatalf("want textPath=%q, got %q", "myfile.go", path)
+	}
+}
+
+// TestDecide_TextFlag_Stdin verifies --text - is recognized (stdin sentinel).
+func TestDecide_TextFlag_Stdin(t *testing.T) {
+	pv, path := decide([]string{"--text", "-"})
+	if pv {
+		t.Fatal("--text - must not trigger the version banner")
+	}
+	if path != "-" {
+		t.Fatalf("want textPath=%q, got %q", "-", path)
+	}
+}
+
+// TestDecide_NoTextFlag_EmptyPath verifies textPath is "" when --text is absent.
+func TestDecide_NoTextFlag_EmptyPath(t *testing.T) {
+	_, path := decide([]string{"--version"})
+	if path != "" {
+		t.Fatalf("want empty textPath when --text absent, got %q", path)
 	}
 }

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -175,10 +175,15 @@
 - ✅ **v1.0.1:** M2 new-best sub-WPM precision fixed; always-zero `missed` stat removed.
 - ✅ **v1.1.0:** Six theme packs (Solarized D/L, Dracula, Nord, Gruvbox D/L);
   non-blocking persistence-failure notice; post-1.0 doc corrections.
+- ✅ **v1.2.0:** Code mode — `--text <file>`/stdin, full-literal whitespace,
+  new `internal/codetext` loader + isolated code renderer/viewport, saved to
+  History but excluded from ★.
 
 ### Next (Optional)
-1. **Gather user feedback** on missing features (Code mode? Vim motions? more themes?)
-2. **Code mode / custom text input** — next-most-valuable product upgrade if requested.
+1. **Gather user feedback** on missing features (Vim motions? more themes?)
+2. **In-app paste for Code mode** — supply the snippet inside the TUI (the
+   architecture already injects the text as a string; Home forks on
+   availability), removing the CLI-only constraint.
 
 ### v2.0 Planning (Future)
 - M4: Add target delivery mechanism; remove MissedChars 0-stub or make it meaningful
@@ -208,6 +213,6 @@
 
 ## Conclusion
 
-**Typeburn v1.1.0 is the current release — feature-complete and production-ready.** The codebase is clean, tested, and well-documented. Post-1.0 work has been purely additive (v1.0.1 precision fix + stub removal; v1.1.0 six theme packs + persistence-failure notice + doc hygiene) with zero breaking changes to existing users.
+**Typeburn v1.2.0 is the current release — feature-complete and production-ready.** The codebase is clean, tested, and well-documented. Post-1.0 work has been purely additive (v1.0.1 precision fix + stub removal; v1.1.0 six theme packs + persistence-failure notice + doc hygiene; v1.2.0 Code mode) with zero breaking changes to existing users.
 
-M1 (timer re-arm) and M2 (new-best precision) — the identified correctness bugs — were fixed in v1.0 (d6369de) and v1.0.1 respectively. Remaining backlog is additive or cosmetic; the next sizeable feature candidate is Code mode / custom text input.
+M1 (timer re-arm) and M2 (new-best precision) — the identified correctness bugs — were fixed in v1.0 (d6369de) and v1.0.1 respectively. Remaining backlog is additive or cosmetic; the next candidate is in-app paste for Code mode (removing the CLI-only constraint).

--- a/internal/app/code_mode_test.go
+++ b/internal/app/code_mode_test.go
@@ -1,0 +1,156 @@
+package app
+
+// code_mode_test.go covers the wiring for ModeCode through the root model:
+// StartTestMsg{Mode:ModeCode} → ScreenTyping with code target, key regression,
+// and result persistence with IsNewBest==false.
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/ui"
+)
+
+// codeTestModel returns a sandboxed root model with codeText wired in.
+func codeTestModel(t *testing.T, codeText, codeHint string) Model {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	return New(theme.Default(), config.Defaults(), codeText, codeHint)
+}
+
+// TestCodeMode_StartTestMsgRoutesToTyping verifies StartTestMsg{Mode:ModeCode}
+// transitions root model to ScreenTyping.
+func TestCodeMode_StartTestMsgRoutesToTyping(t *testing.T) {
+	m := tea.Model(codeTestModel(t, "hello world", ""))
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	m2, _ := m.Update(ui.StartTestMsg{Mode: config.ModeCode, CodeText: "hello world"})
+	rm := m2.(Model)
+	if rm.screen != ScreenTyping {
+		t.Fatalf("after StartTestMsg(ModeCode): want ScreenTyping, got %v", rm.screen)
+	}
+}
+
+// TestCodeMode_TypingTargetMatchesCodeText verifies the typing model's target
+// is exactly the CodeText from StartTestMsg (not words.ForMode output).
+func TestCodeMode_TypingTargetMatchesCodeText(t *testing.T) {
+	codeText := "func main() {\n\treturn\n}"
+	m := tea.Model(codeTestModel(t, codeText, ""))
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	m2, _ := m.Update(ui.StartTestMsg{Mode: config.ModeCode, CodeText: codeText})
+	rm := m2.(Model)
+	got := rm.typing.TargetText()
+	if got != codeText {
+		t.Fatalf("typing target: want %q, got %q", codeText, got)
+	}
+}
+
+// TestCodeMode_TabDuringTest_DeliveredToEngine verifies that Tab during a code
+// test is delivered to the typing engine (not consumed as nav). Tab in the
+// typing engine is RestartSame — so after pressing Tab the startMs resets to 0.
+func TestCodeMode_TabDuringTest_DeliveredToEngine(t *testing.T) {
+	codeText := "a\tb" // contains a literal tab
+	m := tea.Model(codeTestModel(t, codeText, ""))
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m, _ = m.Update(ui.StartTestMsg{Mode: config.ModeCode, CodeText: codeText})
+
+	// Type first char to start the timer.
+	m, _ = sm_sendText(m, "a")
+	beforeStartMs := m.(Model).typing.ExportedStartMs()
+	if beforeStartMs == 0 {
+		t.Fatal("startMs should be non-zero after first keystroke")
+	}
+
+	// Press Tab — should restart (RestartSame), resetting startMs to 0.
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+	afterStartMs := m.(Model).typing.ExportedStartMs()
+	if afterStartMs != 0 {
+		t.Errorf("Tab during code test should reset startMs (RestartSame), got %d", afterStartMs)
+	}
+	// Must still be on ScreenTyping.
+	if m.(Model).screen != ScreenTyping {
+		t.Errorf("Tab must not navigate away from ScreenTyping, got %v", m.(Model).screen)
+	}
+}
+
+// TestCodeMode_EnterDuringTest_DeliveredToEngine verifies Enter is forwarded
+// to the typing engine during a code test. Enter is a printable '\n' rune that
+// advances the engine; after one Enter the engine has one more event in its log.
+func TestCodeMode_EnterDuringTest_DeliveredToEngine(t *testing.T) {
+	// Target starts with a newline so Enter is immediately correct.
+	codeText := "\nhello"
+	m := tea.Model(codeTestModel(t, codeText, ""))
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m, _ = m.Update(ui.StartTestMsg{Mode: config.ModeCode, CodeText: codeText})
+
+	logBefore := len(m.(Model).typing.ExportedLog())
+
+	// Send Enter as a text keystroke (text="\n").
+	m, _ = m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter, Text: "\n"}))
+
+	logAfter := len(m.(Model).typing.ExportedLog())
+	if logAfter <= logBefore {
+		t.Errorf("Enter must advance the engine log: before=%d after=%d", logBefore, logAfter)
+	}
+}
+
+// TestCodeMode_ViewContainsCodeChars verifies the typing view renders chars
+// from the code target. ANSI sequences intersperse individual chars so we
+// check for each rune individually (they appear as plain bytes inside escapes).
+func TestCodeMode_ViewContainsCodeChars(t *testing.T) {
+	codeText := "helloworld"
+	m := tea.Model(codeTestModel(t, codeText, ""))
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m, _ = m.Update(ui.StartTestMsg{Mode: config.ModeCode, CodeText: codeText})
+
+	view := sm_view(m)
+	// Each character of the target must appear as a plain byte somewhere in the
+	// ANSI-decorated view. 'h', 'e', 'l', 'o', 'w', 'r', 'd' all unique enough.
+	for _, ch := range []string{"h", "e", "l", "o", "w", "r", "d"} {
+		if !strings.Contains(view, ch) {
+			t.Fatalf("typing view missing char %q from code target, got:\n%s", ch, view)
+		}
+	}
+}
+
+// TestCodeMode_ResultNotNewBest verifies that completing a code test does NOT
+// set isBest on the ResultModel (IsNewBest returns false for code mode).
+func TestCodeMode_ResultNotNewBest(t *testing.T) {
+	codeText := "hi"
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	m := tea.Model(New(theme.Default(), config.Defaults(), codeText, ""))
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m, _ = m.Update(ui.StartTestMsg{Mode: config.ModeCode, CodeText: codeText})
+
+	// Type all chars so the engine fires completeCmd.
+	var cmd tea.Cmd
+	for _, r := range []rune(codeText) {
+		m, cmd = sm_sendText(m, string(r))
+		if cmd != nil {
+			if msg := cmd(); msg != nil {
+				m, _ = m.Update(msg)
+			}
+		}
+		if m.(Model).screen == ScreenResult {
+			break
+		}
+	}
+
+	if m.(Model).screen != ScreenResult {
+		t.Fatal("code test completion must transition to ScreenResult")
+	}
+	// Result view must NOT contain the star marker (★ = new best).
+	view := sm_view(m)
+	if strings.Contains(view, "★") {
+		t.Fatalf("code mode result must never show new-best (★), got:\n%s", view)
+	}
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -35,6 +35,13 @@ type Model struct {
 	sett     ui.SettingsModel
 	hist     ui.HistoryModel
 
+	// codeText is the user-supplied code snippet loaded from --text <file>.
+	// Empty string means no code text is available; Code mode is then disabled.
+	codeText string
+	// codeHint is a user-facing reason when loading the code text failed
+	// (e.g., "text file is empty"). Empty when codeText loaded successfully.
+	codeHint string
+
 	// quitPrompt is non-nil when the esc-on-Home quit confirmation overlay is
 	// active. ctrl+c always hard-quits regardless of this field.
 	quitPrompt *quitPromptModel
@@ -46,17 +53,20 @@ type Model struct {
 	persistErr string
 }
 
-// New builds the root model loading persisted settings from disk.
-// It falls back to config.Defaults() if the settings file is missing or corrupt.
-func New(th theme.Theme, settings config.Settings) Model {
+// New builds the root model with the given theme, settings, and optional code
+// text/hint. codeText is the snippet loaded from --text (empty = Code disabled);
+// codeHint is a user-facing load-failure reason (empty = no error).
+func New(th theme.Theme, settings config.Settings, codeText, codeHint string) Model {
 	km := config.DefaultKeymap()
-	home := ui.NewHome(settings, th, km)
+	home := ui.NewHome(settings, th, km, codeText, codeHint)
 	m := Model{
 		screen:   ScreenHome,
 		theme:    th,
 		keys:     km,
 		settings: settings,
 		home:     home,
+		codeText: codeText,
+		codeHint: codeHint,
 	}
 	m.sett = ui.NewSettings(&m.settings, th, km, m.onSettingsChange)
 	return m
@@ -70,9 +80,15 @@ func (m Model) Init() tea.Cmd { return nil }
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// StartTestMsg: Home screen requested a test start.
 	if sm, ok := msg.(ui.StartTestMsg); ok {
-		t := ui.NewTyping(sm.Mode, sm.Length, sm.QuoteLen,
-			m.theme, m.keys, m.settings.BlinkCursor).SetSize(m.w, m.h)
-		m.typing = t
+		var t ui.TypingModel
+		if sm.Mode == config.ModeCode {
+			// Code mode: use the supplied snippet verbatim — do not call words.ForMode.
+			t = ui.NewTypingCode(sm.CodeText, m.theme, m.keys, m.settings.BlinkCursor)
+		} else {
+			t = ui.NewTyping(sm.Mode, sm.Length, sm.QuoteLen,
+				m.theme, m.keys, m.settings.BlinkCursor)
+		}
+		m.typing = t.SetSize(m.w, m.h)
 		m.screen = ScreenTyping
 		return m, nil
 	}

--- a/internal/app/model_history.go
+++ b/internal/app/model_history.go
@@ -17,6 +17,10 @@ func buildRecord(msg ui.ResultMsg) storage.Record {
 	if msg.Mode == config.ModeQuote {
 		length = 0
 	}
+	// Code mode stores the rune count of the snippet as display-only length.
+	if msg.Mode == config.ModeCode {
+		length = len([]rune(msg.CodeText))
+	}
 	return storage.Record{
 		Time:        nowUTC(),
 		Mode:        mode,

--- a/internal/app/model_settings.go
+++ b/internal/app/model_settings.go
@@ -9,10 +9,12 @@ import (
 
 // NewFromDisk builds the root model loading persisted settings from disk.
 // Falls back to config.Defaults() if the file is missing or corrupt.
-func NewFromDisk() Model {
+// codeText is the loaded snippet (empty string = no code mode); codeHint is
+// a user-facing reason string when loading failed (empty = no error).
+func NewFromDisk(codeText, codeHint string) Model {
 	s := storage.LoadSettings()
 	th := theme.Load(s.Theme, theme.EnvNoColor())
-	return New(th, s)
+	return New(th, s, codeText, codeHint)
 }
 
 // onSettingsChange is the onChange callback wired into SettingsModel.
@@ -27,7 +29,8 @@ func (m *Model) onSettingsChange(s config.Settings) {
 	}
 	// Rebuild theme from the new name, then propagate to every sub-model.
 	m.theme = theme.Load(s.Theme, theme.EnvNoColor())
-	m.home = ui.NewHome(s, m.theme, m.keys).SetSize(m.w, m.h)
+	// Preserve the loaded code text and hint across settings changes.
+	m.home = ui.NewHome(s, m.theme, m.keys, m.codeText, m.codeHint).SetSize(m.w, m.h)
 	m.typing = m.typing.ApplySettings(s, m.theme)
 	m.result = m.result.ApplyTheme(m.theme)
 	// Re-create SettingsModel so the live theme is visible in the settings view.

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newTestModel() Model {
-	return New(theme.Default(), config.Defaults())
+	return New(theme.Default(), config.Defaults(), "", "")
 }
 
 func press(code rune, mod tea.KeyMod) tea.KeyPressMsg {

--- a/internal/app/persistence_notice_test.go
+++ b/internal/app/persistence_notice_test.go
@@ -32,7 +32,7 @@ func TestPersistNotice_HistoryFailureShownThenDismissed(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", blockedXDG(t))
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	m := tea.Model(New(theme.Default(), config.Defaults()))
+	m := tea.Model(New(theme.Default(), config.Defaults(), "", ""))
 	m = sm_sendSize(m, 80, 24)
 
 	m, _ = m.Update(ui.ResultMsg{
@@ -65,7 +65,7 @@ func TestPersistNotice_SettingsFailureSetsError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", blockedXDG(t))
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	m := New(theme.Default(), config.Defaults())
+	m := New(theme.Default(), config.Defaults(), "", "")
 	s := m.settings
 	s.BlinkCursor = !s.BlinkCursor
 	m.onSettingsChange(s) // pointer receiver mutates m

--- a/internal/app/phase09_polish_test.go
+++ b/internal/app/phase09_polish_test.go
@@ -213,7 +213,7 @@ func TestQuitPromptView_ContainsOptions(t *testing.T) {
 // correctly under NO_COLOR (attribute-only theme, no hex colors).
 func TestNoColor_DegradedNotice(t *testing.T) {
 	th := theme.Load("default", true) // noColor=true
-	m := New(th, config.Defaults())
+	m := New(th, config.Defaults(), "", "")
 	m2, _ := m.Update(tea.WindowSizeMsg{Width: 50, Height: 15})
 	view := m2.(Model).View().Content
 	if !strings.Contains(view, "Terminal too small") {
@@ -229,7 +229,7 @@ func TestNoColor_DegradedNotice(t *testing.T) {
 // (the focus signal that works without color) under NO_COLOR.
 func TestNoColor_HomeScreen(t *testing.T) {
 	th := theme.Load("default", true) // noColor=true
-	m := New(th, config.Defaults())
+	m := New(th, config.Defaults(), "", "")
 	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	view := m2.(Model).View().Content
 	// The active tab must have the ▎ marker (works without color per §5.5).
@@ -241,7 +241,7 @@ func TestNoColor_HomeScreen(t *testing.T) {
 // TestNoColor_SettingsScreen verifies selected row still has ▎ under NO_COLOR.
 func TestNoColor_SettingsScreen(t *testing.T) {
 	th := theme.Load("default", true)
-	m := New(th, config.Defaults())
+	m := New(th, config.Defaults(), "", "")
 	tm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	tm, _ = tm.Update(press('2', 0)) // → Settings
 	view := tm.(Model).View().Content

--- a/internal/app/smoke_test.go
+++ b/internal/app/smoke_test.go
@@ -22,7 +22,7 @@ func sandboxedModel(t *testing.T) Model {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
-	return New(theme.Default(), config.Defaults())
+	return New(theme.Default(), config.Defaults(), "", "")
 }
 
 // sm_sendSize sends a WindowSizeMsg and returns the new model.
@@ -146,7 +146,7 @@ func TestSmoke_ResultMsg_HistoryPersisted(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
 
-	m := tea.Model(New(theme.Default(), config.Defaults()))
+	m := tea.Model(New(theme.Default(), config.Defaults(), "", ""))
 	m = sm_sendSize(m, 80, 24)
 
 	m, _ = m.Update(ui.ResultMsg{
@@ -198,7 +198,7 @@ func TestSmoke_Settings_ThemeRowCycles(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
 
-	m := tea.Model(New(theme.Default(), config.Defaults()))
+	m := tea.Model(New(theme.Default(), config.Defaults(), "", ""))
 	m = sm_sendSize(m, 80, 24)
 
 	// Navigate to Settings (Theme row sel=0 by default).

--- a/internal/codetext/codetext.go
+++ b/internal/codetext/codetext.go
@@ -1,0 +1,84 @@
+// Package codetext loads and normalizes user-supplied text/code for the
+// Code typing mode. It is the I/O boundary for `--text <file>` / `--text -`
+// so the pure-logic packages (words, typing) stay free of file/stdin access.
+//
+// Normalization (full-literal-safe): strip a leading UTF-8 BOM, convert CRLF
+// to LF, and trim exactly one trailing newline (so the snippet's final line
+// needs no closing Enter). Tabs, interior blank lines, and indentation are
+// preserved verbatim — Code mode requires the user to type them.
+package codetext
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+)
+
+// Caps. A snippet over either bound is rejected (not truncated) so the
+// renderer/viewport never face pathological input and the caller can show a
+// clear reason instead.
+const (
+	maxRunes = 10000
+	maxLines = 500
+)
+
+// utf8BOM is the 3-byte UTF-8 byte-order mark, matched on raw bytes (a
+// literal BOM rune is illegal in Go source).
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// Sentinel causes; callers branch with errors.Is to show a precise hint.
+var (
+	ErrEmpty    = errors.New("codetext: input is empty or whitespace-only")
+	ErrBinary   = errors.New("codetext: input is not valid UTF-8 text")
+	ErrTooLarge = errors.New("codetext: input exceeds the size limit")
+)
+
+// Load reads from a file path, or from stdin when path == "-", then
+// normalizes and validates. The returned string is ready to use as a Code
+// target verbatim.
+func Load(path string) (string, error) {
+	if path == "-" {
+		return loadReader(os.Stdin)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("codetext: open %s: %w", path, err)
+	}
+	defer f.Close()
+	return loadReader(f)
+}
+
+// loadReader is the FS-independent core: read all, normalize, validate.
+func loadReader(r io.Reader) (string, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("codetext: read: %w", err)
+	}
+
+	raw = bytes.TrimPrefix(raw, utf8BOM)
+
+	// Binary guard: invalid UTF-8 or a NUL byte means this is not text.
+	if !utf8.Valid(raw) || bytes.IndexByte(raw, 0) >= 0 {
+		return "", ErrBinary
+	}
+
+	s := strings.ReplaceAll(string(raw), "\r\n", "\n")
+
+	// Trim exactly one trailing newline (not all of them).
+	s = strings.TrimSuffix(s, "\n")
+
+	if strings.TrimSpace(s) == "" {
+		return "", ErrEmpty
+	}
+	if utf8.RuneCountInString(s) > maxRunes {
+		return "", fmt.Errorf("%w (max %d runes)", ErrTooLarge, maxRunes)
+	}
+	if strings.Count(s, "\n")+1 > maxLines {
+		return "", fmt.Errorf("%w (max %d lines)", ErrTooLarge, maxLines)
+	}
+	return s, nil
+}

--- a/internal/codetext/codetext_test.go
+++ b/internal/codetext/codetext_test.go
@@ -1,0 +1,91 @@
+package codetext
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadReader_Normalization(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"crlf to lf", "a\r\nb\r\nc", "a\nb\nc"},
+		{"strip utf8 bom", "\xef\xbb\xbfpackage x", "package x"},
+		{"trim exactly one trailing nl", "a\n\n", "a\n"},
+		{"single trailing nl trimmed", "a\n", "a"},
+		{"no trailing nl untouched", "a", "a"},
+		{"interior blanks and tabs preserved", "a\n\n\tb", "a\n\n\tb"},
+		{"unicode kept", "café — ünïcode", "café — ünïcode"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := loadReader(strings.NewReader(c.in))
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestLoadReader_Errors(t *testing.T) {
+	long := strings.Repeat("x", 10001)
+	manyLines := strings.Repeat("a\n", 500) + "b" // 501 lines
+	cases := []struct {
+		name    string
+		in      string
+		wantErr error
+	}{
+		{"empty", "", ErrEmpty},
+		{"whitespace only", "  \n\t\n  ", ErrEmpty},
+		{"nul byte is binary", "package\x00main", ErrBinary},
+		{"invalid utf8 is binary", "abc\xff\xfe", ErrBinary},
+		{"too many runes", long, ErrTooLarge},
+		{"too many lines", manyLines, ErrTooLarge},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := loadReader(strings.NewReader(c.in))
+			if !errors.Is(err, c.wantErr) {
+				t.Errorf("got err %v, want %v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadReader_AtCapBoundaries(t *testing.T) {
+	exactRunes := strings.Repeat("x", 10000)
+	if _, err := loadReader(strings.NewReader(exactRunes)); err != nil {
+		t.Errorf("exactly 10000 runes should pass, got %v", err)
+	}
+	lines500 := strings.Repeat("a\n", 499) + "b" // 500 lines
+	if _, err := loadReader(strings.NewReader(lines500)); err != nil {
+		t.Errorf("exactly 500 lines should pass, got %v", err)
+	}
+}
+
+func TestLoad_FileAndStdin(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "snippet.go")
+	if err := os.WriteFile(fp, []byte("func main() {\n\tprintln(1)\n}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(fp)
+	if err != nil {
+		t.Fatalf("Load(file): %v", err)
+	}
+	if got != "func main() {\n\tprintln(1)\n}" {
+		t.Errorf("file load mismatch: %q", got)
+	}
+
+	if _, err := Load(filepath.Join(dir, "does-not-exist")); err == nil {
+		t.Error("missing file should error")
+	}
+}

--- a/internal/config/mode_seam_sync_test.go
+++ b/internal/config/mode_seam_sync_test.go
@@ -1,0 +1,48 @@
+package config
+
+import "testing"
+
+// knownModes is every mode the app supports. If a new Mode constant is added
+// it MUST be added here AND handled by LengthsFor + Normalize — this test is
+// the guard against the multi-switch seam drifting (same discipline as the
+// theme Available()/Normalize sync test).
+var knownModes = []Mode{ModeTime, ModeWords, ModeQuote, ModeCode}
+
+// TestModeSeam_LengthsForHandlesEveryKnownMode asserts LengthsFor never
+// panics for a known mode and that the no-length modes (quote, code) return
+// nil while the numeric modes return non-empty options.
+func TestModeSeam_LengthsForHandlesEveryKnownMode(t *testing.T) {
+	for _, m := range knownModes {
+		lens := LengthsFor(m)
+		switch m {
+		case ModeQuote, ModeCode:
+			if lens != nil {
+				t.Errorf("LengthsFor(%q): want nil (no length selector), got %v", m, lens)
+			}
+		default:
+			if len(lens) == 0 {
+				t.Errorf("LengthsFor(%q): want non-empty options, got %v", m, lens)
+			}
+		}
+	}
+}
+
+// TestModeSeam_NormalizePreservesKnownAndRepairsUnknown asserts every known
+// mode survives Normalize and an unknown mode is repaired to ModeTime.
+func TestModeSeam_NormalizePreservesKnownAndRepairsUnknown(t *testing.T) {
+	for _, m := range knownModes {
+		s := Defaults()
+		s.DefaultMode = m
+		s.Normalize()
+		if s.DefaultMode != m {
+			t.Errorf("Normalize reset known mode %q to %q", m, s.DefaultMode)
+		}
+	}
+
+	s := Defaults()
+	s.DefaultMode = "definitely-not-a-mode"
+	s.Normalize()
+	if s.DefaultMode != ModeTime {
+		t.Errorf("unknown mode: want fallback ModeTime, got %q", s.DefaultMode)
+	}
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -10,6 +10,10 @@ const (
 	ModeTime  Mode = "time"
 	ModeWords Mode = "words"
 	ModeQuote Mode = "quote"
+	// ModeCode types a user-supplied snippet verbatim (CLI --text). It has
+	// no numeric length and completes on an exact full-text match (like
+	// quote). Whitespace/newlines/tabs are literal.
+	ModeCode Mode = "code"
 )
 
 // LengthsFor returns the selectable length options for a mode. Quote mode has
@@ -18,7 +22,8 @@ func LengthsFor(m Mode) []int {
 	switch m {
 	case ModeWords:
 		return []int{10, 25, 50, 100}
-	case ModeQuote:
+	case ModeQuote, ModeCode:
+		// No numeric length: the quote / supplied snippet bounds the test.
 		return nil
 	default: // ModeTime
 		return []int{15, 30, 60, 120}
@@ -60,7 +65,7 @@ func (s *Settings) Normalize() {
 		s.Theme = "default"
 	}
 	switch s.DefaultMode {
-	case ModeTime, ModeWords, ModeQuote:
+	case ModeTime, ModeWords, ModeQuote, ModeCode:
 	default:
 		s.DefaultMode = ModeTime
 	}

--- a/internal/storage/history_record.go
+++ b/internal/storage/history_record.go
@@ -7,14 +7,15 @@ import "time"
 // Record captures all fields needed for the History screen table, trend sparkline,
 // and new-best detection. It is encoded as JSON in history.json.
 //
-// Mode is one of "time", "words", or "quote" (mirrors config.Mode string values).
-// Length is the numeric parameter for time/words modes; 0 for quote mode.
+// Mode is one of "time", "words", "quote", or "code" (mirrors config.Mode).
+// Length is the numeric parameter for time/words; 0 for quote; the snippet
+// rune count for code (display only — code is excluded from new-best).
 // WPM is math.Round(NetWPM) stored as int for compact display and comparison.
 type Record struct {
 	// Time is the wall-clock moment the test completed (RFC3339 in JSON).
 	Time time.Time `json:"time"`
 
-	// Mode is the test mode string: "time", "words", or "quote".
+	// Mode is the test mode string: "time", "words", "quote", or "code".
 	Mode string `json:"mode"`
 
 	// Length is the mode parameter (seconds for time, word count for words). 0 for quote.

--- a/internal/storage/history_store_test.go
+++ b/internal/storage/history_store_test.go
@@ -328,6 +328,24 @@ func TestIsNewBest_LegacyFallback(t *testing.T) {
 	}
 }
 
+// TestIsNewBest_CodeMode checks that a Code-mode record is never a new best,
+// even when it would otherwise be the first result or the highest WPM.
+func TestIsNewBest_CodeMode(t *testing.T) {
+	// Empty history → would normally be first-ever → still false for code.
+	r := Record{Time: baseTime, Mode: "code", Length: 42, WPM: 80, NetWPM: 80.0}
+	if IsNewBest(nil, r) {
+		t.Error("code mode with empty hist: must never be a new best")
+	}
+	if IsNewBest([]Record{}, r) {
+		t.Error("code mode with empty hist slice: must never be a new best")
+	}
+	// Existing records for other modes should not affect the code exclusion.
+	hist := []Record{makeRecord(0, 40)} // time/30 WPM=40
+	if IsNewBest(hist, r) {
+		t.Error("code mode: must never be a new best regardless of hist")
+	}
+}
+
 // TestIsNewBest_FirstInBucket checks that the first result for a mode/length
 // bucket is always a new best regardless of other buckets.
 func TestIsNewBest_FirstInBucket(t *testing.T) {

--- a/internal/storage/new_best.go
+++ b/internal/storage/new_best.go
@@ -60,6 +60,10 @@ func effWPM(r Record) float64 {
 // hist must NOT already contain r; call IsNewBest before AppendHistory.
 // This function is pure and does not mutate hist.
 func IsNewBest(hist []Record, r Record) bool {
+	// Code-mode runs are never personal bests (display-only, no leaderboard).
+	if r.Mode == "code" {
+		return false
+	}
 	key := modeKey(r.Mode, r.Length)
 	best := -1.0
 	for _, h := range hist {

--- a/internal/typing/completion.go
+++ b/internal/typing/completion.go
@@ -12,7 +12,9 @@ import (
 //   - ModeWords: complete when the user has typed exactly wordTarget words.
 //     A word is considered typed when the trailing space has been entered OR
 //     when the last word in the sequence is fully typed (no trailing space needed).
-//   - ModeQuote: complete when the typed buffer exactly matches the full target.
+//   - ModeQuote / ModeCode: complete when the typed buffer exactly matches
+//     the full target (Code's target is the user-supplied snippet; literal
+//     '\n'/'\t' are ordinary target runes).
 func (e *Engine) Complete(nowMs int64) bool {
 	switch e.mode {
 	case config.ModeTime:
@@ -21,7 +23,7 @@ func (e *Engine) Complete(nowMs int64) bool {
 	case config.ModeWords:
 		return countCompletedWords(e.typed, e.target) >= e.wordTarget
 
-	case config.ModeQuote:
+	case config.ModeQuote, config.ModeCode:
 		return runesEqual(e.typed, e.target)
 
 	default:

--- a/internal/typing/completion_code_test.go
+++ b/internal/typing/completion_code_test.go
@@ -1,0 +1,65 @@
+package typing_test
+
+import (
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+// applyAll feeds every rune of s into the engine in order.
+func applyAll(e *typing.Engine, s string) {
+	ms := int64(0)
+	for _, r := range s {
+		ms += 100
+		e.Apply(r, ms)
+	}
+}
+
+// TestComplete_ModeCode_ExactMatchInclWhitespace verifies ModeCode finishes
+// only on an exact full-text match, treating literal '\n' and '\t' as normal
+// target runes (same rule as ModeQuote).
+func TestComplete_ModeCode_ExactMatchInclWhitespace(t *testing.T) {
+	const target = "func f() {\n\treturn 1\n}"
+
+	t.Run("incomplete until fully typed", func(t *testing.T) {
+		e := typing.New(target, config.ModeCode, 0)
+		applyAll(e, "func f() {")
+		if e.Complete(0) {
+			t.Fatal("should not be complete mid-snippet")
+		}
+	})
+
+	t.Run("complete on exact match incl newline/tab", func(t *testing.T) {
+		e := typing.New(target, config.ModeCode, 0)
+		applyAll(e, target) // includes '\n' and '\t' runes
+		if !e.Complete(0) {
+			t.Fatal("should be complete after exact full match")
+		}
+	})
+
+	t.Run("wrong char is not complete", func(t *testing.T) {
+		e := typing.New(target, config.ModeCode, 0)
+		applyAll(e, "func g() {\n\treturn 1\n}") // f->g
+		if e.Complete(0) {
+			t.Fatal("must not complete on a mismatching buffer of equal length")
+		}
+	})
+
+	t.Run("trailing extra runes are not complete", func(t *testing.T) {
+		e := typing.New(target, config.ModeCode, 0)
+		applyAll(e, target+";")
+		if e.Complete(0) {
+			t.Fatal("extra runes past the target must not count as complete")
+		}
+	})
+
+	t.Run("no word-count dependency", func(t *testing.T) {
+		// A single token with no spaces still completes on exact match.
+		e := typing.New("xyz", config.ModeCode, 0)
+		applyAll(e, "xyz")
+		if !e.Complete(0) {
+			t.Fatal("ModeCode must not require word boundaries")
+		}
+	})
+}

--- a/internal/ui/code_stream_renderer.go
+++ b/internal/ui/code_stream_renderer.go
@@ -1,0 +1,146 @@
+package ui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+// tabVisualWidth is how many columns a literal '\t' occupies on screen. The
+// user still presses a single Tab key to match the single '\t' target rune;
+// this is display-only (locked decision: 2 columns).
+const tabVisualWidth = 2
+
+// RenderCodeStream renders the Code-mode buffer with FULL-LITERAL layout:
+// literal '\n' starts a new row, '\t' shows as tabVisualWidth columns, and
+// long rows hard-wrap at width (no horizontal scroll). A vertical viewport of
+// at most height rows is returned, always containing the caret row
+// (scroll-follow). Per-rune styling reuses the same CharState→Role mapping as
+// the word stream; that tiny switch is duplicated here deliberately so the
+// golden-tested word_stream_renderer.go stays untouched (KISS over forced
+// DRY — same call as the v1.1.0 renderer decision).
+//
+// It is rune-safe and NO_COLOR-safe (the no-color theme only swaps attributes
+// for colors, so row/line structure is identical).
+func RenderCodeStream(
+	states []typing.CharState,
+	target []rune,
+	typed []rune,
+	width, height int,
+	th theme.Theme,
+) string {
+	if width < 1 {
+		width = 40
+	}
+	if height < 1 {
+		height = 20
+	}
+
+	stUntyped := th.Style(theme.RoleTextFaint)
+	stCorrect := th.Style(theme.RoleTextMuted)
+	stIncorrect := th.Style(theme.RoleError)
+	stIncorrectSpace := th.Style(theme.RoleErrorBg)
+	stExtra := th.Style(theme.RoleError).Faint(true)
+	stCurrent := th.Style(theme.RoleCursorBg)
+
+	styleFor := func(s typing.CharState) lipgloss.Style {
+		switch s {
+		case typing.Correct:
+			return stCorrect
+		case typing.Incorrect:
+			return stIncorrect
+		case typing.IncorrectSpace:
+			return stIncorrectSpace
+		case typing.Extra:
+			return stExtra
+		case typing.Current:
+			return stCurrent
+		default:
+			return stUntyped
+		}
+	}
+
+	var rows []string
+	var row strings.Builder
+	rowW := 0
+	caretRow := -1
+
+	flush := func() {
+		rows = append(rows, row.String())
+		row.Reset()
+		rowW = 0
+	}
+
+	for i := 0; i < len(states); i++ {
+		var r rune
+		switch {
+		case i < len(target):
+			r = target[i]
+		case i < len(typed):
+			r = typed[i]
+		default:
+			r = ' '
+		}
+		st := styleFor(states[i])
+		if states[i] == typing.Current {
+			caretRow = len(rows) // caret lives in the row being built now
+		}
+
+		if r == '\n' {
+			if states[i] == typing.Current {
+				row.WriteString(st.Render(" ")) // caret visible at line end
+			}
+			flush()
+			continue
+		}
+
+		cellW := 1
+		text := string(r)
+		if r == '\t' {
+			cellW = tabVisualWidth
+			text = strings.Repeat(" ", tabVisualWidth)
+		}
+		// Hard-wrap continuation (not a logical newline) to avoid horizontal
+		// overflow; a token wider than an empty row is still placed.
+		if rowW > 0 && rowW+cellW > width {
+			flush()
+			if states[i] == typing.Current {
+				caretRow = len(rows)
+			}
+		}
+		row.WriteString(st.Render(text))
+		rowW += cellW
+	}
+	// Always flush the final (possibly empty) in-progress row, and guarantee
+	// at least one row for non-empty input.
+	if row.Len() > 0 || len(rows) == 0 {
+		flush()
+	}
+
+	return joinViewport(rows, caretRow, height)
+}
+
+// joinViewport returns at most height rows, scrolled so caretRow is visible.
+// Fewer rows than height → all rows, unscrolled.
+func joinViewport(rows []string, caretRow, height int) string {
+	if len(rows) <= height {
+		return strings.Join(rows, "\n")
+	}
+	if caretRow < 0 {
+		caretRow = len(rows) - 1
+	}
+	start := 0
+	if caretRow >= height {
+		start = caretRow - height + 1
+	}
+	if max := len(rows) - height; start > max {
+		start = max
+	}
+	if start < 0 {
+		start = 0
+	}
+	return strings.Join(rows[start:start+height], "\n")
+}

--- a/internal/ui/code_stream_renderer_test.go
+++ b/internal/ui/code_stream_renderer_test.go
@@ -1,0 +1,131 @@
+package ui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func strip(s string) string { return ansiRE.ReplaceAllString(s, "") }
+
+// allUntyped builds a states slice (all Untyped) of length n with one Current
+// at caretIdx (or none if caretIdx < 0).
+func statesWithCaret(n, caretIdx int) []typing.CharState {
+	st := make([]typing.CharState, n)
+	for i := range st {
+		st[i] = typing.Untyped
+	}
+	if caretIdx >= 0 && caretIdx < n {
+		st[caretIdx] = typing.Current
+	}
+	return st
+}
+
+func runesOf(s string) []rune { return []rune(s) }
+
+func TestRenderCodeStream_LiteralNewlinesAndTabs(t *testing.T) {
+	th := theme.Load("default", true) // no-color: deterministic structure
+
+	t.Run("newline splits rows", func(t *testing.T) {
+		tgt := runesOf("a\nb")
+		out := strip(RenderCodeStream(statesWithCaret(len(tgt), 0), tgt, nil, 20, 10, th))
+		rows := strings.Split(out, "\n")
+		if len(rows) != 2 || strings.TrimRight(rows[0], " ") != "a" || strings.TrimRight(rows[1], " ") != "b" {
+			t.Fatalf("want rows [a b], got %q", rows)
+		}
+	})
+
+	t.Run("tab renders as 2 visual columns", func(t *testing.T) {
+		tgt := runesOf("\tx")
+		out := strip(RenderCodeStream(statesWithCaret(len(tgt), 0), tgt, nil, 20, 10, th))
+		row0 := strings.Split(out, "\n")[0]
+		if !strings.HasPrefix(row0, "  x") {
+			t.Fatalf("tab should expand to 2 spaces then x; got %q", row0)
+		}
+	})
+}
+
+func TestRenderCodeStream_StateStylingApplied(t *testing.T) {
+	th := theme.Load("default", false) // colored: states must differ visibly
+	tgt := runesOf("ab")
+	st := []typing.CharState{typing.Incorrect, typing.Untyped}
+	out := RenderCodeStream(st, tgt, runesOf("xb"), 20, 10, th)
+	// The incorrect 'a' token must carry styling distinct from a plain rune.
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected ANSI styling in colored output, got %q", out)
+	}
+	if !strings.Contains(strip(out), "a") || !strings.Contains(strip(out), "b") {
+		t.Fatalf("plain content must survive styling, got %q", strip(out))
+	}
+}
+
+func TestRenderCodeStream_Viewport(t *testing.T) {
+	th := theme.Load("default", true)
+	// 30 logical rows: "l0".."l29"
+	var b strings.Builder
+	for i := 0; i < 30; i++ {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString("l")
+		b.WriteByte(byte('0' + i%10))
+	}
+	tgt := runesOf(b.String())
+	height := 10
+
+	rowAtRune := func(idx int) string {
+		out := strip(RenderCodeStream(statesWithCaret(len(tgt), idx), tgt, nil, 20, height, th))
+		return out
+	}
+
+	t.Run("caret at top shows first window", func(t *testing.T) {
+		rows := strings.Split(rowAtRune(0), "\n")
+		if len(rows) != height {
+			t.Fatalf("want %d visible rows, got %d", height, len(rows))
+		}
+		if strings.TrimRight(rows[0], " ") != "l0" {
+			t.Fatalf("top window must start at l0, got %q", rows[0])
+		}
+	})
+
+	t.Run("caret at bottom keeps last row visible", func(t *testing.T) {
+		rows := strings.Split(rowAtRune(len(tgt)-1), "\n")
+		if len(rows) != height {
+			t.Fatalf("want %d visible rows, got %d", height, len(rows))
+		}
+		last := strings.TrimRight(rows[len(rows)-1], " ")
+		if last != "l9" { // row 29 → "l"+(29%10)="l9"
+			t.Fatalf("bottom window must end at last row l9, got %q", last)
+		}
+	})
+
+	t.Run("short input not scrolled", func(t *testing.T) {
+		short := runesOf("x\ny\nz")
+		out := strip(RenderCodeStream(statesWithCaret(len(short), 0), short, nil, 20, height, th))
+		rows := strings.Split(out, "\n")
+		if len(rows) != 3 {
+			t.Fatalf("short input must render exactly its rows, got %d: %q", len(rows), rows)
+		}
+	})
+}
+
+func TestRenderCodeStream_LongLineWraps(t *testing.T) {
+	th := theme.Load("default", true)
+	tgt := runesOf(strings.Repeat("a", 28)) // one logical line, no \n
+	width := 10
+	out := strip(RenderCodeStream(statesWithCaret(len(tgt), 27), tgt, nil, width, 10, th))
+	rows := strings.Split(out, "\n")
+	if len(rows) < 3 {
+		t.Fatalf("28 chars at width 10 must wrap into >=3 rows, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if len(strip(r)) > width {
+			t.Fatalf("row exceeds width %d: %q", width, r)
+		}
+	}
+}

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -13,9 +13,12 @@ import (
 // receives it and transitions to ScreenResult.
 // QuoteLen carries the quote bucket so ResultModel can re-emit StartTestMsg
 // with the correct bucket when the user restarts the same test.
+// CodeText carries the snippet text for ModeCode (used to store rune count and
+// to allow ctrl+r restart with the same text).
 type ResultMsg struct {
 	Result   metrics.Result
 	Mode     config.Mode
 	Length   int
 	QuoteLen words.QuoteLen
+	CodeText string
 }

--- a/internal/ui/phase09_polish_test.go
+++ b/internal/ui/phase09_polish_test.go
@@ -94,7 +94,7 @@ func TestDegradedNotice_NoColor(t *testing.T) {
 // TestNoColor_HomeView_HasAccentMarker verifies ▎ present on Home under NO_COLOR.
 func TestNoColor_HomeView_HasAccentMarker(t *testing.T) {
 	th := theme.Load("default", true)
-	h := NewHome(config.Defaults(), th, config.DefaultKeymap())
+	h := NewHome(config.Defaults(), th, config.DefaultKeymap(), "", "")
 	h = h.SetSize(80, 24)
 	view := h.View()
 	if !strings.Contains(view, "▎") {

--- a/internal/ui/screen_home.go
+++ b/internal/ui/screen_home.go
@@ -13,15 +13,18 @@ import (
 // to ScreenTyping.
 type StartTestMsg struct {
 	Mode     config.Mode
-	Length   int // seconds (Time) or word count (Words); 0 for Quote
+	Length   int // seconds (Time) or word count (Words); 0 for Quote/Code
 	QuoteLen words.QuoteLen
+	// CodeText carries the user-supplied snippet when Mode==ModeCode.
+	// Empty for all other modes.
+	CodeText string
 }
 
 // modeLabels maps mode constants to display names shown in the tab row.
-var modeLabels = []string{"Time", "Words", "Quote"}
+var modeLabels = []string{"Time", "Words", "Quote", "Code"}
 
 // modeOrder is the cycle order for tab switching.
-var modeOrder = []config.Mode{config.ModeTime, config.ModeWords, config.ModeQuote}
+var modeOrder = []config.Mode{config.ModeTime, config.ModeWords, config.ModeQuote, config.ModeCode}
 
 // quoteBucketLabels are the display labels for Quote sub-options.
 var quoteBucketLabels = []string{"short", "medium", "long"}
@@ -33,16 +36,20 @@ var quoteBuckets = []words.QuoteLen{words.QuoteShort, words.QuoteMedium, words.Q
 // currently-selected mode and a per-mode length index so that switching tabs
 // preserves each mode's choice.
 type HomeModel struct {
-	modeIdx int                 // index into modeOrder / modeLabels
-	lenIdx  map[config.Mode]int // selected option index per mode
-	w, h    int
-	th      theme.Theme
-	km      config.Keymap
+	modeIdx  int                 // index into modeOrder / modeLabels
+	lenIdx   map[config.Mode]int // selected option index per mode
+	w, h     int
+	th       theme.Theme
+	km       config.Keymap
+	codeText string // user-supplied snippet; empty = Code row disabled
+	codeHint string // load-failure reason shown on Code row; empty = no error
 }
 
 // NewHome constructs a HomeModel seeded from s. The initial mode and length
 // index are derived from s.DefaultMode and s.DefaultLength.
-func NewHome(s config.Settings, th theme.Theme, km config.Keymap) HomeModel {
+// codeText is the loaded snippet (empty = Code disabled); codeHint is the
+// load-failure reason string (empty = loaded OK or no --text flag).
+func NewHome(s config.Settings, th theme.Theme, km config.Keymap, codeText, codeHint string) HomeModel {
 	// Resolve initial mode index.
 	modeIdx := 0
 	for i, m := range modeOrder {
@@ -53,11 +60,16 @@ func NewHome(s config.Settings, th theme.Theme, km config.Keymap) HomeModel {
 	}
 
 	// Build per-mode length index map seeded to the middle option by default.
+	// Quote defaults to index 1 (medium bucket). Code has no cycler; index is unused.
 	lenIdx := make(map[config.Mode]int)
 	for _, m := range modeOrder {
 		lens := config.LengthsFor(m)
 		if lens == nil {
-			lenIdx[m] = 1 // default to "medium" for Quote
+			if m == config.ModeQuote {
+				lenIdx[m] = 1 // default to "medium" bucket
+			} else {
+				lenIdx[m] = 0 // Code: no-op index, unused
+			}
 			continue
 		}
 		// Find the index of DefaultLength within this mode's option list.
@@ -72,10 +84,12 @@ func NewHome(s config.Settings, th theme.Theme, km config.Keymap) HomeModel {
 	}
 
 	return HomeModel{
-		modeIdx: modeIdx,
-		lenIdx:  lenIdx,
-		th:      th,
-		km:      km,
+		modeIdx:  modeIdx,
+		lenIdx:   lenIdx,
+		th:       th,
+		km:       km,
+		codeText: codeText,
+		codeHint: codeHint,
 	}
 }
 
@@ -90,11 +104,17 @@ func (m HomeModel) SetSize(w, h int) HomeModel {
 func (m HomeModel) currentMode() config.Mode { return modeOrder[m.modeIdx] }
 
 // optionCount returns the number of selectable options for the current mode.
+// Code and Quote have no numeric length selector; Code returns 0, Quote returns
+// the bucket count.
 func (m HomeModel) optionCount() int {
-	if m.currentMode() == config.ModeQuote {
+	switch m.currentMode() {
+	case config.ModeQuote:
 		return len(quoteBucketLabels)
+	case config.ModeCode:
+		return 0 // no cycler; OptLeft/OptRight are no-ops
+	default:
+		return len(config.LengthsFor(m.currentMode()))
 	}
-	return len(config.LengthsFor(m.currentMode()))
 }
 
 // Update handles key events for the Home screen and returns an optional Cmd.
@@ -115,17 +135,17 @@ func (m HomeModel) Update(msg tea.Msg) (HomeModel, tea.Cmd) {
 	case m.km.PrevMode.Matches(k):
 		m.modeIdx = (m.modeIdx - 1 + len(modeOrder)) % len(modeOrder)
 
-	// Decrease length option (clamped at 0).
+	// Decrease length option (clamped at 0, no-op for Code which has no cycler).
 	case m.km.OptLeft.Matches(k):
 		mode := m.currentMode()
-		if m.lenIdx[mode] > 0 {
+		if mode != config.ModeCode && m.lenIdx[mode] > 0 {
 			m.lenIdx[mode]--
 		}
 
-	// Increase length option (clamped at max).
+	// Increase length option (clamped at max, no-op for Code which has no cycler).
 	case m.km.OptRight.Matches(k):
 		mode := m.currentMode()
-		if m.lenIdx[mode] < m.optionCount()-1 {
+		if mode != config.ModeCode && m.lenIdx[mode] < m.optionCount()-1 {
 			m.lenIdx[mode]++
 		}
 
@@ -138,8 +158,21 @@ func (m HomeModel) Update(msg tea.Msg) (HomeModel, tea.Cmd) {
 }
 
 // startCmd builds a Cmd that emits a StartTestMsg with the current selection.
+// For ModeCode with no text loaded, it returns nil (no-op — stay on Home).
 func (m HomeModel) startCmd() tea.Cmd {
 	mode := m.currentMode()
+
+	// Code mode: no-op if no text; emit with CodeText payload if available.
+	if mode == config.ModeCode {
+		if m.codeText == "" {
+			return nil
+		}
+		ct := m.codeText
+		return func() tea.Msg {
+			return StartTestMsg{Mode: config.ModeCode, CodeText: ct}
+		}
+	}
+
 	idx := m.lenIdx[mode]
 
 	var length int

--- a/internal/ui/screen_home_code_test.go
+++ b/internal/ui/screen_home_code_test.go
@@ -1,0 +1,170 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+// newTestHomeCode builds a HomeModel with an empty codeText.
+func newTestHomeCode(codeText, codeHint string) HomeModel {
+	return NewHome(config.Defaults(), theme.Default(), config.DefaultKeymap(), codeText, codeHint)
+}
+
+// TestHome_CodeInModeOrder verifies ModeCode is included in the mode cycle.
+func TestHome_CodeInModeOrder(t *testing.T) {
+	found := false
+	for _, m := range modeOrder {
+		if m == config.ModeCode {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("ModeCode must be present in modeOrder")
+	}
+}
+
+// TestHome_CodeLabelInLabels verifies "Code" appears in modeLabels.
+func TestHome_CodeLabelInLabels(t *testing.T) {
+	found := false
+	for _, l := range modeLabels {
+		if l == "Code" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("modeLabels must include 'Code', got %v", modeLabels)
+	}
+}
+
+// TestHome_TabCycleIncludesCode verifies tab cycling reaches Code mode.
+func TestHome_TabCycleIncludesCode(t *testing.T) {
+	h := newTestHomeCode("", "")
+	seen := false
+	for i := 0; i < len(modeOrder)*2; i++ {
+		h, _ = h.Update(pressTab())
+		if h.currentMode() == config.ModeCode {
+			seen = true
+			break
+		}
+	}
+	if !seen {
+		t.Fatal("tab cycling must reach ModeCode")
+	}
+}
+
+// TestHome_CodeNoText_StartCmdNil verifies Enter is a no-op when no code text.
+func TestHome_CodeNoText_StartCmdNil(t *testing.T) {
+	h := newTestHomeCode("", "pass --text <file> · in-app paste coming soon")
+	// Navigate to Code mode.
+	for h.currentMode() != config.ModeCode {
+		h, _ = h.Update(pressTab())
+	}
+	_, cmd := h.Update(pressEnter())
+	if cmd != nil {
+		t.Fatalf("enter on Code with no text must return nil cmd, got non-nil")
+	}
+}
+
+// TestHome_CodeNoText_SpaceNoop verifies space is also no-op without code text.
+func TestHome_CodeNoText_SpaceNoop(t *testing.T) {
+	h := newTestHomeCode("", "")
+	for h.currentMode() != config.ModeCode {
+		h, _ = h.Update(pressTab())
+	}
+	_, cmd := h.Update(pressKey(' ', 0))
+	if cmd != nil {
+		t.Fatalf("space on Code with no text must return nil cmd")
+	}
+}
+
+// TestHome_CodeWithText_StartCmdEmitsMsg verifies Enter emits StartTestMsg when
+// code text is loaded.
+func TestHome_CodeWithText_StartCmdEmitsMsg(t *testing.T) {
+	codeText := "func main() {\n\treturn\n}"
+	h := newTestHomeCode(codeText, "")
+	for h.currentMode() != config.ModeCode {
+		h, _ = h.Update(pressTab())
+	}
+	_, cmd := h.Update(pressEnter())
+	if cmd == nil {
+		t.Fatal("enter with code text must return non-nil cmd")
+	}
+	msg := cmd()
+	sm, ok := msg.(StartTestMsg)
+	if !ok {
+		t.Fatalf("want StartTestMsg, got %T", msg)
+	}
+	if sm.Mode != config.ModeCode {
+		t.Errorf("want Mode=ModeCode, got %v", sm.Mode)
+	}
+	if sm.CodeText != codeText {
+		t.Errorf("want CodeText=%q, got %q", codeText, sm.CodeText)
+	}
+}
+
+// TestHome_CodeOptLeftRightNoPanic verifies OptLeft/OptRight do not panic on
+// the Code row (which has no length cycler — optionCount==0).
+func TestHome_CodeOptLeftRightNoPanic(t *testing.T) {
+	h := newTestHomeCode("some code", "")
+	for h.currentMode() != config.ModeCode {
+		h, _ = h.Update(pressTab())
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("OptLeft panicked on Code row: %v", r)
+		}
+	}()
+	h, _ = h.Update(pressLeft())
+	h, _ = h.Update(pressRight())
+	// No assertion needed — just must not panic or change mode.
+	if h.currentMode() != config.ModeCode {
+		t.Error("OptLeft/OptRight must not change mode on Code row")
+	}
+}
+
+// TestHome_CodeRow_HintNoText verifies renderOptions for Code without text
+// shows the disabled-style hint string.
+func TestHome_CodeRow_HintNoText(t *testing.T) {
+	h := newTestHomeCode("", "")
+	h = h.SetSize(80, 24)
+	for h.currentMode() != config.ModeCode {
+		h, _ = h.Update(pressTab())
+	}
+	view := h.View()
+	if !strings.Contains(view, "pass --text") {
+		t.Fatalf("Code row without text must show 'pass --text' hint, got:\n%s", view)
+	}
+}
+
+// TestHome_CodeRow_ReadyWithText verifies renderOptions for Code with text
+// shows the "ready" hint.
+func TestHome_CodeRow_ReadyWithText(t *testing.T) {
+	h := newTestHomeCode("some code text", "")
+	h = h.SetSize(80, 24)
+	for h.currentMode() != config.ModeCode {
+		h, _ = h.Update(pressTab())
+	}
+	view := h.View()
+	if !strings.Contains(view, "ready") {
+		t.Fatalf("Code row with text must show 'ready' hint, got:\n%s", view)
+	}
+}
+
+// TestHome_CodeRow_ErrorHint verifies renderOptions shows a custom error hint
+// when codeHint is set (load failure).
+func TestHome_CodeRow_ErrorHint(t *testing.T) {
+	h := newTestHomeCode("", "text file is empty")
+	h = h.SetSize(80, 24)
+	for h.currentMode() != config.ModeCode {
+		h, _ = h.Update(pressTab())
+	}
+	view := h.View()
+	if !strings.Contains(view, "text file is empty") {
+		t.Fatalf("Code row with error hint must show it, got:\n%s", view)
+	}
+}

--- a/internal/ui/screen_home_test.go
+++ b/internal/ui/screen_home_test.go
@@ -14,7 +14,7 @@ import (
 // helpers
 
 func newTestHome() HomeModel {
-	return NewHome(config.Defaults(), theme.Default(), config.DefaultKeymap())
+	return NewHome(config.Defaults(), theme.Default(), config.DefaultKeymap(), "", "")
 }
 
 func pressKey(code rune, mod tea.KeyMod) tea.KeyPressMsg {
@@ -40,7 +40,7 @@ func TestNewHomeSeededFromSettings(t *testing.T) {
 	}
 }
 
-// TestTabCyclesModeForward verifies tab → Time→Words→Quote→Time.
+// TestTabCyclesModeForward verifies tab → Time→Words→Quote→Code→Time.
 func TestTabCyclesModeForward(t *testing.T) {
 	h := newTestHome()
 
@@ -55,18 +55,29 @@ func TestTabCyclesModeForward(t *testing.T) {
 	}
 
 	h, _ = h.Update(pressTab())
+	if h.currentMode() != config.ModeCode {
+		t.Fatalf("after 3rd tab: want ModeCode, got %v", h.currentMode())
+	}
+
+	h, _ = h.Update(pressTab())
 	if h.currentMode() != config.ModeTime {
-		t.Fatalf("after 3rd tab (wrap): want ModeTime, got %v", h.currentMode())
+		t.Fatalf("after 4th tab (wrap): want ModeTime, got %v", h.currentMode())
 	}
 }
 
 // TestShiftTabCyclesModeBackward verifies shift+tab reverses mode order.
+// With four modes (Time, Words, Quote, Code), shift+tab from Time wraps to Code.
 func TestShiftTabCyclesModeBackward(t *testing.T) {
 	h := newTestHome()
-	// Start on Time, shift+tab should wrap to Quote.
+	// Start on Time, shift+tab should wrap to Code (last mode).
+	h, _ = h.Update(pressShiftTab())
+	if h.currentMode() != config.ModeCode {
+		t.Fatalf("shift+tab from Time: want ModeCode (last), got %v", h.currentMode())
+	}
+
 	h, _ = h.Update(pressShiftTab())
 	if h.currentMode() != config.ModeQuote {
-		t.Fatalf("shift+tab from Time: want ModeQuote, got %v", h.currentMode())
+		t.Fatalf("shift+tab from Code: want ModeQuote, got %v", h.currentMode())
 	}
 
 	h, _ = h.Update(pressShiftTab())
@@ -151,12 +162,17 @@ func TestSwitchModePreservesPerModeLengthIndex(t *testing.T) {
 
 // TestLengthIndexInRangeAfterModeSwitch verifies the per-mode index is always
 // within the bounds of the new mode's options (no out-of-range panic).
+// ModeCode is explicitly excluded: it has no length cycler (optionCount==0)
+// so the usual [0,count) check does not apply.
 func TestLengthIndexInRangeAfterModeSwitch(t *testing.T) {
 	h := newTestHome()
 	// Cycle through all modes and check each index is valid.
 	for i := 0; i < len(modeOrder)*2; i++ {
 		h, _ = h.Update(pressTab())
 		mode := h.currentMode()
+		if mode == config.ModeCode {
+			continue // Code has no length cycler; skip range check
+		}
 		idx := h.lenIdx[mode]
 		count := h.optionCount()
 		if idx < 0 || idx >= count {

--- a/internal/ui/screen_home_view.go
+++ b/internal/ui/screen_home_view.go
@@ -57,18 +57,38 @@ func (m HomeModel) renderTabs() string {
 }
 
 // renderOptions builds the length-option row for the current mode.
+// For Code mode a single disabled-style hint line is shown instead of a cycler.
 func (m HomeModel) renderOptions() string {
 	mode := m.currentMode()
-	chosen := m.lenIdx[mode]
-	if mode == config.ModeQuote {
-		return RenderOptions(quoteBucketLabels, chosen, m.th)
+	switch mode {
+	case config.ModeQuote:
+		return RenderOptions(quoteBucketLabels, m.lenIdx[mode], m.th)
+	case config.ModeCode:
+		return m.renderCodeHint()
+	default:
+		lens := config.LengthsFor(mode)
+		labels := make([]string, len(lens))
+		for i, v := range lens {
+			labels[i] = fmt.Sprintf("%d", v)
+		}
+		return RenderOptions(labels, m.lenIdx[mode], m.th)
 	}
-	lens := config.LengthsFor(mode)
-	labels := make([]string, len(lens))
-	for i, v := range lens {
-		labels[i] = fmt.Sprintf("%d", v)
+}
+
+// renderCodeHint returns a single disabled-style hint line for the Code row.
+// When codeHint is non-empty (load error), it shows that. When codeText is
+// loaded it shows "ready · press enter". Otherwise it shows the --text hint.
+func (m HomeModel) renderCodeHint() string {
+	var text string
+	switch {
+	case m.codeHint != "":
+		text = m.codeHint
+	case m.codeText != "":
+		text = "ready · press enter"
+	default:
+		text = "pass --text <file> · in-app paste coming soon"
 	}
-	return RenderOptions(labels, chosen, m.th)
+	return m.th.Style(theme.RoleTextFaint).Render(text)
 }
 
 // homeHints returns the footer hint set for the Home screen per mockups §1.

--- a/internal/ui/screen_result.go
+++ b/internal/ui/screen_result.go
@@ -20,7 +20,8 @@ type ResultModel struct {
 	mode     config.Mode
 	length   int
 	quoteLen words.QuoteLen
-	isBest   bool // set externally by Phase 8; false = badge hidden
+	codeText string // ModeCode snippet, so restart-same re-runs it (not "")
+	isBest   bool   // set externally by Phase 8; false = badge hidden
 
 	w, h int
 	th   theme.Theme
@@ -35,6 +36,7 @@ func NewResult(msg ResultMsg, th theme.Theme, km config.Keymap) ResultModel {
 		mode:     msg.Mode,
 		length:   msg.Length,
 		quoteLen: msg.QuoteLen,
+		codeText: msg.CodeText,
 		th:       th,
 		km:       km,
 	}
@@ -88,9 +90,9 @@ func (m ResultModel) Update(msg tea.Msg) (ResultModel, tea.Cmd) {
 
 // restartSameCmd emits a StartTestMsg that re-creates an identical typing test.
 func (m ResultModel) restartSameCmd() tea.Cmd {
-	mode, length, ql := m.mode, m.length, m.quoteLen
+	mode, length, ql, ct := m.mode, m.length, m.quoteLen, m.codeText
 	return func() tea.Msg {
-		return StartTestMsg{Mode: mode, Length: length, QuoteLen: ql}
+		return StartTestMsg{Mode: mode, Length: length, QuoteLen: ql, CodeText: ct}
 	}
 }
 

--- a/internal/ui/screen_result_test.go
+++ b/internal/ui/screen_result_test.go
@@ -12,6 +12,30 @@ import (
 	"github.com/bavanchun/Typeburn/internal/words"
 )
 
+// TestResult_RestartSame_CodeModeKeepsSnippet is the regression guard for the
+// Result-screen restart-same path dropping the Code snippet (which made the
+// restarted test instantly complete on an empty target).
+func TestResult_RestartSame_CodeModeKeepsSnippet(t *testing.T) {
+	const snippet = "func f() {\n\treturn 1\n}"
+	msg := ResultMsg{
+		Result:   metrics.Result{},
+		Mode:     config.ModeCode,
+		CodeText: snippet,
+	}
+	m := NewResult(msg, theme.Default(), config.DefaultKeymap())
+	out := m.restartSameCmd()()
+	st, ok := out.(StartTestMsg)
+	if !ok {
+		t.Fatalf("want StartTestMsg, got %T", out)
+	}
+	if st.Mode != config.ModeCode {
+		t.Errorf("mode: want code, got %q", st.Mode)
+	}
+	if st.CodeText != snippet {
+		t.Errorf("restart-same dropped the snippet: got %q want %q", st.CodeText, snippet)
+	}
+}
+
 // newTestResult constructs a ResultModel with sample data and 80×24 terminal.
 func newTestResult() ResultModel {
 	res := metrics.Result{

--- a/internal/ui/screen_typing_actions.go
+++ b/internal/ui/screen_typing_actions.go
@@ -21,20 +21,27 @@ func (m TypingModel) restartSame() TypingModel {
 }
 
 // newTest regenerates target text and resets everything.
+// For ModeCode, the same code text is reused (no random re-generation).
 func (m TypingModel) newTest() TypingModel {
-	fresh := newTypingWithSeed(m.mode, m.length, m.ql, m.th, m.keys, m.blink, 0)
+	var fresh TypingModel
+	if m.mode == config.ModeCode {
+		fresh = NewTypingCode(m.target, m.th, m.keys, m.blink)
+	} else {
+		fresh = newTypingWithSeed(m.mode, m.length, m.ql, m.th, m.keys, m.blink, 0)
+	}
 	fresh.w, fresh.h = m.w, m.h
 	return fresh
 }
 
 // completeCmd returns a Cmd that emits a ResultMsg carrying computed metrics.
 // QuoteLen is forwarded so ResultModel can restart the same quote bucket.
+// CodeText is forwarded so the root can persist rune count and allow restart.
 func (m TypingModel) completeCmd(endMs int64) tea.Cmd {
 	log := m.eng.Log()
 	result := metrics.Compute(log, m.mode, endMs)
-	mode, length, ql := m.mode, m.length, m.ql
+	mode, length, ql, ct := m.mode, m.length, m.ql, m.target
 	return func() tea.Msg {
-		return ResultMsg{Result: result, Mode: mode, Length: length, QuoteLen: ql}
+		return ResultMsg{Result: result, Mode: mode, Length: length, QuoteLen: ql, CodeText: ct}
 	}
 }
 

--- a/internal/ui/screen_typing_code.go
+++ b/internal/ui/screen_typing_code.go
@@ -1,0 +1,35 @@
+package ui
+
+// screen_typing_code.go contains the ModeCode constructor and test accessors
+// that extend TypingModel for code-snippet typing. Kept separate to hold
+// screen_typing.go under 200 LOC (modularization boundary: code-mode-specific
+// construction vs general typing engine lifecycle).
+
+import (
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+// NewTypingCode constructs a TypingModel for ModeCode using the supplied text
+// verbatim as the target — words.ForMode is NOT called. This keeps the pure
+// words/typing packages free of code-mode knowledge (I/O boundary is in main).
+func NewTypingCode(target string, th theme.Theme, km config.Keymap, blink bool) TypingModel {
+	eng := typing.New(target, config.ModeCode, 0)
+	return TypingModel{
+		eng:    eng,
+		mode:   config.ModeCode,
+		target: target,
+		th:     th,
+		keys:   km,
+		blink:  blink,
+		seed:   0,
+	}
+}
+
+// ExportedStartMs returns the startMs field for test assertions (white-box
+// access needed by code_mode_test.go to verify engine timer state).
+func (m TypingModel) ExportedStartMs() int64 { return m.startMs }
+
+// ExportedLog returns the engine's keystroke log for test assertions.
+func (m TypingModel) ExportedLog() []typing.Keystroke { return m.eng.Log() }

--- a/internal/ui/screen_typing_view.go
+++ b/internal/ui/screen_typing_view.go
@@ -5,7 +5,13 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/bavanchun/Typeburn/internal/config"
 )
+
+// fixedOverhead is the number of non-stream rows in the typing screen layout:
+// header + blank + blank-before-footer + footer = 4 rows.
+const fixedOverhead = 4
 
 // View renders the full typing screen content as a string. The root app.Model
 // wraps this in lipgloss.Place for centering — View itself does not center.
@@ -28,13 +34,32 @@ func (m TypingModel) View() string {
 		m.th,
 	)
 
-	stream := RenderWordStream(
-		m.eng.States(),
-		[]rune(m.target),
-		typedFromLog(m.eng.Log()),
-		cw,
-		m.th,
-	)
+	// Select renderer based on mode: Code uses the literal code stream renderer;
+	// all other modes use the word stream renderer (golden-tested, unchanged).
+	var stream string
+	if m.mode == config.ModeCode {
+		// streamHeight = total height minus fixed overhead rows; clamp ≥1.
+		streamHeight := m.h - fixedOverhead
+		if streamHeight < 1 {
+			streamHeight = 1
+		}
+		stream = RenderCodeStream(
+			m.eng.States(),
+			[]rune(m.target),
+			typedFromLog(m.eng.Log()),
+			cw,
+			streamHeight,
+			m.th,
+		)
+	} else {
+		stream = RenderWordStream(
+			m.eng.States(),
+			[]rune(m.target),
+			typedFromLog(m.eng.Log()),
+			cw,
+			m.th,
+		)
+	}
 
 	footer := RenderFooter(TypingHints(), m.w, m.th)
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -12,35 +13,65 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/bavanchun/Typeburn/internal/app"
+	"github.com/bavanchun/Typeburn/internal/codetext"
 	"github.com/bavanchun/Typeburn/internal/version"
 )
 
-// decide maps process args to the single startup decision: print the version
-// banner, or launch the TUI. It is a pure function (no os.Exit, no I/O) so the
-// arg-handling contract is unit-testable.
+// decide maps process args to the startup decisions: print the version banner,
+// or launch the TUI, and optionally which file path to load as code text.
+// It is a pure function (no os.Exit, no I/O) so the arg-handling contract is
+// unit-testable.
 //
 // Only an explicitly parsed --version short-circuits. A dedicated
 // ContinueOnError FlagSet with discarded output means unknown flags, -h and
 // the reserved -v all return a parse error, which we treat as "just launch the
 // TUI" — preserving the long-standing behavior that `typeburn <anything>`
 // starts the test rather than exiting 2 with a usage dump.
-func decide(args []string) (printVersion bool) {
+//
+// textPath is "" when --text is absent or when parse fails (fall-through).
+func decide(args []string) (printVersion bool, textPath string) {
 	fs := flag.NewFlagSet("typeburn", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	showVersion := fs.Bool("version", false, "print version and exit")
+	textFlag := fs.String("text", "", "file to load as code typing target (\"-\" = stdin)")
 	if err := fs.Parse(args); err != nil {
-		return false
+		return false, ""
 	}
-	return *showVersion
+	return *showVersion, *textFlag
+}
+
+// codeHintFor returns a user-facing one-liner explaining a codetext load error.
+// It branches on the sentinel errors defined by the codetext package.
+func codeHintFor(err error) string {
+	switch {
+	case errors.Is(err, codetext.ErrEmpty):
+		return "text file is empty"
+	case errors.Is(err, codetext.ErrTooLarge):
+		return "text file too large"
+	case errors.Is(err, codetext.ErrBinary):
+		return "file is not text"
+	default:
+		return "could not read text file"
+	}
 }
 
 func main() {
-	if decide(os.Args[1:]) {
+	printVersion, textPath := decide(os.Args[1:])
+	if printVersion {
 		fmt.Println(version.String())
 		return
 	}
 
-	p := tea.NewProgram(app.NewFromDisk())
+	var codeText, codeHint string
+	if textPath != "" {
+		var err error
+		codeText, err = codetext.Load(textPath)
+		if err != nil {
+			codeHint = codeHintFor(err)
+		}
+	}
+
+	p := tea.NewProgram(app.NewFromDisk(codeText, codeHint))
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, "typeburn:", err)
 		os.Exit(1)

--- a/plans/260519-0142-code-mode-custom-text/brainstorm-summary.md
+++ b/plans/260519-0142-code-mode-custom-text/brainstorm-summary.md
@@ -1,0 +1,127 @@
+# Brainstorm Summary — Code Mode / Custom Text Input
+
+Date: 2026-05-19 · Status: agreed, ready for `/ck:plan`
+
+## Problem statement
+
+Next sizeable roadmap feature: let users practice typing on their own text
+(incl. code) instead of the embedded wordlist/quote pack. Add a `code` test
+mode.
+
+## Scout-grounded context
+
+- Modes = `config.Mode` string enum (`time`/`words`/`quote`,
+  `settings.go:10`), cycled on Home via `modeOrder` (`screen_home.go:24`),
+  persisted in settings + `Record.Mode`. New mode touches the same
+  multi-switch seam (LengthsFor / Normalize / home cycle / Record) — same
+  DRY discipline used for theme packs.
+- **Quote mode is Code mode's twin:** text via `words.ForMode`; engine
+  completion = `runesEqual(typed,target)` exact full-text match
+  (`completion.go:25`). Engine records keystrokes generically; metrics
+  derive post-hoc. AFKTrim is Time-only.
+- Renderer `word_stream_renderer.go` = single-stream hard char-cell wrap with
+  golden tests across time/words/quote. Does NOT preserve `\n` or render
+  tabs.
+- No in-TUI text-input widget exists; `main.go` `decide()` flag plumbing
+  exists & is tested (used by `--version`).
+- History/new-best keys on `modeKey(Mode,Length)` (`new_best.go:63`).
+- `internal/words` & `internal/typing` are pure (no I/O) per the layering
+  rule (re-tightened in docs this cycle).
+
+## Locked decisions
+
+1. **Input:** `typeburn --text <file>` and `--text -` (stdin) this round.
+   Architecture must NOT preclude a later in-TUI paste screen. No paste/edit
+   UI now.
+2. **Whitespace:** full literal preservation. Target contains literal `\n`
+   and `\t` runes. User presses Enter to match `\n`, Tab to match `\t`, and
+   types every space/indentation exactly. Tab visual width = **2 columns**
+   (display-only; one Tab keypress matches one `\t`).
+3. **Persistence:** Code runs ARE saved to history (visible in History) but
+   are **excluded from ★ new-best** (custom text not comparable).
+4. **Home behaviour:** Code mode is **always** in the Tab cycle; when no
+   `--text` was supplied it is shown **disabled with a hint**
+   (`pass --text <file> · in-app paste coming soon`) and Enter is a no-op.
+   Code mode has **no length selector**.
+5. **Out of scope:** syntax highlighting, saved-snippet library, language
+   detection / per-language stats, in-TUI paste editing, AFKTrim for code.
+
+## Architecture (agreed)
+
+- **New mode:** add `ModeCode = "code"` to `config.Mode`; extend
+  `LengthsFor` (Code → nil/none), `Normalize` (accept "code"), `modeOrder`,
+  storage `Record.Mode` doc. Same documented-duplication + sync-test
+  discipline as the theme work where a switch is duplicated.
+- **Engine/completion:** `typing.New(target, ModeCode, …)` with target =
+  literal snippet runes. Add `case ModeCode:` in `completion.go` aliasing the
+  Quote exact-match rule. No word-count / no AFKTrim for code. Metrics
+  unchanged (newlines/tabs counted as typed chars consistently).
+- **Loader — new `internal/codetext` package (pure-core stays pure):**
+  reads file or stdin (`-`), normalizes: CRLF→LF, strip UTF-8 BOM, trim a
+  single trailing `\n` (so EOF needs no final Enter), reject/cap oversized
+  (~10k runes / ~500 lines) and empty/whitespace-only/binary input with a
+  graceful error (no crash; Home shows Code disabled + reason). Returns
+  `(string, error)`. App wires it in; `words.ForMode` is bypassed for code.
+- **Renderer — Approach A: new `internal/ui/code_stream_renderer.go`** +
+  vertical viewport that scrolls to keep the caret line visible. Honors
+  literal `\n` (real line breaks) and `\t` (2-col visual). Reuses the
+  existing per-char `theme.Role` state styling. `word_stream_renderer.go`
+  and its golden tests are **untouched** (regression isolation; the two
+  rendering models are genuinely different — rejected generalizing into one).
+- **Wiring:** `main.go decide()` gains `--text`; loaded text flows through
+  `app.Model` → `StartTestMsg` (carry the code text/availability) →
+  `NewTyping`. Home forks on text-supplied vs not.
+- Rejected: collapse-to-one-stream (excluded by the full-literal choice);
+  generalized single renderer (Approach B — high golden-test regression
+  risk, false DRY).
+
+## Expected output
+
+`typeburn --text snippet.go` → Home shows Code selectable → start → snippet
+rendered multi-line with literal indentation, 2-col tabs, real line breaks,
+caret scrolling with a viewport; user types every char; Tab matches `\t`,
+Enter matches `\n`; mistakes use existing char-state roles; completion on
+exact full-text match; result screen shows; record persisted `Mode="code"`,
+never ★; History lists it. No `--text` → Code in cycle but disabled + hint,
+Enter no-op, other modes unaffected. `cat f | typeburn --text -` works.
+
+## Acceptance criteria
+
+- All of the above behaviours verifiable; time/words/quote unchanged
+  (golden tests pass — word-stream renderer untouched).
+- `codetext` normalization unit-tested (CRLF, BOM, trailing-nl trim, size
+  cap, empty/binary → error).
+- Completion/engine: ModeCode exact-match table-tested incl. `\n`/`\t`.
+- Viewport scroll-follow-caret table-tested (caret near top/bottom/long
+  file).
+- Home disabled-Code state + hint + Enter-no-op tested; length selector
+  absent for Code.
+- `Record.Mode=="code"` never returned by `IsNewBest`; appears in history.
+- gofmt/vet/`go test ./... -race -count=1` green; prod files <200 LOC;
+  module stays pure (words/typing no new I/O imports).
+- Ships via protected-main PR flow; semver **minor → v1.2.0**.
+
+## Risks
+
+- Viewport scroll math (new) — table-test caret at top/mid/bottom + file
+  longer/shorter than screen; degraded (small terminal) gate still wins.
+- Tab/Enter must reach the engine mid-test — verify
+  `model_key_handler.go` delegates all keys to typing during a test (it
+  does today); add a regression test.
+- Multi-switch mode seam drift — mirror the theme sync-test discipline.
+- Oversized/binary/empty input — must degrade gracefully, never panic;
+  explicit tests.
+- New renderer dup vs word-stream — accepted: different rendering models;
+  isolation chosen deliberately over false-DRY.
+
+## Out of scope (deferred)
+
+In-TUI paste screen + editing, syntax highlighting, saved-snippet library,
+language detection / per-language stats, elastic tab stops, AFKTrim for code.
+Architecture leaves room for a later paste screen (text-source is an
+injected string; Home already forks on availability).
+
+## Open questions
+
+None — all input/whitespace/persistence/home/renderer/loader decisions
+locked with the user.

--- a/plans/260519-0142-code-mode-custom-text/phase-01-branch-setup.md
+++ b/plans/260519-0142-code-mode-custom-text/phase-01-branch-setup.md
@@ -1,0 +1,42 @@
+---
+phase: 1
+title: "Branch Setup"
+status: pending
+priority: P1
+effort: "5m"
+dependencies: []
+---
+
+# Phase 1: Branch Setup
+
+## Overview
+Create the protected-main feature branch all phases commit to. Gate phase —
+no code, no commit.
+
+## Requirements
+- Functional: `feat/v1.2.0-code-mode` exists off latest `main`.
+- Non-functional: respects hard-enforced protected-main (local hook +
+  branch protection).
+
+## Architecture
+Single shared branch; sequential per-phase commits.
+
+## Related Code Files
+- Create/Modify/Delete: none
+
+## Implementation Steps
+1. `git -C /Users/vchun/Codes/My-projects/Typeburn fetch origin`
+2. `git switch main && git pull --ff-only origin main`
+3. `git switch -c feat/v1.2.0-code-mode` (its OWN Bash call — the
+   protect-main hook evaluates HEAD pre-exec; never chain `switch -c &&
+   commit`).
+4. Confirm branch + clean tree. Commit the plan dir as
+   `docs(plan): v1.2.0 code mode plan + brainstorm`.
+
+## Success Criteria
+- [ ] On `feat/v1.2.0-code-mode`, up to date with origin/main.
+- [ ] Plan artifacts committed on the branch.
+
+## Risk Assessment
+- Hook denies chained `switch -c && commit` (HEAD=main at hook time): run
+  branch creation as a standalone step. Known from v1.1.0.

--- a/plans/260519-0142-code-mode-custom-text/phase-02-codetext-loader.md
+++ b/plans/260519-0142-code-mode-custom-text/phase-02-codetext-loader.md
@@ -1,0 +1,63 @@
+---
+phase: 2
+title: "Codetext Loader"
+status: pending
+priority: P1
+effort: "3h"
+dependencies: [1]
+---
+
+# Phase 2: Codetext Loader (TDD)
+
+## Overview
+New pure `internal/codetext` package: read a file or stdin (`-`), normalize,
+enforce a size cap, return `(string, error)`. Keeps `internal/words` /
+`internal/typing` I/O-free (layering rule). One commit.
+
+## Requirements
+- Functional: `Load(path string) (string, error)` — `path=="-"` reads
+  `os.Stdin`; else reads the file. Normalize: CRLF→LF; strip leading UTF-8
+  BOM; trim exactly one trailing `\n`; reject empty/whitespace-only and
+  non-UTF-8/binary (contains NUL or invalid runes) with a descriptive error;
+  cap at **10000 runes AND 500 lines** — over cap → error (no truncation;
+  caller shows a notice). Tabs/newlines are PRESERVED (full-literal).
+- Non-functional: no dependency on `config`/`ui`/`typing`; stdlib only;
+  file <200 LOC; deterministic + table-tested.
+
+## Architecture
+`package codetext`. `Load` injectable for tests: keep a small
+`loadReader(io.Reader) (string,error)` core that `Load` calls (file/stdin
+just pick the reader) so normalization is tested without touching the FS.
+Error values: sentinel `var ErrEmpty, ErrTooLarge, ErrBinary error` (wrapped
+with context) so callers can branch on cause.
+
+## Related Code Files
+- Create: `internal/codetext/codetext.go`, `internal/codetext/codetext_test.go`
+- Modify/Delete: none
+
+## Implementation Steps (tests-first)
+1. **RED:** write `codetext_test.go` table covering: CRLF→LF; BOM stripped;
+   one trailing `\n` trimmed (and only one — `"a\n\n"`→`"a\n"`); interior
+   blank lines & tabs preserved; empty / whitespace-only → `ErrEmpty`;
+   NUL byte / invalid UTF-8 → `ErrBinary`; >10000 runes → `ErrTooLarge`;
+   >500 lines → `ErrTooLarge`; exactly-at-cap passes; stdin path via
+   `loadReader(strings.NewReader(...))`; a real temp file via `Load(tmp)`.
+   Run → compile-fail/red.
+2. **GREEN:** implement `codetext.go` minimally to pass.
+3. Refactor for clarity; keep <200 LOC.
+4. `make fmt && make lint && make test-race`. Commit:
+   `feat(codetext): file/stdin loader with literal-safe normalization`.
+
+## Success Criteria
+- [ ] All table cases green; FS-independent core tested via reader.
+- [ ] words/typing import graph unchanged (no new I/O there) — `go list`
+  shows `codetext` importing only stdlib.
+- [ ] gofmt/vet/`-race` green; file <200 LOC.
+- [ ] One commit.
+
+## Risk Assessment
+- Trailing-newline rule ambiguity: spec is "trim exactly one final `\n`";
+  test `"a\n\n"`→`"a\n"` and `"a"`→`"a"` pin it.
+- Binary detection false-positives: use "contains NUL or
+  `utf8.Valid==false`"; document; test a UTF-8 snippet with unicode stays OK.
+- Cap chosen 10k runes/500 lines — both enforced (whichever first).

--- a/plans/260519-0142-code-mode-custom-text/phase-03-modecode-completion-seam.md
+++ b/plans/260519-0142-code-mode-custom-text/phase-03-modecode-completion-seam.md
@@ -1,0 +1,73 @@
+---
+phase: 3
+title: "ModeCode + Completion Seam"
+status: pending
+priority: P1
+effort: "3h"
+dependencies: [1]
+---
+
+# Phase 3: ModeCode + Completion Seam (TDD)
+
+## Overview
+Add `ModeCode` across the mode seam (config enum, LengthsFor, Normalize,
+storage Record doc) and make the typing engine complete a code test by exact
+full-text match — reusing the Quote rule. One commit.
+
+## Requirements
+- Functional: `config.ModeCode Mode = "code"`. `LengthsFor(ModeCode)` →
+  `nil` (no length options). `Settings.Normalize` accepts `"code"`.
+  `typing` completion: `case ModeCode` behaves identically to `ModeQuote`
+  (`runesEqual(typed,target)`), incl. literal `\n`/`\t` runes; no word-count,
+  no AFKTrim. Metrics path unchanged (chars derive from keystroke log).
+- Non-functional: mode-seam duplication guarded by a sync test (mirror the
+  theme `theme_available_sync_test.go` discipline); files <200 LOC.
+
+## Architecture
+`config.Mode` is a string enum used in switches at: `LengthsFor`
+(`settings.go:17`), `Normalize` (`settings.go:62`), `modeOrder`
+(`screen_home.go:24`, Phase 5), `completion.go` (isComplete switch),
+`storage.Record.Mode` doc. Code reuses Quote's completion arm:
+`case ModeQuote, ModeCode: return runesEqual(e.typed, e.target)`.
+`countCompletedWords`/AFKTrim are never reached for code (not Words/Time).
+
+## Related Code Files
+- Modify: `internal/config/settings.go` (const + LengthsFor + Normalize),
+  `internal/typing/completion.go` (ModeCode arm),
+  `internal/storage/history_record.go` (Mode doc comment: add "code")
+- Create: `internal/config/mode_seam_sync_test.go` (asserts every mode in
+  `modeOrder`-equivalent set is handled by LengthsFor+Normalize; and that
+  Normalize accepts exactly the known modes incl. code, unknown→ModeTime)
+- Modify (tests): `internal/typing/completion_test.go` (ModeCode cases),
+  `internal/config/settings_test.go` (LengthsFor/Normalize code)
+
+## Implementation Steps (tests-first)
+1. **RED:** add completion_test cases — a ModeCode engine with target
+   containing `\n` and `\t`: not complete until `typed==target` exactly;
+   wrong char ≠ complete; trailing extra runes ≠ complete (same semantics as
+   the existing Quote tests — copy/adapt). settings_test: `LengthsFor("code")
+   == nil`; `Normalize` keeps `"code"`, maps unknown→`time`. New
+   `mode_seam_sync_test.go`: list the known modes
+   {time,words,quote,code}; assert each is non-panicking in `LengthsFor`
+   and preserved by `Normalize`; assert a bogus mode → `ModeTime`. Run → red.
+2. **GREEN:** add `ModeCode` const; `LengthsFor` `case ModeCode: return nil`;
+   `Normalize` add `ModeCode` to the valid switch; `completion.go` add
+   `ModeCode` to the Quote arm; update `history_record.go` Mode comment.
+3. Refactor; keep files <200 LOC.
+4. `make fmt && make lint && make test-race`. Commit:
+   `feat(mode): add ModeCode with exact-match completion`.
+
+## Success Criteria
+- [ ] ModeCode completes only on exact full-text match incl `\n`/`\t`;
+  Quote/Words/Time completion tests unchanged & green.
+- [ ] `LengthsFor(ModeCode)==nil`; Normalize accepts "code"; sync test red
+  if a mode is added to the enum but missed in LengthsFor/Normalize.
+- [ ] gofmt/vet/`-race` green; <200 LOC.
+- [ ] One commit.
+
+## Risk Assessment
+- Hidden Words/Time assumptions on code path: code is neither, so
+  countCompletedWords/AFKTrim unreachable — assert via a test that a ModeCode
+  run with no word boundaries still completes on exact match.
+- Sync-test placement: `package config` internal or `config_test` external —
+  must compile without importing `ui`; keep it in `internal/config`.

--- a/plans/260519-0142-code-mode-custom-text/phase-04-code-renderer-viewport.md
+++ b/plans/260519-0142-code-mode-custom-text/phase-04-code-renderer-viewport.md
@@ -1,0 +1,89 @@
+---
+phase: 4
+title: "Code Renderer + Viewport"
+status: pending
+priority: P1
+effort: "5h"
+dependencies: [1]
+---
+
+# Phase 4: Code Renderer + Viewport (TDD)
+
+## Overview
+New isolated `internal/ui/code_stream_renderer.go`: render the rune buffer
+with **literal** line breaks (`\n`) and 2-col tab (`\t`) visuals, per-char
+`theme.Role` state styling, plus a vertical viewport that scrolls to keep the
+caret line visible. `word_stream_renderer.go` and its golden tests are NOT
+touched. One commit.
+
+## Requirements
+- Functional: `RenderCodeStream(target, typed []rune, states
+  []typing.CharState, th theme.Theme, width, height int) string`. Splits on
+  literal `\n` into rows; `\t` rendered as 2 visual columns (the target rune
+  stays a single `\t`; caret/state map 1:1 to runes); reuses the same
+  per-char state→Role styling as the word stream (correct/incorrect/cursor/
+  untyped). Long rows: hard-wrap at `width` (continuation rows) so no
+  horizontal scroll. **Viewport:** show a height-bounded window of rows that
+  always contains the caret row (scroll-follow); caret near top → window from
+  0; near bottom → clamps so last rows show; file shorter than height → no
+  scroll, top-aligned.
+- Non-functional: NO_COLOR-safe (attribute-only path identical layout);
+  pure function (no Bubble Tea state); file <200 LOC (split helpers into
+  `code_viewport.go` if needed, each <200).
+
+## Architecture
+Approach A — isolation. Rune index ↔ (row,col) mapping computed from `\n`
+positions; tab expands visual width only (display), never the rune/state
+index. Viewport = compute caretRow, then `start = clamp(caretRow - margin, 0,
+maxStart)`, render rows `[start, start+height)`. Reuse the existing
+state→`theme.Style(Role)` helper from the word renderer if exported/shared;
+if private, extract a tiny shared `char_style.go` (no behaviour change to
+word stream — covered by its untouched goldens).
+
+## Related Code Files
+- Create: `internal/ui/code_stream_renderer.go`,
+  `internal/ui/code_stream_renderer_test.go` (+ `code_viewport.go` /
+  `_test.go` if split for <200 LOC)
+- Modify: possibly extract a shared `internal/ui/char_style.go` ONLY if the
+  per-char styler is currently private to word_stream (behaviour-neutral;
+  word-stream goldens must stay green to prove it)
+- Delete: none
+
+## Implementation Steps (tests-first)
+1. **RED:** `code_stream_renderer_test.go` cases (string-asserted, ANSI
+   stripped or NO_COLOR theme for determinism):
+   - `"a\nb"` → two rows; tab `"\tx"` → 2 spaces then `x`.
+   - state styling: an incorrect rune carries the error treatment; cursor on
+     the right rune; untyped faint — same expectations as word-stream tests.
+   - viewport: target of N rows with height H<N — caret on row 0 → window
+     `[0,H)`; caret on last row → window ends at N (last rows visible); caret
+     mid → caret row within window; N≤H → all rows, no scroll.
+   - long single line > width → wraps into continuation rows; caret tracking
+     stays correct across the wrap.
+   - NO_COLOR theme → identical row/line structure (only attrs differ).
+   Run → red.
+2. **GREEN:** implement renderer + viewport minimally to pass.
+3. Refactor; split for <200 LOC; ensure word_stream_renderer.go + its
+   goldens are byte-unchanged (`git diff` shows no edits there, or only the
+   behaviour-neutral shared-styler extraction with goldens still green).
+4. `make fmt && make lint && make test-race`. Commit:
+   `feat(ui): literal multi-line code renderer with scroll-follow viewport`.
+
+## Success Criteria
+- [ ] Literal `\n` → real rows; `\t` → 2-col visual; per-char states correct.
+- [ ] Viewport keeps caret visible for top/mid/bottom/short/long; clamps at
+  ends; no horizontal scroll (long lines wrap).
+- [ ] word_stream_renderer.go untouched (or only neutral styler extraction)
+  — its golden tests still green.
+- [ ] NO_COLOR layout identical; gofmt/vet/`-race` green; files <200 LOC.
+- [ ] One commit.
+
+## Risk Assessment
+- Viewport off-by-one at clamps — explicit top/bottom boundary tests.
+- Tab-as-2-cols vs caret index drift — assert caret column after a `\t`
+  equals prior+2 visually while rune index advances by 1.
+- Shared-styler extraction risk — gate on word-stream goldens staying green;
+  if private and risky to extract, duplicate the tiny styler instead (KISS >
+  forced DRY, same call as the v1.1.0 renderer decision).
+- Degraded (terminal <60×20) gate still wins upstream in `model_view.go`
+  (unchanged) — renderer assumes it's only called above the safe minimum.

--- a/plans/260519-0142-code-mode-custom-text/phase-05-wiring-home-history.md
+++ b/plans/260519-0142-code-mode-custom-text/phase-05-wiring-home-history.md
@@ -1,0 +1,99 @@
+---
+phase: 5
+title: "Wiring + Home + History"
+status: pending
+priority: P1
+effort: "4h"
+dependencies: [2, 3, 4]
+---
+
+# Phase 5: Wiring + Home + History (TDD)
+
+## Overview
+Wire the pieces: `main.go --text` flag → `codetext.Load` → injected into
+`app.Model` → `StartTestMsg` → `NewTyping` (Code path uses the loaded text +
+the code renderer, bypassing `words.ForMode`). Home shows Code in the cycle
+(disabled+hint when no text, no length selector). `IsNewBest` excludes
+`Mode=="code"`. One commit.
+
+## Requirements
+- Functional:
+  - `typeburn --text <file>` / `--text -` parsed by `decide()` (extend the
+    existing tested FlagSet; unknown-flag/`-h` behaviour preserved). Load
+    failure (ErrEmpty/ErrTooLarge/ErrBinary) → app starts normally with Code
+    disabled and the error reason as the hint (no crash, no os.Exit beyond
+    existing `--version` semantics).
+  - Home: `modeOrder` includes `ModeCode`; when no code text → row shows
+    disabled style + hint `pass --text <file> · in-app paste coming soon`,
+    Enter is a no-op (stays on Home); when code text present → Enter emits
+    `StartTestMsg` for Code. **No length selector** rendered on the Code row
+    (Code row has no value-cycler).
+  - Typing screen uses the code renderer + viewport for `ModeCode`
+    (`screen_typing.go` selects renderer by mode); Tab/Enter reach the engine
+    mid-test (verify `model_key_handler.go` already delegates all keys while
+    typing — add a regression test, do not change behaviour).
+  - Result/History: a Code run persists a `Record{Mode:"code",
+    Length:runeCount,…}`; `IsNewBest` returns false for `Mode=="code"`;
+    History screen lists it.
+- Non-functional: pure-core untouched (loader is in `codetext`; `words`
+  unchanged); files <200 LOC; goldens for other modes unchanged.
+
+## Architecture
+`StartTestMsg` gains a code payload (e.g. `CodeText string` + the existing
+`Mode`). `app.Model` holds the loaded code text + an availability flag from
+`New`/startup wiring (text passed in from `main.go`). `NewTyping` for
+`ModeCode`: `target = codeText` (skip `words.ForMode`), renderer = code
+renderer. `IsNewBest` (`new_best.go`): early `if r.Mode == "code" { return
+false }`. Home forks rendering on `codeAvailable`.
+
+## Related Code Files
+- Modify: `main.go` (`decide()` `--text`, load, pass into app),
+  `internal/app/model.go` (carry code text/availability),
+  `internal/app/model_view.go`/wiring + `internal/ui/messages.go`
+  (StartTestMsg payload), `internal/ui/screen_home.go` +
+  `screen_home_view.go` + `settings_rows.go`-style row (Code disabled/hint,
+  no length), `internal/ui/screen_typing.go` (renderer select by mode),
+  `internal/storage/new_best.go` (exclude code)
+- Create: tests alongside each (`*_test.go`)
+- Delete: none
+
+## Implementation Steps (tests-first)
+1. **RED:**
+   - `main_test.go`/`decide` test: `--text path` populates the parsed
+     value; `--text -` recognized; absent → zero value; unknown flags / `-h`
+     / `--version` behaviour unchanged (extend existing decide tests).
+   - `new_best_test.go`: a `Record{Mode:"code"}` that would otherwise be a
+     PB → `IsNewBest==false`; non-code unaffected (existing tests stay green).
+   - Home test: no code → Code row disabled, hint text present, Enter →
+     still Home (no StartTestMsg); with code → Enter emits StartTestMsg{Mode:
+     code}; Code row has no length cycler; Tab cycle includes Code.
+   - app/key regression test: during a ModeCode test, a Tab and an Enter
+     keypress are delivered to the engine (not consumed as nav).
+   - app integration: feeding code text + completing exact match →
+     ResultMsg → persisted Record Mode=="code", visible via NavHistory.
+   Run → red.
+2. **GREEN:** implement wiring minimally to pass; reuse Phases 2–4 APIs.
+3. Refactor; keep files <200 LOC (split screen_home if it grows).
+4. `make fmt && make lint && make test-race`. Commit:
+   `feat: wire --text code mode through Home, typing, history`.
+
+## Success Criteria
+- [ ] `--text file`/`-` works end to end; bad input → Code disabled + reason,
+  no crash.
+- [ ] Home: Code in cycle; disabled+hint w/o text; no length selector;
+  Enter no-op w/o text, starts test w/ text.
+- [ ] Tab/Enter reach engine mid-code-test (regression test green).
+- [ ] Code Record persisted, never ★, listed in History.
+- [ ] Other modes’ goldens/tests unchanged; gofmt/vet/`-race` green;
+  files <200 LOC.
+- [ ] One commit.
+
+## Risk Assessment
+- `decide()` FlagSet must keep `ContinueOnError`/discarded-output semantics
+  (no `os.Exit(2)` on unknown) — assert via the preserved decide tests.
+- StartTestMsg payload growth could ripple to ResultModel re-emit
+  (`QuoteLen` precedent) — mirror that pattern; test ctrl+r restart on a
+  code test re-uses the same text.
+- Home view LOC creep → split view/row helpers.
+- Ensure `words.ForMode` is NOT called for code (keeps core pure) — assert
+  no `words` import added to the code path.

--- a/plans/260519-0142-code-mode-custom-text/phase-06-integration-verify.md
+++ b/plans/260519-0142-code-mode-custom-text/phase-06-integration-verify.md
@@ -1,0 +1,64 @@
+---
+phase: 6
+title: "Integration Verify"
+status: pending
+priority: P1
+effort: "1.5h"
+dependencies: [5]
+---
+
+# Phase 6: Integration Verify
+
+## Overview
+Prove the whole module is green, regression-free, and the goldens for
+time/words/quote are unchanged before the release PR. Read + test only
+(fixup commit only if a defect is found).
+
+## Requirements
+- Functional: phases 2–5 commits present; full CI gate green together;
+  manual smoke of a real `--text` file AND `--text -` stdin.
+- Non-functional: no regression in any package; word_stream goldens
+  byte-identical; coverage ≥ baseline.
+
+## Architecture
+Sequential TDD phases each committed; this joins + validates. Mandatory
+subagents (per cook): `tester` (full suite+coverage), `code-reviewer` (diff
+vs main against acceptance criteria + the brainstorm decisions).
+
+## Related Code Files
+- Modify: none (defect fixup only, on the owning phase's files)
+
+## Implementation Steps
+1. Confirm 4 impl commits on `feat/v1.2.0-code-mode`.
+2. `make fmt` (no diff), `make lint`, `make test-race` (the CI gate) — 100%.
+3. Coverage: theme/config/app/ui/typing + new `codetext` ≥ baselines
+   (theme 100%, ui ~87%, typing ~95%, metrics ~93%); `codetext` high.
+4. Manual smoke (`make build`): `./bin/typeburn --text <a real .go file>` →
+   Code selectable → multi-line literal render, 2-col tabs, Tab/Enter match,
+   viewport scrolls, completion on exact match, result shows, History lists
+   it, not ★. `cat file | ./bin/typeburn --text -` works. No `--text` →
+   Code disabled+hint, other modes unaffected. Oversized/empty/binary file
+   → Code disabled with reason, no crash.
+5. Side-effect sweep: `git diff main...HEAD --stat`; confirm
+   `word_stream_renderer.go` + its goldens unchanged (or only the
+   behaviour-neutral shared-styler extraction with goldens green); no
+   `words`/`typing` new I/O import; no unintended exported-signature change.
+6. Spawn `tester` then `code-reviewer` (parallel, read-only) with the
+   brainstorm decisions + acceptance criteria as context. Address any
+   critical/high; observational → note & proceed.
+7. Fixup on the owning phase's files only if needed; re-run step 2.
+
+## Success Criteria
+- [ ] `gofmt -l` empty, `go vet` clean, `go test ./... -race -count=1` 100%.
+- [ ] Coverage ≥ baseline; `codetext` well-covered.
+- [ ] Manual smoke (file + stdin + no-text + bad-input) all pass.
+- [ ] Goldens for time/words/quote unchanged; no pure-core I/O leak.
+- [ ] code-reviewer: 0 critical (or all addressed).
+
+## Risk Assessment
+- Golden drift from a shared-styler extraction — step 5 catches; revert to
+  duplicated styler if goldens move.
+- Coverage regression from new untested branches (viewport edges, loader
+  errors) — step 3 enforces; add tests on the owning phase.
+- Manual-smoke-only items (real terminal viewport scroll) can't be unit-
+  proven fully — call out residual visual risk explicitly in the report.

--- a/plans/260519-0142-code-mode-custom-text/phase-07-release-v1-2-0.md
+++ b/plans/260519-0142-code-mode-custom-text/phase-07-release-v1-2-0.md
@@ -1,0 +1,71 @@
+---
+phase: 7
+title: "Release v1.2.0"
+status: pending
+priority: P1
+effort: "1h"
+dependencies: [6]
+---
+
+# Phase 7: Release v1.2.0
+
+## Overview
+Ship v1.2.0 (minor — new feature) via the proven PR-based, fix-forward
+runbook. Protected-main: PR → squash-merge → disposable dry-run → annotated
+tag on the merged SHA.
+
+## Requirements
+- Functional: GitHub Release `v1.2.0` with 7 assets (6 archives +
+  `checksums.txt`) and curated notes (non-empty body).
+- Non-functional: never delete-and-re-tag a pushed version; tag pushed in a
+  SEPARATE push (never `--follow-tags`).
+
+## Architecture
+Notes via `CHANGELOG.md [Unreleased]`→`[1.2.0]` extracted to
+`.github/release-notes.md` (`--release-notes`). `.goreleaser.yaml` keeps the
+`changelog.filters.exclude:['.*']` filter (NOT `disable:true`). `ci.yml`
+does not run on tags → `release.yml` self-gates. GoReleaser pinned
+`v2.15.4` (lockstep — unchanged).
+
+## Related Code Files
+- Modify: `CHANGELOG.md` (author `[Unreleased]` then promote → `[1.2.0] -
+  <date>` + link refs), `.github/release-notes.md` (mirror the `[1.2.0]`
+  section), `docs/project-roadmap.md` (Code mode → shipped v1.2.0; update
+  Conclusion to v1.2.0), `README.md` (document `--text` usage + Code mode),
+  `docs/design-guidelines.md` / `docs/system-architecture.md` (Code renderer
+  + codetext package + ModeCode), `CLAUDE.md` (note ModeCode/codetext in the
+  architecture section)
+- Create/Delete: none (version is ldflags/tag injected — no constant)
+
+## Implementation Steps
+1. Author `CHANGELOG.md [Unreleased]` (Added: Code mode + `--text`; note
+   history-but-not-★; out-of-scope deferred items) — on the feature branch
+   during Phase 5/6 ideally; here promote `[Unreleased]`→`[1.2.0] - <date>`,
+   add link refs, regenerate `.github/release-notes.md`. Update README +
+   docs. Commit: `docs: changelog + release notes + docs for v1.2.0`.
+2. Push branch; `gh pr create` → `main` (no AI refs). Wait `ci.yml` green.
+3. **Squash-merge**; record merged `main` SHA.
+4. Disposable dry-run: `git tag v0.0.0-rc.test <SHA>` → push → watch
+   `release.yml` → verify **7 assets** + non-empty notes + checksums →
+   `gh release delete v0.0.0-rc.test --yes --cleanup-tag`.
+5. Real tag: `git tag -a v1.2.0 <same SHA> -m "Typeburn v1.2.0"` →
+   `git push origin v1.2.0` (separate push, NEVER `--follow-tags`).
+6. Verify published `v1.2.0` (7 assets, notes, not draft/pre). Land any
+   leftover plan-status/reports + journal via a `chore/...` PR (separate
+   `git switch -c` step — hook evaluates HEAD pre-exec).
+7. `/ck:journal`.
+
+## Success Criteria
+- [ ] PR squash-merged, `ci.yml` green.
+- [ ] Dry-run proved 7 assets + non-empty notes, then deleted.
+- [ ] `v1.2.0` on the dry-run-proven SHA; pushed separately.
+- [ ] Release live (7 assets, curated notes, not draft/pre).
+- [ ] Roadmap/README/docs reflect v1.2.0 + Code mode.
+
+## Risk Assessment
+- Empty release body — keep exclude-all changelog filter; dry-run asserts
+  non-empty before the real tag.
+- Re-tag temptation on defect — forbidden; fix forward to v1.2.1.
+- `--follow-tags` accident — push branch and tag in distinct commands.
+- `ck plan check` dirties tracked plan files mid-release — stash before
+  switching to main; finalize via the chore PR (known from v1.1.0).

--- a/plans/260519-0142-code-mode-custom-text/plan.md
+++ b/plans/260519-0142-code-mode-custom-text/plan.md
@@ -1,0 +1,76 @@
+---
+title: "Code Mode / Custom Text Input (v1.2.0)"
+description: "ModeCode: type CLI-supplied text/code with full-literal whitespace; new codetext loader + isolated code renderer; TDD per phase, protected-main PR flow"
+status: pending
+priority: P2
+branch: "feat/v1.2.0-code-mode"
+tags: [feature, mode, tdd, release]
+blockedBy: []
+blocks: []
+created: "2026-05-18T18:44:04.961Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Code Mode / Custom Text Input (v1.2.0)
+
+## Overview
+
+New `code` test mode: practice typing on CLI-supplied text/code
+(`typeburn --text <file>` | `--text -`) with **full-literal whitespace**
+(Enter→`\n`, Tab→`\t`, tab=2-col visual, every space/indent typed). Engine
+reuses Quote's exact-match completion; a new isolated multi-line renderer +
+viewport handles layout; a new pure `internal/codetext` package does the
+I/O+normalization. Saved to history, excluded from ★. Semver minor →
+**v1.2.0**.
+
+Source of truth: [brainstorm-summary.md](./brainstorm-summary.md) (all
+input/whitespace/persistence/Home/renderer/loader decisions locked).
+
+## Execution model
+
+`--tdd`: every implementation phase is **tests-first** — write failing tests
+that pin the new behaviour (and lock adjacent existing behaviour) → see red →
+implement → green. Protected-main: feature branch
+`feat/v1.2.0-code-mode` → per-phase commits → PR → squash-merge → tag on
+merged SHA. Sequential (the renderer/engine/Home chain has real deps); no
+parallel groups.
+
+| Phase | Name | Status | Depends | TDD focus |
+|-------|------|--------|---------|-----------|
+| 1 | [Branch Setup](./phase-01-branch-setup.md) | Pending | — | gate, no commit |
+| 2 | [Codetext Loader](./phase-02-codetext-loader.md) | Pending | 1 | normalize/size/stdin tests → impl |
+| 3 | [ModeCode + Completion Seam](./phase-03-modecode-completion-seam.md) | Pending | 1 | completion+LengthsFor+Normalize+sync tests → impl |
+| 4 | [Code Renderer + Viewport](./phase-04-code-renderer-viewport.md) | Pending | 1 | literal `\n`/`\t` + scroll-follow tests → impl |
+| 5 | [Wiring + Home + History](./phase-05-wiring-home-history.md) | Pending | 2,3,4 | decide()/Home-disabled/IsNewBest-excludes-code tests → impl |
+| 6 | [Integration Verify](./phase-06-integration-verify.md) | Pending | 5 | full -race, goldens unchanged, review |
+| 7 | [Release v1.2.0](./phase-07-release-v1-2-0.md) | Pending | 6 | CHANGELOG/PR/dry-run/tag |
+
+**Dependency:** 1 → 2,3,4 (sequential, each tests-first) → 5 → 6 → 7.
+
+## Key locked decisions
+
+- `--text <file>`|`-`(stdin) now; in-TUI paste deferred but **not
+  precluded** (text-source is an injected string; Home forks on availability).
+- Full literal whitespace; tab visual = **2 cols**; user types all
+  indentation; trim one trailing `\n`; CRLF→LF; strip BOM; size cap
+  ~10k runes / ~500 lines → graceful notice (no panic).
+- Code runs **saved to history, never ★** (`IsNewBest` excludes
+  `Mode=="code"`).
+- Code **always** in Home cycle; no `--text` → shown disabled + hint, Enter
+  no-op; **no length selector** for Code.
+- Renderer **Approach A**: new `internal/ui/code_stream_renderer.go` +
+  viewport; `word_stream_renderer.go` + its golden tests untouched.
+- Loader in new pure `internal/codetext` (keeps `words`/`typing` I/O-free).
+- Mode-seam duplication (LengthsFor/Normalize/modeOrder/Record) guarded by a
+  sync test, same discipline as the theme work.
+
+## Out of scope
+
+In-TUI paste/edit, syntax highlighting, snippet library, language
+detection/per-lang stats, elastic tab stops, AFKTrim for code.
+
+## Dependencies
+
+No cross-plan deps — prior plans completed; v1.1.0 shipped (its plan.md
+top-level status frontmatter is stale-cosmetic only).


### PR DESCRIPTION
## Summary

**v1.2.0** — new `code` test mode: type your own text/code via `typeburn --text <file>` or `--text -` (stdin).

- **`internal/codetext`** (new, pure stdlib): file/stdin load + normalization (BOM, CRLF→LF, trim one trailing `\n`, reject empty/binary/over-cap 10k runes·500 lines). Keeps `words`/`typing` I/O-free.
- **ModeCode**: exact full-text completion (reuses the Quote arm; literal `\n`/`\t` are ordinary target runes); `LengthsFor(code)=nil`; mode-seam sync test guards drift.
- **Isolated code renderer + viewport**: literal line breaks, tabs=2 cols, long-line wrap (no h-scroll), caret-following scroll. `word_stream_renderer.go` byte-untouched.
- **Wiring**: `decide()` → `(bool,string)` with `--text` (all prior fall-through preserved); Home shows Code tab (disabled+hint w/o text, Enter no-op; no length cycler); Code runs saved to History, **excluded from ★**; bad input → disabled + reason, no crash.
- **Fix (found in review)**: Result-screen restart-same now keeps the Code snippet (was building an empty instant-complete test) + regression test.

## Verification

- tester subagent: gofmt/vet/`go test ./... -race` all green; coverage codetext 90.9%, typing 96.2%, ui 86.3%; goldens byte-identical; zero regressions to time/words/quote.
- code-review: 8/10, 0 critical; the 1 HIGH defect fixed + regression-tested; Lows accepted.
- TDD throughout (tests-first per phase); every prod file <200 LOC.
- 3 exported-sig changes (`New`/`NewFromDisk`/`NewHome`) intentional, internal-only, all call sites updated.

## Out of scope (deferred)

In-app paste/edit (architecture leaves room), syntax highlighting, snippet library, language detection, AFKTrim for code.