### PR TITLE
feat: broadly-installable on-ramp (Go 1.25, install.sh, Homebrew cask)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.25.x"
           cache: true
 
       - name: Build
@@ -36,3 +36,27 @@ jobs:
 
       - name: Test (race detector)
         run: go test ./... -race -count=1
+
+  installer:
+    name: install.sh & release config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # ubuntu-latest ships shellcheck; pin nothing extra. Zero warnings is
+      # a hard gate — the installer is piped to users' shells.
+      - name: ShellCheck install.sh
+        run: shellcheck install.sh scripts/test-install-sh.sh
+
+      # Offline harness: localhost stand-in for the GitHub API + downloads.
+      - name: install.sh regression harness
+        run: ./scripts/test-install-sh.sh
+
+      # Catches .goreleaser.yaml schema drift before a tag ever triggers a
+      # real publish (no network/build — config validation only).
+      - name: GoReleaser config check
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "v2.15.4"
+          args: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.25.x"
           cache: true
       - name: Build
         run: go build ./...
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.25.x"
           cache: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
@@ -72,6 +72,12 @@ jobs:
           args: release --clean --release-notes=.github/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Scoped at the STEP level only (never job-level): a fine-grained
+          # PAT with contents r/w on bavanchun/homebrew-tap-typeburn ONLY.
+          # GoReleaser reads it as {{ .Env.HOMEBREW_TAP_TOKEN }} to commit the
+          # cask cross-repo; the default GITHUB_TOKEN cannot. Job `permissions:`
+          # (contents: write, source repo) is intentionally left unchanged.
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       - name: Assert asset count
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,15 +5,26 @@
 # publish/auth/release-notes path is exercised by the Phase 5 disposable-tag dry-run.
 version: 2
 
-before:
-  hooks:
-    # Build only. No `go mod tidy` (mutates go.sum, needs network) and no
-    # `go test` (arbitrary code in the privileged publish job) — tests run in
-    # release.yml's separate, least-privilege `test` job before this ever runs.
-    - go build ./...
+# Deterministic, lowercase identity. Pinning project_name + builds.binary +
+# archives.name_template removes GoReleaser's derived-name ambiguity: the
+# archive filenames and the binary inside them are fixed strings that
+# install.sh and the Homebrew cask reference verbatim. Without these, the
+# v2 defaults derive the name from the module path (capital `Typeburn`) and
+# embed a version segment install.sh cannot predict.
+project_name: typeburn
+
+# No `before.hooks`. A `go build ./...` hook would execute arbitrary project
+# code (incl. test/tooling packages) inside the privileged, token-bearing
+# publish job. release.yml's separate least-privilege `test` job already
+# builds the tree before this job runs; GoReleaser's own `builds:` step
+# compiles only the release main package per target — nothing wider runs
+# beside the tap token.
 
 builds:
-  - env:
+  # Pinned lowercase binary name. install.sh and the Homebrew cask extract a
+  # member named exactly `typeburn`; do not let it derive from the module path.
+  - binary: typeburn
+    env:
       - CGO_ENABLED=0
       # Fail loudly on any module drift instead of silently rewriting go.sum.
       - GOFLAGS=-mod=readonly
@@ -37,7 +48,12 @@ builds:
 
 archives:
   # Plural `formats:` — singular `format:` is removed in this v2 line.
-  - formats: ["tar.gz"]
+  # Explicit name_template: fixed, predictable archive filenames that
+  # install.sh maps os/arch to verbatim. The default v2 template embeds a
+  # version segment and the derived project name — both unpredictable to a
+  # static installer resolving the latest tag.
+  - name_template: "typeburn_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: ["tar.gz"]
     format_overrides:
       - goos: windows
         formats: ["zip"]
@@ -69,3 +85,31 @@ release:
     owner: bavanchun
     name: Typeburn
   draft: false
