### PR TITLE
chore: finalize v1.3.0 plan status, reports, journal

### DIFF
--- a/docs/journals/2026-05-19-v1.3.0-in-app-paste.md
+++ b/docs/journals/2026-05-19-v1.3.0-in-app-paste.md
@@ -1,0 +1,101 @@
+# v1.3.0 — In-App Paste for Code Mode
+
+**Date**: 2026-05-19 15:55
+**Severity**: Medium (new screen + exported API; non-breaking, all tests pass)
+**Component**: codetext, UI (ScreenCodePaste), App routing, Home, Release
+**Status**: Resolved
+
+## What Happened
+
+Typeburn v1.3.0 shipped in-app paste for Code mode: a 6th screen
+`ScreenCodePaste` reachable from the Home Code row when no snippet is loaded.
+`internal/codetext` was refactored to expose a pure `Normalize(string)
+(string, error)` sharing the exact post-read core with `Load(path)` (extracted
+unexported `normalize([]byte)`); `Load` behaviour is byte-identical and its
+prior tests pass unchanged (regression lock + a parity test). The paste
+sub-model (Approach A) captures one `tea.PasteMsg`, normalizes
+`msg.Content`, emits `CodePastedMsg{Text}` on success, and on failure stays
+showing the mapped reason (errors.Is against the codetext sentinels) for
+retry. It owns only normalization + error state — no I/O, no app-state
+mutation, no esc handling (the existing global Back handler routes esc→Home).
+The root applies a valid paste via a new `HomeModel.WithCodeText` on the
+*existing* Home (not a `NewHome` rebuild — that would reset modeIdx to
+DefaultMode and lose the Code selection), so Enter immediately starts the
+Code test. `--text` still works and takes precedence. Released
+protected-main: PR #8 → squash 813c21c → disposable v0.0.0-rc.test (7 assets
++ 1004-char notes verified, deleted) → annotated v1.3.0 on the same SHA →
+release.yml success → https://github.com/bavanchun/Typeburn/releases/tag/v1.3.0.
+tester: gofmt/vet/-race green, 292/292, codetext 91.7% / ui 86.7% coverage,
+zero regressions. code-reviewer: DONE_WITH_CONCERNS, 0 critical/high.
+
+## The Brutal Truth
+
+The implementation went clean — TDD per phase made the red→green rhythm
+mechanical and the seam from v1.2.0 (inject snippet as a string, Home forks
+on availability) absorbed the new screen with zero engine/renderer change.
+The honest friction was self-inflicted twice. First: two prod files landed at
+exactly 201 LOC — one line over the plan's own `<200` bar. Easy to wave away
+("it's one line"), but the rule exists so files stay scannable; the fix
+(extract `model_code_paste.go` mirroring the existing `model_*.go` split,
+tighten two doc comments) was 10 minutes and left the router cleaner than
+before. Second, and sharper: the code-reviewer flagged six `F3`/`phase09`
+plan-artifact references in test comments — a direct violation of my own
+standing rule that code/test names must encode the *invariant*, not the
+plan's taxonomy. It was tempting to dismiss as cosmetic; it is not. Plan
+headers get renumbered and those refs rot into noise. The reviewer was
+right, the fix was rephrasing to the underlying invariant, and
+DONE_WITH_CONCERNS was the correct status to block on until done. The
+lesson restated: a mandatory read-only review gate earns its cost not by
+catching crashes but by catching the small disciplined things you'd
+rationalize past at 90% done.
+
+## Technical Details
+
+**codetext refactor:**
+- `normalize([]byte) (string, error)` is the single post-read pipeline:
+  strip UTF-8 BOM (byte-level `{0xEF,0xBB,0xBF}`), reject binary
+  (invalid UTF-8 / NUL), CRLF→LF, trim exactly one trailing `\n`, then
+  ErrEmpty / ErrTooLarge (>10000 runes or >500 lines).
+- `loadReader` reads then calls `normalize`; `Normalize(s)` calls
+  `normalize([]byte(s))`. `Load` signature/behaviour unchanged.
+- Parity test asserts `Normalize(s)` ≡ `loadReader(strings.NewReader(s))`
+  (incl. a byte-level BOM-prefixed input) across 14 representative cases.
+
+**ScreenCodePaste (internal/ui):**
+- `CodePasteModel{th, w, h, errMsg}`; `errMsg==""` ⇒ waiting, else errored.
+- `Update` handles ONLY `tea.PasteMsg`; all else is a no-op (esc handled
+  globally — no cancel message exists).
+- `pasteErrReason` maps sentinels via `errors.Is` (handles wrapped
+  ErrTooLarge with the cap suffix).
+- View: title + instruction + one status line; `RoleWarning` for the error
+  line (whole-line render; `RoleError` styles per-char and is the wrong
+  semantic). NO_COLOR line-structure parity test.
+
+**App routing:**
+- `Screen` iota gains `ScreenCodePaste`; root holds a `codePaste` field
+  sized on WindowSizeMsg and rebuilt fresh on `NavCodePasteMsg`.
+- `tea.PasteMsg`: Typing branch byte-intact; new `if screen==ScreenCodePaste`
+  appended after it; else ignored (Home returns nil cmd).
+- `CodePastedMsg` → `applyCodePaste`: set codeText, clear codeHint,
+  `home.WithCodeText`, screen→Home (Code still selected, proven
+  behaviourally: post-paste Enter emits `StartTestMsg{ModeCode}`).
+- esc verified to route via the existing global Back `else` (no new code).
+
+**F4 (bracketed paste enablement):** Bubble Tea v2.0.6 enables bracketed
+paste by default — `tea.View.DisableBracketedPasteMode` defaults false and
+the cursed renderer emits `ansi.SetModeBracketedPaste`. `main.go` sets no
+disabling option; Typing paste already relies on the same mechanism. No
+`main.go` change; the deterministic routed-`PasteMsg` tests prove delivery.
+
+## Outcome
+
+v1.3.0 live, 7 assets, 1004-char curated notes, not draft/pre. All prior
+behaviour (Load, Typing PasteMsg, goldens, `--text`, NO_COLOR) preserved.
+Runbook unchanged and verified end-to-end again (PR → squash → dry-run →
+tag). Prod files all <200 LOC after the mid-flight modularization.
+
+## Unresolved Questions
+
+None. Chunked-paste ("last PasteMsg wins") remains a documented
+terminal-dependent behaviour, not a defect; the routed-PasteMsg unit test
+is the deterministic proof and a real-terminal smoke is environment-bound.

