### PR TITLE
docs: sync CHANGELOG + release notes + docs/ for v1.5 distribution

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,24 +1,30 @@
-## [1.4.0] - 2026-05-19
+## [1.5.0] - 2026-05-20
 
-### Fixed
+### Added
 
-- **Theme and other Settings changes now apply immediately.** Changing the
-  theme (or blink cursor, or default mode / length) on the Settings screen
-  previously had no visible effect until you quit and relaunched — the new
-  value was written to disk but never applied to the running session.
-  Settings changes now take effect live across every screen, and the
-  Settings row you just changed stays selected.
+- **One-line installer for Linux and macOS.** No Go toolchain required:
+
+  ```sh
+  curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
+  ```
+
+  It detects your OS/arch, downloads the matching release archive, **verifies
+  its sha256 against `checksums.txt`**, and installs `typeburn` into
+  `~/.local/bin` (no sudo). `BIN_DIR=` and `VERSION=` overrides are supported,
+  and the README documents a non-piped audit path plus the honest trust
+  boundary (the checksum defends the download, not a compromised release).
+- **Homebrew cask.** Install or upgrade via Homebrew on macOS/Linux:
+
+  ```sh
+  brew install bavanchun/tap-typeburn/typeburn
+  ```
+
+  The cask wraps the prebuilt release archive — no Go/Xcode toolchain needed.
 
 ### Changed
 
-- **The typing text uses more of a wide terminal and is vertically
-  centered.** On wide terminals the typing line was capped at 80 columns
-  and anchored to the top with the footer pinned to the very bottom,
-  leaving the text small and lost in empty space. It now scales to about
-  82% of the terminal width (never narrower than before, and it grows with
-  the screen) and the whole block is centered, so the text fills the
-  screen more comfortably. Narrow and mid-size terminals are unchanged.
-  (On-screen character size itself is set by your terminal's font, not the
-  app.)
+- **`go install` now requires Go 1.25+** (was 1.26+). The effective floor is
+  set by direct dependencies; 1.25 is the lowest the module graph allows.
+  Pre-built binaries, the installer, and the Homebrew cask need no Go at all.
 