+  # `auto` flags any tag GoReleaser reads as a prerelease (e.g. the disposable
+  # dry-run tag `v0.0.0-rc.test`) as a GitHub prerelease. GitHub excludes
+  # prereleases from `/releases/latest`, so the dry-run never becomes the
+  # version install.sh resolves. Load-bearing safe-dry-run guarantee.
+  prerelease: auto
+
+homebrew_casks:
+  # Commits a Cask (not a formula — no user Go/Xcode toolchain) wrapping the
+  # prebuilt release archive to a SEPARATE tap repo. The cask `.rb` is pushed
+  # into that repo's Casks/ directory; it is NOT a GitHub release asset, so
+  # the release-asset count stays 7 (6 archives + checksums.txt).
+  - name: typeburn
+    binaries:
+      - typeburn
+    repository:
+      owner: bavanchun
+      name: homebrew-tap-typeburn
+      # MUST be explicit. The default GITHUB_TOKEN is scoped to the source
+      # repo and cannot push cross-repo to the tap — a fine-grained PAT
+      # scoped to the tap repo only is injected as HOMEBREW_TAP_TOKEN.
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Casks
+    homepage: "https://github.com/bavanchun/Typeburn"
+    description: "A Monkeytype-style terminal typing test, distraction-free and keyboard-driven."
+    # `auto`: on a prerelease tag the cask is NOT committed to the tap (it is
+    # left in dist/ only). With release.prerelease:auto above, the disposable
+    # dry-run tag publishes nothing durable to users.
+    skip_upload: "auto"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in improving Typeburn.
 
 ## Prerequisites
 
-- **Go 1.26+** (the module targets `go 1.26.2`).
+- **Go 1.25+** (the module targets `go 1.25.0`).
 - **GoReleaser `v2.15.4`** — the **exact pinned version**. Install with:
 
   ```sh
@@ -88,17 +88,51 @@ conventional `feat:`/`fix:` commits, so it would be empty). The `[1.0.0]`-style
 section is extracted to `.github/release-notes.md` and passed to GoReleaser via
 `--release-notes`.
 
-## Homebrew (planned — not yet enabled)
+## Homebrew (enabled — cask via the tap)
 
-Homebrew distribution is intentionally deferred. To enable it later:
+Users install with:
 
-1. Provision a public tap repository, e.g. `bavanchun/homebrew-tap`.
-2. Mint a **fine-grained** Personal Access Token scoped to **only** that tap
-   repo with `Contents: write`, with an expiry. **Never** use a classic or
-   org-wide PAT. Store it as a repository secret (e.g. `HOMEBREW_TAP_TOKEN`).
-3. Add a `homebrew_casks:` block to `.goreleaser.yaml` referencing the tap and
-   that secret, and wire the secret into the `goreleaser` job in `release.yml`.
+```sh
+brew install bavanchun/tap-typeburn/typeburn
+```
 
-(There is deliberately no commented-out `brews:`/`homebrew_casks:` block in
-`.goreleaser.yaml` — dead schema rots across GoReleaser versions; this prose is
-the spec instead.)
+This is a **cask** (not a formula): it wraps the prebuilt release archive, so
+no user Go/Xcode toolchain is needed. GoReleaser's `homebrew_casks:` block
+(`.goreleaser.yaml`) commits the cask `.rb` into the tap repo
+`bavanchun/homebrew-tap-typeburn` under `Casks/`. The cask is **not** a GitHub
+release asset — the release-asset count stays 7 (6 archives + `checksums.txt`).
+
+Wiring:
+
+1. Tap repo `bavanchun/homebrew-tap-typeburn` (provisioned).
+2. A **fine-grained** PAT scoped to **only** that tap repo with
+   `Contents: read and write`, shortest viable expiry. **Never** a classic or
+   org-wide PAT. Stored as the repo secret `HOMEBREW_TAP_TOKEN`
+   (`gh secret set HOMEBREW_TAP_TOKEN -R bavanchun/Typeburn`).
+3. `.goreleaser.yaml` `homebrew_casks:` references
+   `token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"` (the default `GITHUB_TOKEN` cannot
+   push cross-repo). `release.yml` injects `HOMEBREW_TAP_TOKEN` at the
+   GoReleaser **step `env:` only** — never job-level; job `permissions:`
+   stay scoped to the source repo.
+4. `release.prerelease: auto` + cask `skip_upload: "auto"`: a prerelease/`-rc`
+   tag (e.g. the disposable dry-run `v0.0.0-rc.test`) is flagged prerelease
+   and commits **nothing** to the tap.
+
+### Tap rollback runbook (a bad cask breaks `brew upgrade` for everyone)
+
+A broken `Casks/typeburn.rb` in the tap repo affects every user's next
+`brew install`/`brew upgrade`. The CI PAT is intentionally too narrow to
+self-heal interactively, so rollback is a **manual human action**:
+
+1. With a HUMAN GitHub credential (NOT the CI PAT), in
+   `bavanchun/homebrew-tap-typeburn`:
+   `git revert <bad commit touching Casks/typeburn.rb>` and push.
+   This restores the last-good cask immediately for all users.
+2. Fix the root cause in this repo, then ship a **fix-forward** patch release
+   (a new tag) — never delete-and-re-tag a shipped version (it has reached
+   the module proxy / Homebrew users).
+3. The next stable release's GoReleaser run overwrites the cask cleanly.
+
+(There is deliberately no commented-out alternate schema in
+`.goreleaser.yaml` — dead schema rots across GoReleaser versions; the live
+block plus this prose is the spec.)

