### PR TITLE
fix(release): refresh release-notes.md to v2.0.0

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,30 +1,24 @@
-## [1.5.0] - 2026-05-20
+## [2.0.0] - 2026-05-20
 
 ### Added
 
-- **One-line installer for Linux and macOS.** No Go toolchain required:
-
-  ```sh
-  curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
-  ```
-
-  It detects your OS/arch, downloads the matching release archive, **verifies
-  its sha256 against `checksums.txt`**, and installs `typeburn` into
-  `~/.local/bin` (no sudo). `BIN_DIR=` and `VERSION=` overrides are supported,
-  and the README documents a non-piped audit path plus the honest trust
-  boundary (the checksum defends the download, not a compromised release).
-- **Homebrew cask.** Install or upgrade via Homebrew on macOS/Linux:
-
-  ```sh
-  brew install bavanchun/tap-typeburn/typeburn
-  ```
-
-  The cask wraps the prebuilt release archive — no Go/Xcode toolchain needed.
+- Professional CLI surface via cobra/fang: `run`, `history`, `version`,
+  `config`, and `replay` subcommands, with styled `-h` / `--help`.
+- Scriptable JSON output for `history`, `version`, `config list`, `replay`,
+  and raw `run --no-tui --json` results.
+- Raw terminal runner: `typeburn run --no-tui --mode words --words 10`.
+  It restores terminal state on normal completion, panic, and handled aborts.
+- Schema-versioned keystroke replay fixture and parser
+  (`schema_version: 1`).
 
 ### Changed
 
-- **`go install` now requires Go 1.25+** (was 1.26+). The effective floor is
-  set by direct dependencies; 1.25 is the lowest the module graph allows.
-  Pre-built binaries, the installer, and the Homebrew cask need no Go at all.
+- `main.go` is now a thin fang/cobra entrypoint. The v1 aliases
+  `--version` and `--text <file>` still work, and root-level unknown args still
+  fall through to the TUI.
+- Session construction moved into `internal/runner` so the TUI, replay, and
+  raw runner share target/engine setup.
+- Dependency policy now explicitly permits cobra, fang, and `golang.org/x/*`
+  for the CLI surface.
 
-[1.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.5.0
+[2.0.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.0.0


### PR DESCRIPTION
## Summary

- Replaces stale v1.5.0 content in `.github/release-notes.md` with the v2.0.0 section, sourced verbatim from `CHANGELOG.md`.
- Caught by a `v0.0.0-rc.test` dry-run against the v2.0.0 candidate SHA (`94403b5`) — the GoReleaser publish step succeeded but emitted the v1.5.0 body, which would have been baked into an immutable `v2.0.0` release.

## Context

`release.yml` invokes GoReleaser with `--release-notes=.github/release-notes.md` (the repo intentionally uses curated notes rather than GoReleaser's auto-changelog; see `CONTRIBUTING.md` and the `changelog.filters.exclude: ['.*']` trick in `.goreleaser.yaml`). The dry-run release + tag have already been deleted via `gh release delete v0.0.0-rc.test --cleanup-tag`.

## Test plan

- [x] `make lint` (run before opening this PR — no Go files touched, but kept honest)
- [ ] CI green on PR
- [ ] After merge: re-run the `v0.0.0-rc.test` dry-run against the new main SHA; confirm release body now shows v2.0.0 content; delete dry-run; then annotated `v2.0.0` tag.