--- a/plans/260519-1325-in-app-paste-code-mode/phase-01-branch-setup.md
+++ b/plans/260519-1325-in-app-paste-code-mode/phase-01-branch-setup.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Branch Setup"
-status: pending
+status: completed
 priority: P1
 effort: "5m"
 dependencies: []

--- a/plans/260519-1325-in-app-paste-code-mode/phase-02-codetext-normalize-refactor.md
+++ b/plans/260519-1325-in-app-paste-code-mode/phase-02-codetext-normalize-refactor.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "codetext Normalize Refactor"
-status: pending
+status: completed
 priority: P1
 effort: "1.5h"
 dependencies: [1]

--- a/plans/260519-1325-in-app-paste-code-mode/phase-03-screencodepaste-sub-model.md
+++ b/plans/260519-1325-in-app-paste-code-mode/phase-03-screencodepaste-sub-model.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "ScreenCodePaste Sub-model"
-status: pending
+status: completed
 priority: P1
 effort: "3h"
 dependencies: [2]

--- a/plans/260519-1325-in-app-paste-code-mode/phase-04-wiring-routing-home.md
+++ b/plans/260519-1325-in-app-paste-code-mode/phase-04-wiring-routing-home.md
@@ -1,7 +1,7 @@
 ---
 phase: 4
 title: "Wiring + Routing + Home"
-status: pending
+status: completed
 priority: P1
 effort: "3h"
 dependencies: [3]

--- a/plans/260519-1325-in-app-paste-code-mode/phase-05-integration-verify.md
+++ b/plans/260519-1325-in-app-paste-code-mode/phase-05-integration-verify.md
@@ -1,7 +1,7 @@
 ---
 phase: 5
 title: "Integration Verify"
-status: pending
+status: completed
 priority: P1
 effort: "1h"
 dependencies: [4]

--- a/plans/260519-1325-in-app-paste-code-mode/phase-06-release-v1-3-0.md
+++ b/plans/260519-1325-in-app-paste-code-mode/phase-06-release-v1-3-0.md
@@ -1,7 +1,7 @@
 ---
 phase: 6
 title: "Release v1.3.0"
-status: pending
+status: completed
 priority: P1
 effort: "1h"
 dependencies: [5]

--- a/plans/260519-1325-in-app-paste-code-mode/plan.md
+++ b/plans/260519-1325-in-app-paste-code-mode/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "In-app Paste for Code Mode (v1.3.0)"
 description: "New ScreenCodePaste: supply the Code-mode snippet via in-TUI bracketed paste; codetext.Normalize refactor; TDD per phase, protected-main PR flow"
-status: pending
+status: completed
 priority: P2
 branch: "feat/v1.3.0-in-app-paste"
 tags: [feature, ui, tdd, release]
@@ -35,12 +35,12 @@ merged SHA. Sequential.
 
 | Phase | Name | Status | Depends | TDD focus |
 |-------|------|--------|---------|-----------|