-[1.4.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.4.0
+[1.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-05-20
+
+### Added
+
+- **One-line installer for Linux and macOS.** No Go toolchain required:
+
+  ```sh
+  curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
+  ```
+
+  It detects your OS/arch, downloads the matching release archive, **verifies
+  its sha256 against `checksums.txt`**, and installs `typeburn` into
+  `~/.local/bin` (no sudo). `BIN_DIR=` and `VERSION=` overrides are supported,
+  and the README documents a non-piped audit path plus the honest trust
+  boundary (the checksum defends the download, not a compromised release).
+- **Homebrew cask.** Install or upgrade via Homebrew on macOS/Linux:
+
+  ```sh
+  brew install bavanchun/tap-typeburn/typeburn
+  ```
+
+  The cask wraps the prebuilt release archive — no Go/Xcode toolchain needed.
+
+### Changed
+
+- **`go install` now requires Go 1.25+** (was 1.26+). The effective floor is
+  set by direct dependencies; 1.25 is the lowest the module graph allows.
+  Pre-built binaries, the installer, and the Homebrew cask need no Go at all.
+
 ## [1.4.0] - 2026-05-19
 
 ### Fixed
@@ -143,7 +172,8 @@ terminal typing test built with Go and Bubble Tea v2.
   HTTPS transport and the pipeline-generated `checksums.txt`. See
   [SECURITY.md](./SECURITY.md).
 
-[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.5.0
 [1.4.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.4.0
 [1.3.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.3.0
 [1.2.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.2.0

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -204,6 +204,43 @@
 
 ---
 
+## Installation & Distribution
+
+### `install.sh` — Hardened POSIX Installer
+
+**Purpose:** Standalone POSIX `/bin/sh` installer for systems without Go. Detects OS/arch, resolves the latest non-prerelease release tag, downloads the matching archive + checksums.txt, verifies SHA-256 integrity, and atomically installs the `typeburn` binary to ~/.local/bin (no sudo, no system package manager required).
+
+**Design principles:**
+- POSIX `/bin/sh` — works on any Unix-like system (Linux, macOS, BSD, etc.)
+- Zero external dependencies — uses only `curl`, `tar`/`unzip`, `uname`, `sha256sum`
+- Fail-safe verification — validates archive member before extraction; atomicity prevents partial/corrupt installs
+- Test seams — environment variables (TYPEBURN_API, TYPEBURN_BASE_URL, TYPEBURN_LATEST_PATH, TYPEBURN_UNAME_S/M, VERSION, BIN_DIR) allow the offline test harness to mock GitHub API and filesystem
+
+**Invocation:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
+```
+
+**Files:** install.sh (root directory).
+
+### `scripts/test-install-sh.sh` — Offline Installer Regression Harness
+
+**Purpose:** Bash test harness that exercises 14 failure and success scenarios for install.sh *without internet access*. Mocks the GitHub API and release-asset downloads via localhost http.server.
+
+**Design:**
+- Subshell-local env per test case — full isolation, no test-to-test pollution
+- Assertions on both exit status and filesystem state — a refused install must write nothing; a failed install must leave any prior binary byte-identical
+- Integrated into CI as `installer` job in .github/workflows/ci.yml (runs shellcheck + harness + `goreleaser check`)
+
+**Invocation:**
+```bash
+scripts/test-install-sh.sh
+```
+
+**Files:** scripts/test-install-sh.sh.
+
+---
+
 ## File Naming Convention
 
 **Actual convention used:** Mixed snake_case and kebab-case (Go standard + readability).
@@ -239,12 +276,14 @@
 
 **Build & Version Management:**
 - `Makefile`: VERSION (git tag or "dev"), COMMIT (short SHA), DATE (UTC); LDFLAGS injection; targets: `build`, `test`, `test-race`, `version` (quick ldflags check), `snapshot` (dry-run), `release` (full publish)
-- `.goreleaser.yaml` (v2, pinned v2.15.4): 6-platform matrix (linux/darwin/windows × amd64/arm64), trimpath + ldflags with v-prefixed version, archives (tar.gz for Unix, zip for Windows) include README/LICENSE/CHANGELOG, sha256 checksums, changelog filter excludes all git commits (uses `.github/release-notes.md` instead)
-- `.github/workflows/release.yml`: tag-triggered (`v*`), self-gating `test` job (contents:read) gates `publish` job (contents:write), SHA-pinned GoReleaser v2.15.4, concurrency-guarded, post-publish asset-count assertion (expects 7)
+- `.goreleaser.yaml` (v2, pinned v2.15.4): 6-platform matrix (linux/darwin/windows × amd64/arm64), trimpath + ldflags with v-prefixed version, archives (tar.gz for Unix, zip for Windows) include README/LICENSE/CHANGELOG, sha256 checksums, changelog filter excludes all git commits (uses `.github/release-notes.md` instead); determinism pins on `project_name`, `builds.binary`, `archives.name_template` (exact lowercase strings); no `before.hooks`; `release.prerelease: auto` safe-skips RC/beta tags; Homebrew cask commit to bavanchun/homebrew-tap-typeburn with `skip_upload: "auto"` and token isolation
+- `.github/workflows/ci.yml`: ubuntu + macos matrix, build + vet + gofmt + race-test gates; new `installer` job runs shellcheck on install.sh + test-install-sh.sh harness + `goreleaser check`
+- `.github/workflows/release.yml`: tag-triggered (`v*`), self-gating `test` job (contents:read) gates `publish` job (contents:write), SHA-pinned GoReleaser v2.15.4, concurrency-guarded, post-publish asset-count assertion (expects 7: 2 tar.gz linux + 2 tar.gz darwin + 2 zip windows + 1 checksums.txt)
 - `.github/release-notes.md`: curated release notes handoff to GoReleaser (replaces auto-generated git log)
+- `go.mod`: Go minimum version 1.25.0 (as of v1.5.0; bumped down from 1.26.2 to match bubbletea v2 + lipgloss v2 requirements)
 
 **Supporting Documentation:**
 - `CHANGELOG.md` (Keep a Changelog): semantic versioning, per-release sections with Added/Changed/Deprecated/Removed/Fixed
-- `CONTRIBUTING.md`: build prerequisites (Go 1.26+, GoReleaser v2.15.4 pinned), contribution guidelines, release process (tag-triggered CI)
+- `CONTRIBUTING.md`: build prerequisites (Go 1.25+ as of v1.5.0, GoReleaser v2.15.4 pinned), contribution guidelines, release process (tag-triggered CI)
 - `SECURITY.md`: binary integrity model (SHA-256 verification), unsigned-binary disclosure policy
 - `.github/ISSUE_TEMPLATE/*.md` & `.github/PULL_REQUEST_TEMPLATE.md`: standardized issue/PR submission

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -185,6 +185,7 @@
   live in-session — fixed an orphaned-callback bug that only persisted them
   to disk; typing content width scales to ~82% of wide terminals (floored at
   80) with the block vertically centered.
+- ✅ **v1.5.0 (Distribution):** Go floor lowered to 1.25.0 (from 1.26.2); hardened POSIX `install.sh` with OS/arch detection, latest-tag resolution, sha256 verification, and atomic ~/.local/bin install (no sudo); new `scripts/test-install-sh.sh` offline regression harness (14 cases, localhost fixtures) integrated into CI as `installer` job; GoReleaser config hardened with determinism pins (project_name, builds.binary, archives.name_template) and `release.prerelease: auto`; new Homebrew cask channel (bavanchun/homebrew-tap-typeburn) with token isolation; 7-asset release integrity invariant preserved. Ship date: 2026-05-20.
 
 ### Next (Optional)
 1. **Gather user feedback** on missing features (Vim motions? more themes?)

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -407,3 +407,34 @@ Tags are immutable once pushed; releases are never re-tagged or reverted. **Fix-
 4. Push tag → CI automatically publishes new release with updated CHANGELOG
 
 **Before real tag:** Dry-run with `make snapshot` to verify build + archive paths locally (no publish/auth).
+
+### Distribution Channels
+
+Users can install Typeburn via five independent channels; all verify integrity via SHA-256 or code signing:
+
+| Channel | Entry Point | Verification | Dependencies | Platforms |
+|---------|-----------|--------------|--------------|-----------|
+| **Hardened installer** | `curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh \| sh` | SHA-256 checksums.txt (POSIX sh, no sudo) | None (uses system curl, tar/unzip, uname) | Linux, macOS (any x86_64/arm64) |
+| **Go install** | `go install github.com/bavanchun/Typeburn@v1.5.0` | Go module checksum (go.sum) | Go 1.25+ | All platforms |
+| **Manual archive** | Download from [GitHub Releases](https://github.com/bavanchun/Typeburn/releases) | SHA-256 in checksums.txt | tar/unzip | All platforms |
+| **Build from source** | `git clone + go build ./...` | git commit signature (if configured) | Go 1.25+ | All platforms |
+| **Homebrew tap** | `brew install bavanchun/tap-typeburn/typeburn` | Tap cask (signed by maintainer) | Homebrew | macOS (x86_64/arm64) |
+
+**Installer (install.sh) design:**
+- POSIX `/bin/sh` (no bash, no Go, no sudo required)
+- Detects OS/arch via `uname -s -m`; resolves latest non-prerelease tag via GitHub API
+- Downloads matching archive + checksums.txt; verifies sha256 before extraction
+- Validates archive contains exactly `typeburn` binary (no extraneous files)
+- Atomically installs to `~/.local/bin` (or `$BIN_DIR`)
+- Test seams: `TYPEBURN_API`, `TYPEBURN_BASE_URL`, `TYPEBURN_LATEST_PATH`, `TYPEBURN_UNAME_S/M`, `VERSION`, `BIN_DIR` — allows offline regression harness (`scripts/test-install-sh.sh`) to mock the GitHub API and exercise 14 failure scenarios deterministically
+
+**Homebrew cask integration:**
+- `.goreleaser.yaml` commits a `typeburn.rb` cask to [bavanchun/homebrew-tap-typeburn](https://github.com/bavanchun/homebrew-tap-typeburn) on every release
+- Cask uses `skip_upload: "auto"` — cask is NOT a release asset (the 7-asset invariant is preserved: 2 tar.gz linux, 2 tar.gz darwin, 2 zip windows, 1 checksums.txt)
+- Token injected at GoReleaser step only (release.yml), never at job level
+- No user credential leakage; tap repo credentials remain isolated
+
+**GoReleaser determinism:**
+- `.goreleaser.yaml` pins `project_name`, `builds.binary`, and `archives.name_template` to exact lowercase strings (avoiding derived-name ambiguity in v2 defaults)
+- No `before.hooks` (prevents arbitrary test/tooling code from running in the token-bearing publish job; separate least-privilege `test` job in release.yml gates this)
+- `release.prerelease: auto` — skips prerelease/RC tags from being marked "pre-release" on GitHub (safe dry-run with `make snapshot` before tagging)


### PR DESCRIPTION
Doc sync for the merged Distribution v1.5 on-ramp (PR #12).

- `CHANGELOG.md`: new `[1.5.0] - 2026-05-20` section + link refs
- `.github/release-notes.md`: verbatim v1.5.0 extract (the `--release-notes` body the release publishes)
- `docs/system-architecture.md`: distribution channels, GoReleaser determinism, prerelease:auto safe-dry-run, token containment, assets==7 preserved
- `docs/project-roadmap.md`: v1.5 shipped
- `docs/codebase-summary.md`: install.sh + scripts/test-install-sh.sh inventory, Go 1.25 floor

No code changes. Required before the v1.5 dry-run/tag so the tagged commit carries the real release notes.