--- a/README.md
+++ b/README.md
@@ -22,9 +22,33 @@ Distraction-free, keyboard-driven, and works on any ANSI terminal.
 
 ## Installation
 
-Requires **Go 1.26+**.
+**1. Quick install (Linux/macOS, no Go toolchain):**
 
-**1. `go install` (latest tagged release):**
+```sh
+curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
+```
+
+Detects your OS/arch, downloads the matching release archive, **verifies its
+sha256 against `checksums.txt`**, and installs `typeburn` into `~/.local/bin`
+(no sudo). Override the target with `BIN_DIR=…` or pin a tag with `VERSION=vX.Y.Z`.
+
+> **Trust boundary — read before piping any script to a shell.** The sha256
+> check defends against a corrupted or man-in-the-middled *download*. It does
+> **not** make `curl … | sh` inherently safe: the script, the archive, and
+> `checksums.txt` all come from the same GitHub release (and `checksums.txt`
+> is unsigned), so a compromised release would be self-consistent. If that
+> boundary matters to you, use the non-piped audit path instead:
+>
+> ```sh
+> curl -fsSL -o install.sh https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh
+> less install.sh        # read it
+> sh install.sh          # then run it
+> ```
+>
+> Windows is not covered by `install.sh` (POSIX `sh` only) — use the manual
+> archive below.
+
+**2. `go install` (latest tagged release):**
 
 ```sh
 go install github.com/bavanchun/Typeburn@latest
@@ -38,14 +62,17 @@ go install github.com/bavanchun/Typeburn@latest
 > until the proxy ingests the tag, `go install ...@vX.Y.Z` can 404. Downloading
 > the release binary (below) is immediate and unaffected.
 
-**2. Download a pre-built binary:**
+Requires **Go 1.25+**.
+
+**3. Download a pre-built binary:**
 
 Grab the archive for your OS/arch from the
 [latest release](https://github.com/bavanchun/Typeburn/releases/latest)
 (linux/darwin/windows × amd64/arm64), verify it against `checksums.txt`,
-extract, and run the `Typeburn` binary.
+extract, and run the `typeburn` binary (the release archives ship a lowercase
+`typeburn`; only the `go install` path above produces `Typeburn`).
 
-**3. Build from source:**
+**4. Build from source:**
 
 ```sh
 make build            # → ./bin/typeburn (lowercase, local convention)