-| 1 | [Branch Setup](./phase-01-branch-setup.md) | Pending | — | gate, no commit |
-| 2 | [codetext Normalize Refactor](./phase-02-codetext-normalize-refactor.md) | Pending | 1 | Normalize/Load parity → refactor |
-| 3 | [ScreenCodePaste Sub-model](./phase-03-screencodepaste-sub-model.md) | Pending | 2 | paste→Normalize, waiting/error/esc states → impl |
-| 4 | [Wiring + Routing + Home](./phase-04-wiring-routing-home.md) | Pending | 3 | Screen enum/routing/PasteMsg-route/CodePastedMsg/Home-row tests → impl |
-| 5 | [Integration Verify](./phase-05-integration-verify.md) | Pending | 4 | full -race, goldens unchanged, tester+review |
-| 6 | [Release v1.3.0](./phase-06-release-v1-3-0.md) | Pending | 5 | CHANGELOG/PR/dry-run/tag |
+| 1 | [Branch Setup](./phase-01-branch-setup.md) | Completed | — | gate, no commit |
+| 2 | [codetext Normalize Refactor](./phase-02-codetext-normalize-refactor.md) | Completed | 1 | Normalize/Load parity → refactor |
+| 3 | [ScreenCodePaste Sub-model](./phase-03-screencodepaste-sub-model.md) | Completed | 2 | paste→Normalize, waiting/error/esc states → impl |
+| 4 | [Wiring + Routing + Home](./phase-04-wiring-routing-home.md) | Completed | 3 | Screen enum/routing/PasteMsg-route/CodePastedMsg/Home-row tests → impl |
+| 5 | [Integration Verify](./phase-05-integration-verify.md) | Completed | 4 | full -race, goldens unchanged, tester+review |
+| 6 | [Release v1.3.0](./phase-06-release-v1-3-0.md) | Completed | 5 | CHANGELOG/PR/dry-run/tag |
 
 **Dependency:** 1 → 2 → 3 → 4 → 5 → 6.
 

--- a/plans/260519-1325-in-app-paste-code-mode/reports/code-reviewer-260519-v1.3.0.md
+++ b/plans/260519-1325-in-app-paste-code-mode/reports/code-reviewer-260519-v1.3.0.md
@@ -1,0 +1,31 @@
+# Code-Reviewer Report — v1.3.0 in-app paste
+
+Date: 2026-05-19 · Status: DONE_WITH_CONCERNS (resolved)
+
+## Verdict
+Strong, disciplined implementation. All locked decisions (a)–(f) honored,
+including Approach-A purity, no-esc-handling, WithCodeText-vs-NewHome, and
+Typing PasteMsg byte-intact. Build/vet/gofmt/-race all green; 11/11 packages.
+
+## Findings
+- **Critical/High/Low:** none.
+- **Medium M1 (resolved):** 6 plan-artifact refs (`F3`, `phase09`) in test
+  comments/names — violates the rule that code/test names encode the
+  invariant, not plan taxonomy. Rephrased to the invariant in commit
+  `93f8c1a`; verified zero remaining refs; gate re-run green.
+
+## Edge cases verified
+- F4 bracketed paste reaches new screen (Bubble Tea v2 default; main.go
+  unchanged; routed-PasteMsg test confirms).
+- Chunked paste = "last wins" (independent attempts; recovery test covers).
+- Over-cap/binary/empty → no partial state, reason shown, retry works.
+- esc via existing global Back handler (no dead cancel message).
+- `--text` precedence intact; codetext parity exact; PasteMsg `.Content`
+  read correctly.
+
+## Positives
+Pure value-receiver sub-model; errors.Is sentinel mapping; F3 covered
+white-box + behaviourally; no golden changes; exported surface == locked set.
+
+## Unresolved questions
+None.

--- a/plans/260519-1325-in-app-paste-code-mode/reports/tester-260519-v1.3.0.md
+++ b/plans/260519-1325-in-app-paste-code-mode/reports/tester-260519-v1.3.0.md
@@ -1,0 +1,22 @@
+# Tester Report — v1.3.0 in-app paste
+
+Date: 2026-05-19 · Status: DONE
+
+## CI gate
+- `gofmt -l .` clean · `go vet ./...` clean
+- `go test ./... -race -count=1`: 292/292 pass, 11/11 packages
+- `make build`: success
+
+## Coverage vs baseline
+- internal/codetext 91.7% (≥90% ✓)
+- internal/ui 86.7% (≥86% ✓)
+- internal/typing 96.2% · internal/app 74.3% (no formal baseline; new branches covered)
+
+## Acceptance criteria — all verified
+- Normalize/Load parity (14 cases incl. byte-level BOM); prior TestLoadReader_* unchanged & green.
+- Sub-model: valid→CodePastedMsg{normalized}; empty/over-cap/binary→error+reason; retry recovers; non-paste no-op.
+- Routing: NavCodePasteMsg→ScreenCodePaste; CodePastedMsg→Home, Code preserved (Enter→Code test); esc→Home codeText unchanged; PasteMsg screen-scoped (Typing branch intact, phase09 untouched & green).
+- Home: empty Code + Enter/Space → NavCodePasteMsg; `--text` path unchanged.
+
+## Notes
+Real-terminal interactive bracketed-paste smoke out of scope (non-interactive env); routed-PasteMsg unit tests are the deterministic proof. Zero regressions; release-ready.


### PR DESCRIPTION
Post-release housekeeping for v1.3.0 (docs-only; no code). Marks all 6 phases completed, adds the tester + code-reviewer reports and the v1.3.0 journal. Release already live: https://github.com/bavanchun/Typeburn/releases/tag/v1.3.0