### PR TITLE
fix: render TUI in alternate screen buffer (full-window, no scroll)

### DIFF
--- a/internal/app/model_view.go
+++ b/internal/app/model_view.go
@@ -9,6 +9,16 @@ import (
 	"github.com/bavanchun/Typeburn/internal/ui"
 )
 
+// altView wraps a frame string in the alternate screen buffer. The altscreen
+// gives the program full-window mode with no scrollback (the TUI cannot be
+// scrolled) and restores the prior terminal contents on quit. Every View()
+// return path goes through here so altscreen is unconditional.
+func altView(s string) tea.View {
+	v := tea.NewView(s)
+	v.AltScreen = true
+	return v
+}
+
 // View renders the active screen centered in the terminal.
 //
 // Single chokepoint: if the terminal is below the 60×20 safe minimum, the
@@ -21,12 +31,12 @@ func (m Model) View() tea.View {
 	// Degraded gate — must check before any screen delegation.
 	if m.w > 0 && m.h > 0 && (m.w < 60 || m.h < 20) {
 		notice := ui.DegradedNotice(m.w, m.h, m.theme)
-		return tea.NewView(lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, notice))
+		return altView(lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, notice))
 	}
 
 	// Quit-prompt overlay on Home screen.
 	if m.quitPrompt != nil && m.screen == ScreenHome {
-		return tea.NewView(m.quitPrompt.view(m.w, m.h, m.theme))
+		return altView(m.quitPrompt.view(m.w, m.h, m.theme))
 	}
 
 	// Compute the final frame string in one place (single return) so the
@@ -70,5 +80,5 @@ func (m Model) View() tea.View {
 		out = strings.Join(lines, "\n")
 	}
 
-	return tea.NewView(out)
+	return altView(out)
 }


### PR DESCRIPTION
## Problem

Launching `typeburn` rendered in the normal terminal buffer (inline), so terminal scrollback stayed active — the TUI could be scrolled and did not take over the full window.

## Root cause

Bubble Tea **v2** removed the `tea.WithAltScreen()` program option; altscreen is now controlled via the `tea.View.AltScreen` field returned from `Model.View()`.

## Fix

`internal/app/model_view.go`: added an `altView` helper that sets `AltScreen = true`, and routed all 4 `View()` return paths (degraded gate, quit-prompt overlay, main frame, fallback) through it so altscreen is unconditional.

## Result

- Full-window TUI takeover
- No scrollback (cannot be scrolled)
- Prior terminal contents restored on quit
- Empty area still uses terminal-default background (unchanged by design — RoleBg)

## Verification

- `make lint` — gofmt clean + `go vet` clean
- `make test-race` — all 11 packages PASS
- `make build` — OK