@@ -54,7 +81,13 @@ go build -o typeburn .
 make run               # run without installing (or: go run .)
 ```
 
-**4. Homebrew:** planned, not yet available (see [CONTRIBUTING.md](./CONTRIBUTING.md)).
+**5. Homebrew (macOS/Linux):**
+
+```sh
+brew install bavanchun/tap-typeburn/typeburn
+```
+
+A cask wrapping the prebuilt release archive (no Go/Xcode toolchain needed).
 
 ## Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bavanchun/Typeburn
 
-go 1.26.2
+go 1.25.0
 
 require (
 	charm.land/bubbletea/v2 v2.0.6

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# Typeburn installer — POSIX sh, no sudo, no Go toolchain.
+#
+#   curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
+#
+# Trust boundary (read this before piping any script to a shell):
+#   The sha256 verification below defends against a corrupted or
+#   man-in-the-middled DOWNLOAD. It does NOT make `curl … | sh` "safe": the
+#   script, the archive, and checksums.txt all come from the same GitHub
+#   release, so a compromised release would be self-consistent. checksums.txt
+#   is unsigned. If that boundary matters to you, use the non-piped audit path
+#   in the README (download, read this script, verify, then run).
+#
+# What it does: detect os/arch, resolve the latest NON-prerelease tag, download
+# the matching release archive + checksums.txt, verify sha256, validate the
+# archive member, then atomically install `typeburn` into ~/.local/bin.
+#
+# Env (the TYPEBURN_* / *_UNAME_* knobs exist for the offline test harness):
+#   VERSION              pin a tag (e.g. v1.5.0); the API "prerelease":true
+#                        check is skipped (operator intent) but the string
+#                        guard still rejects -rc/-test/-beta/… tags
+#   BIN_DIR              install dir (default: ~/.local/bin)
+#   TYPEBURN_API         GitHub API base
+#   TYPEBURN_BASE_URL    release-download base
+#   TYPEBURN_LATEST_PATH API path for "latest" (default: releases/latest)
+#   TYPEBURN_UNAME_S/M   override uname -s / -m
+set -eu
+
+REPO="bavanchun/Typeburn"
+API="${TYPEBURN_API:-https://api.github.com/repos/$REPO}"
+BASE_URL="${TYPEBURN_BASE_URL:-https://github.com/$REPO/releases/download}"
+LATEST_PATH="${TYPEBURN_LATEST_PATH:-releases/latest}"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+BIN_NAME="typeburn"
+
+die() { printf 'install.sh: %s\n' "$*" >&2; exit 1; }
+info() { printf '==> %s\n' "$*"; }
+warn() { printf 'install.sh: warning: %s\n' "$*" >&2; }
+
+# fetch <url> <dest> : explicit failure (POSIX sh has no `pipefail`; never
+# rely on a pipe's exit status — check every download by hand).
+fetch() {
+  _u="$1"; _d="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL -o "$_d" "$_u" || return 1
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$_d" "$_u" || return 1
+  else
+    die "need curl or wget"
+  fi
+  [ -s "$_d" ] || return 1   # reject empty/truncated-to-zero downloads
+}
+
+is_prerelease() {
+  # Defence-in-depth against a poisoned `releases/latest` (a disposable
+  # -rc dry-run tag) and against an explicit VERSION=-rc override.
+  case "$1" in
+    *-rc*|*-RC*|*-test*|*-alpha*|*-beta*|*-pre*|*-dev*|*-snapshot*|*SNAPSHOT*)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# --- platform -------------------------------------------------------------
+uname_s="${TYPEBURN_UNAME_S:-$(uname -s)}"
+uname_m="${TYPEBURN_UNAME_M:-$(uname -m)}"
+case "$uname_s" in
+  Linux)  os="linux" ;;
+  Darwin) os="darwin" ;;
+  *) die "unsupported OS '$uname_s' — install.sh covers linux and darwin only. Windows: download the .zip from the releases page manually." ;;
+esac
+case "$uname_m" in
+  x86_64|amd64)  arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) die "unsupported architecture '$uname_m' — supported: x86_64/amd64, arm64/aarch64." ;;
+esac
+
+# --- resolve version ------------------------------------------------------
+tmp="$(mktemp -d)"
+chmod 700 "$tmp"
+stage=""
+cleanup() {
+  rm -rf "$tmp"
+  [ -n "$stage" ] && rm -f "$stage" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM HUP
+
+if [ -n "${VERSION:-}" ]; then
+  tag="$VERSION"
+else
+  info "resolving latest release"
+  fetch "$API/$LATEST_PATH" "$tmp/latest.json" \
+    || die "could not query the releases API (set VERSION=vX.Y.Z to bypass, e.g. on rate-limit)"
+  if grep -q '"prerelease"[[:space:]]*:[[:space:]]*true' "$tmp/latest.json"; then
+    die "refusing: the resolved 'latest' release is flagged prerelease"
+  fi
+  tag="$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$tmp/latest.json" | head -1)"
+fi
+[ -n "$tag" ] || die "could not determine a release tag"
+if is_prerelease "$tag"; then
+  die "refusing prerelease/test tag '$tag' (install.sh installs stable releases only)"
+fi
+
+ver="${tag#v}"   # GoReleaser strips the leading v from archive names
+archive="typeburn_${ver}_${os}_${arch}.tar.gz"
+info "installing $tag ($os/$arch)"
+
+# --- download + verify ----------------------------------------------------
+fetch "$BASE_URL/$tag/$archive" "$tmp/$archive" \
+  || die "download failed: $BASE_URL/$tag/$archive"
+fetch "$BASE_URL/$tag/checksums.txt" "$tmp/checksums.txt" \
+  || die "download failed: checksums.txt for $tag"
+
+expected="$(awk -v f="$archive" '$2==f {print $1}' "$tmp/checksums.txt" | head -1)"
+[ -n "$expected" ] || die "no checksum entry for $archive in checksums.txt"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/$archive" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$tmp/$archive" | awk '{print $1}')"
+else
+  die "need sha256sum or shasum to verify the download"
+fi
+[ "$expected" = "$actual" ] \
+  || die "checksum mismatch for $archive (expected $expected, got $actual) — aborting, nothing installed"
+info "sha256 verified"
+
+# --- extract + validate member -------------------------------------------
+# Reject absolute paths and `..` path COMPONENTS before extracting anything
+# (precise: a benign filename like `foo..bar` must not trip this — the
+# literal-member extraction below is the primary control regardless).
+tar -tzf "$tmp/$archive" | while IFS= read -r entry; do
+  case "$entry" in
+    /*|../*|*/../*|*/..|..) echo "BADPATH" ; break ;;
+  esac
+done | grep -q BADPATH && die "archive contains an unsafe path — aborting"
+
+mkdir -p "$tmp/x"
+tar -xzf "$tmp/$archive" -C "$tmp/x" "$BIN_NAME" 2>/dev/null \
+  || die "archive does not contain a '$BIN_NAME' entry"
+[ -e "$tmp/x/$BIN_NAME" ] || die "extracted '$BIN_NAME' missing"
+[ ! -L "$tmp/x/$BIN_NAME" ] || die "refusing: '$BIN_NAME' in the archive is a symlink"
+[ -f "$tmp/x/$BIN_NAME" ] || die "refusing: '$BIN_NAME' in the archive is not a regular file"
+
+# --- atomic install -------------------------------------------------------
+mkdir -p "$BIN_DIR"
+stage="$BIN_DIR/.$BIN_NAME.$$.tmp"   # same filesystem as the final path
+cp "$tmp/x/$BIN_NAME" "$stage"
+chmod 0755 "$stage"
+mv -f "$stage" "$BIN_DIR/$BIN_NAME"  # rename = atomic; prior binary intact until here
+stage=""
+info "installed $BIN_DIR/$BIN_NAME"
+
+# --- PATH membership + precedence ----------------------------------------
+case ":$PATH:" in
+  *":$BIN_DIR:"*) on_path=1 ;;
+  *) on_path=0 ;;
+esac
+if [ "$on_path" -eq 0 ]; then
+  warn "$BIN_DIR is not on your PATH. Add it:"
+  # Literal $PATH is intentional — this is a copy-paste line for the user's shell.
+  # shellcheck disable=SC2016
+  printf '    export PATH="%s:$PATH"\n' "$BIN_DIR" >&2
+else
+  resolved="$(command -v "$BIN_NAME" 2>/dev/null || true)"
+  if [ -n "$resolved" ] && [ "$resolved" != "$BIN_DIR/$BIN_NAME" ]; then
+    warn "another '$BIN_NAME' takes PATH precedence: $resolved (just installed: $BIN_DIR/$BIN_NAME)"
+  fi
+fi
+
+info "done — run: $BIN_NAME --version"

--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,9 @@ chmod 700 "$tmp"
 stage=""
 cleanup() {
   rm -rf "$tmp"
-  [ -n "$stage" ] && rm -f "$stage" 2>/dev/null || true
+  if [ -n "$stage" ]; then
+    rm -f "$stage" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT INT TERM HUP
 

--- a/scripts/test-install-sh.sh
+++ b/scripts/test-install-sh.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Offline regression harness for install.sh.
+#
+# No internet: a localhost python http.server stands in for the GitHub API and
+# the release-asset download host. install.sh exposes test-only env seams
+# (TYPEBURN_API, TYPEBURN_BASE_URL, TYPEBURN_UNAME_S/M, TYPEBURN_LATEST_PATH) so
+# every failure mode is exercised deterministically. Each case asserts BOTH the
+# exit status and the filesystem: a refused install must write nothing; a failed
+# install must leave any prior binary byte-identical.
+#
+# Subshell-local env per case is the intended isolation, hence the SC2030/SC2031
+# suppression — each case must not leak env into the next.
+#
+# Run: scripts/test-install-sh.sh   (exit 0 = all green)
+# shellcheck disable=SC2030,SC2031
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+WORK="$(mktemp -d)"
+SRV_PID=""
+PASS=0
+FAIL=0
+
+cleanup() {
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+note() { printf '      %s\n' "$*"; }
+ok()   { PASS=$((PASS + 1)); printf 'PASS  %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf 'FAIL  %s\n' "$1"; }
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
+  else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+# --- Fixtures -------------------------------------------------------------
+# Real GoReleaser identity (verified from `make snapshot`): archive is
+# typeburn_<version-without-v>_<os>_<arch>.tar.gz, member is `typeburn`,
+# checksums.txt is GNU `<sha256>␣␣<name>` format.
+DOCROOT="$WORK/docroot"
+STABLE_TAG="v9.9.9"
+STABLE_VER="9.9.9"
+mkdir -p "$DOCROOT/api/releases" "$DOCROOT/dl/$STABLE_TAG"
+
+make_archive() { # os arch outdir -> prints archive filename
+  local os="$1" arch="$2" out="$3" stage name
+  stage="$WORK/stage_${os}_${arch}"
+  mkdir -p "$stage"
+  printf '#!/bin/sh\necho "typeburn-fake $*"\n' >"$stage/typeburn"
+  chmod 755 "$stage/typeburn"
+  name="typeburn_${STABLE_VER}_${os}_${arch}.tar.gz"
+  tar -czf "$out/$name" -C "$stage" typeburn
+  echo "$name"
+}
+
+: >"$DOCROOT/dl/$STABLE_TAG/checksums.txt"
+for combo in darwin:amd64 darwin:arm64 linux:amd64 linux:arm64; do
+  os="${combo%%:*}"; arch="${combo##*:}"
+  fn="$(make_archive "$os" "$arch" "$DOCROOT/dl/$STABLE_TAG")"
+  printf '%s  %s\n' "$(sha256_of "$DOCROOT/dl/$STABLE_TAG/$fn")" "$fn" \
+    >>"$DOCROOT/dl/$STABLE_TAG/checksums.txt"
+done
+
+printf '{"tag_name":"%s","prerelease":false}\n' "$STABLE_TAG" \
+  >"$DOCROOT/api/releases/latest"
+printf '{"tag_name":"%s","prerelease":true}\n' "v0.0.0-rc.test" \
+  >"$DOCROOT/api/releases/latest-pre"
+
+# --- Local server ---------------------------------------------------------
+( cd "$DOCROOT" && exec python3 -u -m http.server 0 --bind 127.0.0.1 ) \
+  >"$WORK/srv.log" 2>&1 &
+SRV_PID=$!
+PORT=""
+for _ in $(seq 1 50); do
+  PORT="$(sed -n 's/.* port \([0-9][0-9]*\).*/\1/p' "$WORK/srv.log" | head -1)"
+  [ -n "$PORT" ] && break
+  sleep 0.1
+done
+[ -n "$PORT" ] || { echo "server did not start" >&2; cat "$WORK/srv.log" >&2; exit 1; }
+BASE="http://127.0.0.1:$PORT"
+export TYPEBURN_API="$BASE/api"
+export TYPEBURN_BASE_URL="$BASE/dl"
+
+# === (a) os/arch matrix → exact real asset names, happy path =============
+for combo in Darwin:x86_64:darwin:amd64 Darwin:arm64:darwin:arm64 \
+             Linux:x86_64:linux:amd64 Linux:aarch64:linux:arm64; do
+  uS="${combo%%:*}"; rest="${combo#*:}"
+  uM="${rest%%:*}"; rest="${rest#*:}"
+  goos="${rest%%:*}"; goarch="${rest##*:}"
+  bd="$WORK/bin_a_${goos}_${goarch}"
+  label="(a) $uS/$uM → typeburn_${STABLE_VER}_${goos}_${goarch}.tar.gz"
+  if (
+    export BIN_DIR="$bd" TYPEBURN_UNAME_S="$uS" TYPEBURN_UNAME_M="$uM"
+    out="$(sh "$INSTALL_SH" 2>&1)" || { echo "$out"; exit 1; }
+    [ -x "$bd/typeburn" ] || { echo "binary not installed: $out"; exit 1; }
+  ); then ok "$label"; else bad "$label"; fi
+done
+
+# === (b) checksum mismatch → nonzero, nothing written ===================
+bd="$WORK/bin_b"; CKDIR="$WORK/dl_b/$STABLE_TAG"; mkdir -p "$CKDIR"
+cp "$DOCROOT/dl/$STABLE_TAG"/*.tar.gz "$CKDIR/"
+sed 's/^[0-9a-f]\{64\}/0000000000000000000000000000000000000000000000000000000000000000/' \
+  "$DOCROOT/dl/$STABLE_TAG/checksums.txt" >"$CKDIR/checksums.txt"
+if (
+  export BIN_DIR="$bd" TYPEBURN_UNAME_S=Linux TYPEBURN_UNAME_M=x86_64 \
+         TYPEBURN_BASE_URL="$BASE/dl_b"
+  sh "$INSTALL_SH" >/dev/null 2>&1 && exit 1
+  [ ! -e "$bd/typeburn" ] || exit 1
+); then ok "(b) checksum mismatch refused, nothing written"
+else bad "(b) checksum mismatch"; fi
+
+# === (c) unsupported platform → exit 1 + clear message ==================
+for plat in Windows:x86_64 FreeBSD:amd64 Linux:mips; do
+  uS="${plat%%:*}"; uM="${plat##*:}"; bd="$WORK/bin_c_${uS}_${uM}"
+  if (
+    export BIN_DIR="$bd" TYPEBURN_UNAME_S="$uS" TYPEBURN_UNAME_M="$uM"
+    out="$(sh "$INSTALL_SH" 2>&1)"; rc=$?
+    [ "$rc" -eq 1 ] || { echo "rc=$rc"; exit 1; }
+    echo "$out" | grep -qi "unsupported" || { echo "no clear msg: $out"; exit 1; }
+    [ ! -e "$bd/typeburn" ] || exit 1
+  ); then ok "(c) $uS/$uM unsupported → exit 1, clear msg"
+  else bad "(c) $uS/$uM unsupported"; fi
+done
+
+# === (d) truncated/empty download → abort, no partial install ===========
+bd="$WORK/bin_d"; DDIR="$WORK/dl_d/$STABLE_TAG"; mkdir -p "$DDIR"
+: >"$DDIR/typeburn_${STABLE_VER}_linux_amd64.tar.gz"
+cp "$DOCROOT/dl/$STABLE_TAG/checksums.txt" "$DDIR/checksums.txt"
+if (
+  export BIN_DIR="$bd" TYPEBURN_UNAME_S=Linux TYPEBURN_UNAME_M=x86_64 \
+         TYPEBURN_BASE_URL="$BASE/dl_d"
+  sh "$INSTALL_SH" >/dev/null 2>&1 && exit 1
+  [ ! -e "$bd/typeburn" ] || exit 1
+); then ok "(d) empty/truncated download aborts, nothing written"
+else bad "(d) truncated download"; fi
+
+# === (e) BIN_DIR absent (nested) → mkdir -p, still succeeds =============
+bd="$WORK/no/such/dir/deep/bin"
+if (
+  export BIN_DIR="$bd" TYPEBURN_UNAME_S=Linux TYPEBURN_UNAME_M=x86_64
+  out="$(sh "$INSTALL_SH" 2>&1)" || { echo "$out"; exit 1; }
+  [ -x "$bd/typeburn" ] || exit 1
+); then ok "(e) absent nested BIN_DIR created via mkdir -p"
+else bad "(e) absent BIN_DIR"; fi
+
+# === (f) prerelease refused — poisoned latest AND VERSION override ======
+if (
+  export BIN_DIR="$WORK/bin_f1" TYPEBURN_UNAME_S=Linux TYPEBURN_UNAME_M=x86_64 \
+         TYPEBURN_LATEST_PATH="releases/latest-pre"
+  out="$(sh "$INSTALL_SH" 2>&1)" && exit 1
+  echo "$out" | grep -qi "prerelease\|refus" || { echo "no msg: $out"; exit 1; }
+  [ ! -e "$WORK/bin_f1/typeburn" ] || exit 1
+); then ok "(f) poisoned prerelease latest refused"
+else bad "(f) prerelease latest"; fi
+if (
+  export BIN_DIR="$WORK/bin_f2" TYPEBURN_UNAME_S=Linux TYPEBURN_UNAME_M=x86_64 \
+         VERSION="v0.0.0-rc.test"
+  sh "$INSTALL_SH" >/dev/null 2>&1 && exit 1
+  [ ! -e "$WORK/bin_f2/typeburn" ] || exit 1
+); then ok "(f) explicit VERSION=-rc.test refused"
+else bad "(f) VERSION rc override"; fi
+
+# === (g) malicious archive member (symlink) → reject ====================
+bd="$WORK/bin_g"; GDIR="$WORK/dl_g/$STABLE_TAG"; gstage="$WORK/gstage"
+mkdir -p "$GDIR" "$gstage"
+ln -s /etc/passwd "$gstage/typeburn"
+tar -czf "$GDIR/typeburn_${STABLE_VER}_linux_amd64.tar.gz" -C "$gstage" typeburn
+printf '%s  %s\n' \
+  "$(sha256_of "$GDIR/typeburn_${STABLE_VER}_linux_amd64.tar.gz")" \
+  "typeburn_${STABLE_VER}_linux_amd64.tar.gz" >"$GDIR/checksums.txt"
+if (
+  export BIN_DIR="$bd" TYPEBURN_UNAME_S=Linux TYPEBURN_UNAME_M=x86_64 \
+         TYPEBURN_BASE_URL="$BASE/dl_g"
+  sh "$INSTALL_SH" >/dev/null 2>&1 && exit 1
+  [ ! -e "$bd/typeburn" ] && [ ! -L "$bd/typeburn" ] || exit 1
+); then ok "(g) symlink archive member rejected"
+else bad "(g) symlink member"; fi
+
+# === (h) failed install leaves prior binary byte-identical ==============
+bd="$WORK/bin_h"; mkdir -p "$bd"
+printf 'OLD-BINARY-SENTINEL\n' >"$bd/typeburn"; chmod 755 "$bd/typeburn"
+before="$(sha256_of "$bd/typeburn")"
+HDIR="$WORK/dl_h/$STABLE_TAG"; mkdir -p "$HDIR"
+cp "$DOCROOT/dl/$STABLE_TAG"/*.tar.gz "$HDIR/"
+sed 's/^[0-9a-f]\{64\}/deadbeef00000000000000000000000000000000000000000000000000000000/' \
+  "$DOCROOT/dl/$STABLE_TAG/checksums.txt" >"$HDIR/checksums.txt"
+if (
+  export BIN_DIR="$bd" TYPEBURN_UNAME_S=Linux TYPEBURN_UNAME_M=x86_64 \
+         TYPEBURN_BASE_URL="$BASE/dl_h"
+  sh "$INSTALL_SH" >/dev/null 2>&1 && exit 1
+  after="$(sha256_of "$bd/typeburn")"
+  [ "$before" = "$after" ] || exit 1
+); then ok "(h) failed install left prior binary byte-identical"
+else bad "(h) prior binary integrity"; fi
+
+# --- Report ---------------------------------------------------------------
+echo "----------------------------------------"
+echo "install.sh harness: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test-install-sh.sh
+++ b/scripts/test-install-sh.sh
@@ -24,7 +24,9 @@ PASS=0
 FAIL=0
 
 cleanup() {
-  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+  if [ -n "$SRV_PID" ]; then
+    kill "$SRV_PID" 2>/dev/null || true
+  fi
   rm -rf "$WORK"
 }
 trap cleanup EXIT INT TERM
@@ -177,7 +179,7 @@ if (
   export BIN_DIR="$bd" TYPEBURN_UNAME_S=Linux TYPEBURN_UNAME_M=x86_64 \
          TYPEBURN_BASE_URL="$BASE/dl_g"
   sh "$INSTALL_SH" >/dev/null 2>&1 && exit 1
-  [ ! -e "$bd/typeburn" ] && [ ! -L "$bd/typeburn" ] || exit 1
+  if [ -e "$bd/typeburn" ] || [ -L "$bd/typeburn" ]; then exit 1; fi
 ); then ok "(g) symlink archive member rejected"
 else bad "(g) symlink member"; fi
 


### PR DESCRIPTION
Distribution v1.5 — closes the install-friction gap for terminal users.
Plan: `plans/20260519-distribution-v1.5-onramp/` (lands via separate chore PR).

## What
- **Go floor 1.26.2 → 1.25.0** — bounded by deps (bubbletea/v2 v2.0.6 + lipgloss/v2 v2.0.3 pin `go 1.25.0`). Full race suite + `goreleaser build` verified green under an *installed* go1.25.10 toolchain (11 pkgs, oracle-matched). Lockstep: go.mod, ci.yml, release.yml ×2, CONTRIBUTING.md, README.md.
- **GoReleaser determinism** — `project_name`/`builds.binary`/`archives.name_template` pinned to lowercase `typeburn`; install.sh + cask reference fixed names.
- **`install.sh`** (POSIX sh) — os/arch detect, latest non-prerelease tag, sha256-verified download, archive-member validation (symlink/non-regular/traversal reject), atomic install to `~/.local/bin`, no sudo. Honest trust-boundary docs. Offline harness (14 cases) + shellcheck added to CI (`installer` job).
- **Homebrew cask** — `homebrew_casks:` commits to `bavanchun/homebrew-tap-typeburn`; `release.prerelease:auto` + `skip_upload:auto` make the disposable dry-run publish nothing durable. Token at GoReleaser step env only; `before.hooks` go-build removed (no project code beside the tap PAT). **Release-asset count stays 7** (cask ≠ asset, verified via snapshot).

## Verification
- `go test ./... -race` under go1.25.10: 11/11 pkgs PASS
- `shellcheck install.sh scripts/test-install-sh.sh`: clean
- `scripts/test-install-sh.sh`: 14/14
- `goreleaser check`: valid; snapshot → exactly 7 release assets + cask `.rb` (not an asset)
- Real-binary E2E: actual archive → sha256 → atomic install → `typeburn --version` OK
- Adversarial code review: 0 Critical/High, all acceptance criteria PASS

## Out of scope this PR (gated, follow-up)
- G0/G1 PAT provisioning (`HOMEBREW_TAP_TOKEN`) — manual human gate
- P4 safe dry-run (`v0.0.0-rc.test`) + clean-container verify — after merge, before real v1.5 tag
- Scoop/winget, AUR, deb/rpm, Nix, snap — deferred