### PR TITLE
feat(update): opt-in update check v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.1.0] - unreleased
+
+### Added
+
+- **Update check** (`internal/update`): pure-stdlib package that fetches the
+  latest GitHub release, caches the result for 24 h under
+  `$XDG_STATE_HOME/typeburn/update-check.json`, and compares semver.
+- `typeburn version --check-update` explicit flag: always hits the network,
+  prints a human-readable or `--json` result regardless of config.
+- `update_check` config key (boolean, default `false`, opt-in):
+  `typeburn config set update_check on`. When enabled, every TUI launch
+  performs an opportunistic background check (800 ms timeout); if a newer
+  stable release is found, the Result screen shows a muted footer hint.
+- Result-screen update-available footer: `↑ v2.1.0 available — run "typeburn version --check-update"`.
+  Belt-and-suspenders semver injection guard at both cache-load and render time.
+
+### Changed
+
+- Size cap raised from 8 MiB → 10 MiB (net/http adds ~260 KB).
+- `typeburn config list` and `typeburn config set` now include `update_check`.
+- `parseBool` now accepts `on`/`off`/`yes`/`no` in addition to `true`/`false`/`1`/`0`.
+
 ## [2.0.0] - 2026-05-20
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS := -s -w \
 	-X $(MODULE).Commit=$(COMMIT) \
 	-X $(MODULE).Date=$(DATE)
 
-SIZE_LIMIT ?= 8388608
+SIZE_LIMIT ?= 10485760
 
 .PHONY: build run test test-race lint fmt clean version snapshot release size-check notui-noexit-check
 
@@ -47,7 +47,7 @@ version: build
 	@$(BIN_DIR)/$(BINARY) --version
 
 # v2 CLI measurement after cobra/fang/x/term: 5,302,642 bytes on darwin/arm64.
-# Keep an 8 MiB guard so dependency growth is deliberate.
+# v2.1 adds net/http for update-check (~260 KB): cap raised to 10 MiB.
 size-check: build
 	@actual=$$(stat -f%z $(BIN_DIR)/$(BINARY) 2>/dev/null || stat -c%s $(BIN_DIR)/$(BINARY)); \
 	if [ $$actual -gt $(SIZE_LIMIT) ]; then \

--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ a ★ personal best.
 See [docs/cli-reference.md](./docs/cli-reference.md) for the full subcommand
 surface, JSON shapes, exit codes, and raw `--no-tui` limitations.
 
+### Check for updates
+
+```sh
+typeburn version --check-update          # always hits network, human-readable
+typeburn version --check-update --json   # machine-readable JSON
+```
+
+Opt-in automatic check on TUI launch (result cached 24 h):
+
+```sh
+typeburn config set update_check on
+```
+
+When enabled, every TUI launch runs a background check with an 800 ms timeout.
+If a newer stable release is found, the Result screen shows a muted footer hint:
+`↑ v2.1.0 available — run "typeburn version --check-update"`.
+
 The minimum usable terminal size is **60 columns × 20 rows**. If the terminal is
 too small the app shows a resize prompt and resumes automatically once you resize.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -72,10 +72,73 @@ typeburn config list
 typeburn config list --json
 typeburn config get theme
 typeburn config set theme nord
+typeburn config set update_check on
 ```
 
-Keys: `theme`, `default_mode`, `default_length`, `blink_cursor`.
+Keys: `theme`, `default_mode`, `default_length`, `blink_cursor`, `update_check`.
+
+| Key | Values | Default | Notes |
+|---|---|---|---|
+| `theme` | name string | `default` | Built-in theme name |
+| `default_mode` | `time\|words\|quote\|code` | `time` | |
+| `default_length` | positive int | `30` | Seconds or word count |
+| `blink_cursor` | `true\|false` | `false` | |
+| `update_check` | `on\|off` (also `true\|false\|yes\|no\|1\|0`) | `off` | Opt-in opportunistic check |
+
 `config set` is strict: invalid values exit 1 before writing `settings.json`.
+
+### update_check
+
+When `update_check` is `on`, each TUI launch fires an opportunistic GitHub
+release check with an 800 ms timeout. On success the result is cached for 24 h
+at `$XDG_STATE_HOME/typeburn/update-check.json` (default
+`~/.local/state/typeburn/update-check.json`). If a newer stable release exists,
+the Result screen shows a muted footer hint.
+
+The check is **always opt-in**. It is never triggered by `--no-tui` runs.
+
+## Version
+
+```sh
+typeburn version
+typeburn version --json
+typeburn version --check-update
+typeburn version --check-update --json
+```
+
+`--check-update` always hits the network (ignores cache). Output:
+
+Human-readable (no upgrade):
+```
+typeburn v2.0.0 (abc1234, 2026-05-20)  ✓ up to date
+```
+
+Human-readable (upgrade available):
+```
+typeburn v2.0.0 (abc1234, 2026-05-20)
+
+A newer version is available: v2.1.0
+
+Upgrade:
+  brew upgrade typeburn
+  curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
+  go install github.com/bavanchun/Typeburn@latest
+```
+
+JSON schema (`--check-update --json`):
+```json
+{
+  "version": {"version": "v2.0.0", "commit": "abc1234", "date": "2026-05-20T00:00:00Z"},
+  "update_check": {
+    "schema_version": 1,
+    "current": "v2.0.0",
+    "latest": "v2.1.0",
+    "upgrade_available": true,
+    "release_url": "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0",
+    "checked_at": "2026-05-21T10:00:00Z"
+  }
+}
+```
 
 ## Replay
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -4,6 +4,28 @@
 
 ## Package Overview
 
+### `internal/update` — GitHub Release Update Check
+
+**Purpose:** Pure-stdlib (no bubbletea/lipgloss) package that fetches the latest GitHub release, compares semver, and caches the result. Opt-in feature; never called on `--no-tui` paths.
+
+**Key types:**
+- `Release`: GitHub API payload (TagName, Draft, Prerelease, PublishedAt, HTMLURL)
+- `Result`: {SchemaVersion, Current, Latest, UpgradeAvailable, ReleaseURL, CheckedAt}
+
+**Entry points:**
+- `Check(ctx, currentVer, force) (*Result, error)`: returns nil,nil for dev/unknown versions; uses cache unless force=true
+- `FetchLatest(ctx, currentVer) (Release, error)`: raw HTTP call; ErrRateLimit/ErrUpstream sentinels
+- `Compare(a, b string) int`: semver comparison (-1/0/1), tolerates leading v, strips pre-release suffix
+- `IsPrerelease(tag string) bool`: detects -rc/-beta/-alpha/-pre and v0.0.0- prefix
+
+**Cache:** `$XDG_STATE_HOME/typeburn/update-check.json` (default `~/.local/state/typeburn/`), 24 h TTL, 7 d max-age, schema-version + semver re-validation + URL-prefix check on load (injection guard).
+
+**Test seams:** package-level vars `fetchURL` (HTTP endpoint) and `cacheFilePath` (temp dir in tests).
+
+**Files:** `result.go`, `compare.go`, `compare_test.go`, `prerelease.go`, `prerelease_test.go`, `client.go`, `client_test.go`, `cache.go`, `cache_test.go`, `check.go`, `check_test.go`.
+
+---
+
 ### `internal/version` — Build-Time Version Injection
 
 **Purpose:** Expose the release version and commit metadata to the `--version` flag and error messages. Supports two injection paths: ldflags-stamped binaries (GoReleaser, `make release`) and fallback to module build info (bare `go install`).

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -190,6 +190,9 @@
   `version`, `config`, `replay`), JSON outputs, schema-versioned replay logs,
   and raw `run --no-tui`; v1 root aliases remain compatible. Ship date:
   2026-05-20.
+- 🔄 **v2.1.0 (Update Check):** opt-in `update_check` config key, opportunistic
+  TUI launch check (800 ms timeout, 24 h cache), Result-screen footer hint, and
+  `typeburn version --check-update` explicit flag with `--json` support.
 
 ### Next (Optional)
 1. **Gather user feedback** on missing features (Vim motions? more themes?)

--- a/internal/app/code_mode_test.go
+++ b/internal/app/code_mode_test.go
@@ -21,7 +21,7 @@ func codeTestModel(t *testing.T, codeText, codeHint string) Model {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
-	return New(theme.Default(), config.Defaults(), codeText, codeHint)
+	return New(theme.Default(), config.Defaults(), codeText, codeHint, nil)
 }
 
 // TestCodeMode_StartTestMsgRoutesToTyping verifies StartTestMsg{Mode:ModeCode}
@@ -127,7 +127,7 @@ func TestCodeMode_ResultNotNewBest(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
-	m := tea.Model(New(theme.Default(), config.Defaults(), codeText, ""))
+	m := tea.Model(New(theme.Default(), config.Defaults(), codeText, "", nil))
 	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m, _ = m.Update(ui.StartTestMsg{Mode: config.ModeCode, CodeText: codeText})
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bavanchun/Typeburn/internal/config"
 	"github.com/bavanchun/Typeburn/internal/theme"
 	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/internal/update"
 )
 
 // Screen enumerates the top-level screens. Routing switches on this value.
@@ -46,6 +47,10 @@ type Model struct {
 	// (e.g., "text file is empty"). Empty when codeText loaded successfully.
 	codeHint string
 
+	// updateHint is set when an opportunistic check found a newer release.
+	// Nil means no hint to display. Forwarded to ResultModel after each test.
+	updateHint *update.Result
+
 	// quitPrompt is non-nil when the esc-on-Home quit confirmation overlay is
 	// active. ctrl+c always hard-quits regardless of this field.
 	quitPrompt *quitPromptModel
@@ -57,20 +62,23 @@ type Model struct {
 	persistErr string
 }
 
-// New builds the root model with the given theme, settings, and optional code
-// text/hint. codeText is the snippet loaded from --text (empty = Code disabled);
-// codeHint is a user-facing load-failure reason (empty = no error).
-func New(th theme.Theme, settings config.Settings, codeText, codeHint string) Model {
+// New builds the root model with the given theme, settings, optional code
+// text/hint, and an optional update hint.
+// codeText is the snippet loaded from --text (empty = Code disabled);
+// codeHint is a user-facing load-failure reason (empty = no error);
+// updateHint is non-nil when an opportunistic check found a newer release.
+func New(th theme.Theme, settings config.Settings, codeText, codeHint string, updateHint *update.Result) Model {
 	km := config.DefaultKeymap()
 	home := ui.NewHome(settings, th, km, codeText, codeHint)
 	m := Model{
-		screen:   ScreenHome,
-		theme:    th,
-		keys:     km,
-		settings: settings,
-		home:     home,
-		codeText: codeText,
-		codeHint: codeHint,
+		screen:     ScreenHome,
+		theme:      th,
+		keys:       km,
+		settings:   settings,
+		home:       home,
+		codeText:   codeText,
+		codeHint:   codeHint,
+		updateHint: updateHint,
 	}
 	m.sett = ui.NewSettings(settings, th, km)
 	return m

--- a/internal/app/model_history.go
+++ b/internal/app/model_history.go
@@ -46,7 +46,7 @@ func (m Model) handleResultMsg(msg ui.ResultMsg) Model {
 		m.persistErr = "Couldn't save result to disk"
 	}
 
-	m.result = ui.NewResult(msg, m.theme, m.keys).WithBest(isBest).SetSize(m.w, m.h)
+	m.result = ui.NewResult(msg, m.theme, m.keys).WithBest(isBest).WithUpdateHint(m.updateHint).SetSize(m.w, m.h)
 	m.screen = ScreenResult
 	return m
 }

--- a/internal/app/model_settings.go
+++ b/internal/app/model_settings.go
@@ -5,16 +5,18 @@ import (
 	"github.com/bavanchun/Typeburn/internal/storage"
 	"github.com/bavanchun/Typeburn/internal/theme"
 	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/internal/update"
 )
 
 // NewFromDisk builds the root model loading persisted settings from disk.
 // Falls back to config.Defaults() if the file is missing or corrupt.
 // codeText is the loaded snippet (empty string = no code mode); codeHint is
-// a user-facing reason string when loading failed (empty = no error).
-func NewFromDisk(codeText, codeHint string) Model {
+// a user-facing reason string when loading failed (empty = no error);
+// updateHint is non-nil when an opportunistic check found a newer release.
+func NewFromDisk(codeText, codeHint string, updateHint *update.Result) Model {
 	s := storage.LoadSettings()
 	th := theme.Load(s.Theme, theme.EnvNoColor())
-	return New(th, s, codeText, codeHint)
+	return New(th, s, codeText, codeHint, updateHint)
 }
 
 // applySettings applies a settings change to the LIVE model the program

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -7,11 +7,14 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/metrics"
 	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/internal/update"
 )
 
 func newTestModel() Model {
-	return New(theme.Default(), config.Defaults(), "", "")
+	return New(theme.Default(), config.Defaults(), "", "", nil)
 }
 
 func press(code rune, mod tea.KeyMod) tea.KeyPressMsg {
@@ -67,6 +70,39 @@ func TestCtrlCQuits(t *testing.T) {
 	if _, ok := cmd().(tea.QuitMsg); !ok {
 		t.Fatalf("ctrl+c should return tea.Quit, got %T", cmd())
 	}
+}
+
+// TestUpdateHint_ForwardedToResult checks that an updateHint set on Model is
+// forwarded to the ResultModel via handleResultMsg.
+func TestUpdateHint_ForwardedToResult(t *testing.T) {
+	hint := &update.Result{Latest: "v2.1.0", UpgradeAvailable: true}
+	m := New(theme.Default(), config.Defaults(), "", "", hint)
+
+	resultMsg := ui.ResultMsg{
+		Result: metrics.Result{NetWPM: 80, Accuracy: 95, DurationMs: 30000},
+		Mode:   config.ModeTime,
+		Length: 30,
+	}
+	m2 := m.handleResultMsg(resultMsg)
+	if m2.result.UpdateHint() == nil {
+		t.Error("updateHint should be forwarded to ResultModel")
+	}
+}
+
+// TestUpdateHint_NilSafe checks that nil updateHint doesn't cause panics via handleResultMsg.
+func TestUpdateHint_NilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handleResultMsg panicked with nil updateHint: %v", r)
+		}
+	}()
+	m := New(theme.Default(), config.Defaults(), "", "", nil)
+	resultMsg := ui.ResultMsg{
+		Result: metrics.Result{NetWPM: 80, Accuracy: 95, DurationMs: 30000},
+		Mode:   config.ModeTime,
+		Length: 30,
+	}
+	_ = m.handleResultMsg(resultMsg)
 }
 
 func TestViewRendersActiveScreen(t *testing.T) {

--- a/internal/app/persistence_notice_test.go
+++ b/internal/app/persistence_notice_test.go
@@ -32,7 +32,7 @@ func TestPersistNotice_HistoryFailureShownThenDismissed(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", blockedXDG(t))
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	m := tea.Model(New(theme.Default(), config.Defaults(), "", ""))
+	m := tea.Model(New(theme.Default(), config.Defaults(), "", "", nil))
 	m = sm_sendSize(m, 80, 24)
 
 	m, _ = m.Update(ui.ResultMsg{
@@ -65,7 +65,7 @@ func TestPersistNotice_SettingsFailureSetsError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", blockedXDG(t))
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	m := New(theme.Default(), config.Defaults(), "", "")
+	m := New(theme.Default(), config.Defaults(), "", "", nil)
 	s := m.settings
 	s.BlinkCursor = !s.BlinkCursor
 	m = m.applySettings(s) // value receiver → use the returned model

--- a/internal/app/phase09_polish_test.go
+++ b/internal/app/phase09_polish_test.go
@@ -213,7 +213,7 @@ func TestQuitPromptView_ContainsOptions(t *testing.T) {
 // correctly under NO_COLOR (attribute-only theme, no hex colors).
 func TestNoColor_DegradedNotice(t *testing.T) {
 	th := theme.Load("default", true) // noColor=true
-	m := New(th, config.Defaults(), "", "")
+	m := New(th, config.Defaults(), "", "", nil)
 	m2, _ := m.Update(tea.WindowSizeMsg{Width: 50, Height: 15})
 	view := m2.(Model).View().Content
 	if !strings.Contains(view, "Terminal too small") {
@@ -229,7 +229,7 @@ func TestNoColor_DegradedNotice(t *testing.T) {
 // (the focus signal that works without color) under NO_COLOR.
 func TestNoColor_HomeScreen(t *testing.T) {
 	th := theme.Load("default", true) // noColor=true
-	m := New(th, config.Defaults(), "", "")
+	m := New(th, config.Defaults(), "", "", nil)
 	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	view := m2.(Model).View().Content
 	// The active tab must have the ▎ marker (works without color per §5.5).
@@ -241,7 +241,7 @@ func TestNoColor_HomeScreen(t *testing.T) {
 // TestNoColor_SettingsScreen verifies selected row still has ▎ under NO_COLOR.
 func TestNoColor_SettingsScreen(t *testing.T) {
 	th := theme.Load("default", true)
-	m := New(th, config.Defaults(), "", "")
+	m := New(th, config.Defaults(), "", "", nil)
 	tm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	tm, _ = tm.Update(press('2', 0)) // → Settings
 	view := tm.(Model).View().Content

--- a/internal/app/smoke_test.go
+++ b/internal/app/smoke_test.go
@@ -22,7 +22,7 @@ func sandboxedModel(t *testing.T) Model {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
-	return New(theme.Default(), config.Defaults(), "", "")
+	return New(theme.Default(), config.Defaults(), "", "", nil)
 }
 
 // sm_sendSize sends a WindowSizeMsg and returns the new model.
@@ -161,7 +161,7 @@ func TestSmoke_ResultMsg_HistoryPersisted(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmp)
 	t.Setenv("NO_COLOR", "")
 
-	m := tea.Model(New(theme.Default(), config.Defaults(), "", ""))
+	m := tea.Model(New(theme.Default(), config.Defaults(), "", "", nil))
 	m = sm_sendSize(m, 80, 24)
 
 	m, _ = m.Update(ui.ResultMsg{
@@ -209,7 +209,7 @@ func TestSmoke_Settings_ThemeRowCycles(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmp)
 	t.Setenv("NO_COLOR", "")
 
-	m := tea.Model(New(theme.Default(), config.Defaults(), "", ""))
+	m := tea.Model(New(theme.Default(), config.Defaults(), "", "", nil))
 	m = sm_sendSize(m, 80, 24)
 
 	// Navigate to Settings (Theme row sel=0 by default).
@@ -240,7 +240,7 @@ func TestSmoke_Settings_ThemeAppliesLive(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmp)
 	t.Setenv("NO_COLOR", "")
 
-	m := tea.Model(New(theme.Default(), config.Defaults(), "", ""))
+	m := tea.Model(New(theme.Default(), config.Defaults(), "", "", nil))
 	m = sm_sendSize(m, 100, 40)
 	m, _ = sm_sendKey(m, '2', 0) // → Settings, Theme row (sel=0)
 
@@ -269,7 +269,7 @@ func TestSmoke_Settings_BlinkAppliesLive(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
 
-	m := tea.Model(New(theme.Default(), config.Defaults(), "", ""))
+	m := tea.Model(New(theme.Default(), config.Defaults(), "", "", nil))
 	m = sm_sendSize(m, 100, 40)
 	m, _ = sm_sendKey(m, '2', 0) // Settings
 

--- a/internal/cli/cmd_config.go
+++ b/internal/cli/cmd_config.go
@@ -89,6 +89,7 @@ func configRows(s config.Settings) [][]string {
 		{"default_mode", string(s.DefaultMode)},
 		{"default_length", strconv.Itoa(s.DefaultLength)},
 		{"blink_cursor", strconv.FormatBool(s.BlinkCursor)},
+		{"update_check", strconv.FormatBool(s.UpdateCheck)},
 	}
 }
 
@@ -126,9 +127,15 @@ func configSet(s *config.Settings, key, value string) error {
 	case "blink_cursor":
 		v, ok := parseBool(value)
 		if !ok {
-			return usageError("blink_cursor must be true, false, 1, or 0")
+			return usageError("blink_cursor must be true, false, 1, 0, on, off, yes, or no")
 		}
 		s.BlinkCursor = v
+	case "update_check":
+		v, ok := parseBool(value)
+		if !ok {
+			return usageError("update_check must be true, false, 1, 0, on, off, yes, or no")
+		}
+		s.UpdateCheck = v
 	default:
 		return usageError("unknown config key %q", key)
 	}
@@ -136,10 +143,10 @@ func configSet(s *config.Settings, key, value string) error {
 }
 
 func parseBool(value string) (bool, bool) {
-	switch value {
-	case "true", "1":
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "1", "on", "yes":
 		return true, true
-	case "false", "0":
+	case "false", "0", "off", "no":
 		return false, true
 	default:
 		return false, false

--- a/internal/cli/cmd_config_test.go
+++ b/internal/cli/cmd_config_test.go
@@ -72,6 +72,7 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 		{"default_mode", "bad"},
 		{"default_length", "999"},
 		{"blink_cursor", "maybe"},
+		{"update_check", "maybe"},
 		{"unknown", "value"},
 	}
 	for _, tt := range tests {
@@ -81,5 +82,79 @@ func TestConfigRejectsInvalidValues(t *testing.T) {
 				t.Fatal("expected error")
 			}
 		})
+	}
+}
+
+func TestUpdateCheckSetGet(t *testing.T) {
+	settings := config.Defaults()
+	var out bytes.Buffer
+
+	execRoot := func(args ...string) error {
+		out.Reset()
+		root := NewRoot(
+			WithWriters(&out, &bytes.Buffer{}),
+			WithHomeRunner(func(context.Context, string, string) error { return nil }),
+			WithSettingsStore(
+				func() config.Settings { return settings },
+				func(s config.Settings) error { settings = s; return nil },
+			),
+		)
+		root.SetArgs(args)
+		return root.Execute()
+	}
+
+	// Default is false.
+	if err := execRoot("config", "get", "update_check"); err != nil {
+		t.Fatalf("get update_check: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "false" {
+		t.Fatalf("default update_check: want false, got %q", out.String())
+	}
+
+	// Set to true and read back.
+	if err := execRoot("config", "set", "update_check", "true"); err != nil {
+		t.Fatalf("set update_check true: %v", err)
+	}
+	if err := execRoot("config", "get", "update_check"); err != nil {
+		t.Fatalf("get update_check after set: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "true" {
+		t.Fatalf("after set: want true, got %q", out.String())
+	}
+
+	// Test parseBool directly for all accepted forms.
+	for _, trueVal := range []string{"true", "1", "on", "yes", "TRUE", "ON", " yes "} {
+		v, ok := parseBool(trueVal)
+		if !ok || !v {
+			t.Errorf("parseBool(%q) = (%v, %v), want (true, true)", trueVal, v, ok)
+		}
+	}
+	for _, falseVal := range []string{"false", "0", "off", "no", "FALSE", "OFF", " no "} {
+		v, ok := parseBool(falseVal)
+		if !ok || v {
+			t.Errorf("parseBool(%q) = (%v, %v), want (false, true)", falseVal, v, ok)
+		}
+	}
+	for _, badVal := range []string{"maybe", "yes1", "2", ""} {
+		_, ok := parseBool(badVal)
+		if ok {
+			t.Errorf("parseBool(%q) should reject", badVal)
+		}
+	}
+}
+
+func TestConfigListIncludesUpdateCheck(t *testing.T) {
+	var out bytes.Buffer
+	root := NewRoot(
+		WithWriters(&out, &bytes.Buffer{}),
+		WithHomeRunner(func(context.Context, string, string) error { return nil }),
+		WithSettingsStore(func() config.Settings { return config.Defaults() }, nil),
+	)
+	root.SetArgs([]string{"config", "list"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("config list: %v", err)
+	}
+	if !strings.Contains(out.String(), "update_check") {
+		t.Errorf("config list output missing update_check:\n%s", out.String())
 	}
 }

--- a/internal/cli/cmd_run.go
+++ b/internal/cli/cmd_run.go
@@ -81,7 +81,8 @@ func runTUICommand(ctx context.Context, e env, req runRequest) error {
 		}
 		codeText = text
 	}
-	model := app.New(theme.Load(themeName, theme.EnvNoColor()), settings, codeText, "")
+	hint := resolveUpdateHint(ctx, settings)
+	model := app.New(theme.Load(themeName, theme.EnvNoColor()), settings, codeText, "", hint)
 	start := ui.StartTestMsg{
 		Mode: req.mode, Length: req.length, QuoteLen: req.quoteLen, CodeText: codeText,
 	}

--- a/internal/cli/cmd_version.go
+++ b/internal/cli/cmd_version.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/bavanchun/Typeburn/internal/update"
 	"github.com/bavanchun/Typeburn/internal/version"
 	"github.com/spf13/cobra"
 )
 
+// checkFn is the update.Check function; overridden in tests via this seam.
+var checkFn = update.Check
+
 func newVersionCmd() *cobra.Command {
-	var asJSON bool
+	var asJSON, checkUpdate bool
 	cmd := &cobra.Command{
 		Use:           "version",
 		Short:         "Print version information",
@@ -18,19 +22,36 @@ func newVersionCmd() *cobra.Command {
 		SilenceUsage:  true,
 		Args:          cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVersion(cmd, asJSON)
+			return runVersion(cmd, asJSON, checkUpdate)
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "print version as JSON")
+	cmd.Flags().BoolVar(&checkUpdate, "check-update", false, "check GitHub for a newer release")
 	return cmd
 }
 
-func runVersion(cmd *cobra.Command, asJSON bool) error {
-	if !asJSON {
+func runVersion(cmd *cobra.Command, asJSON, checkUpdate bool) error {
+	if !asJSON && !checkUpdate {
 		fmt.Fprintln(cmd.OutOrStdout(), version.String())
 		return nil
 	}
+
+	// version.Resolve() returns Info{Version, Commit, Date}.
 	info := version.Resolve()
+
+	if !checkUpdate {
+		return renderVersionJSON(cmd, info)
+	}
+
+	result, err := checkFn(cmd.Context(), info.Version, true)
+
+	if asJSON {
+		return renderVersionCheckJSON(cmd, info, result, err)
+	}
+	return renderVersionCheckHuman(cmd, info.Version, result, err)
+}
+
+func renderVersionJSON(cmd *cobra.Command, info version.Info) error {
 	out := struct {
 		Version   string `json:"version"`
 		Commit    string `json:"commit"`
@@ -49,4 +70,78 @@ func runVersion(cmd *cobra.Command, asJSON bool) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
+}
+
+func renderVersionCheckJSON(cmd *cobra.Command, info version.Info, result *update.Result, checkErr error) error {
+	versionObj := struct {
+		Version   string `json:"version"`
+		Commit    string `json:"commit"`
+		Date      string `json:"date"`
+		GoVersion string `json:"go_version"`
+		OS        string `json:"os"`
+		Arch      string `json:"arch"`
+	}{
+		Version:   info.Version,
+		Commit:    info.Commit,
+		Date:      info.Date,
+		GoVersion: runtime.Version(),
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+
+	if checkErr != nil {
+		out := struct {
+			Version     any `json:"version"`
+			UpdateCheck any `json:"update_check"`
+		}{
+			Version: versionObj,
+			UpdateCheck: struct {
+				Error string `json:"error"`
+			}{checkErr.Error()},
+		}
+		_ = enc.Encode(out)
+		return checkErr
+	}
+	if result == nil {
+		out := struct {
+			Version     any `json:"version"`
+			UpdateCheck any `json:"update_check"`
+		}{
+			Version: versionObj,
+			UpdateCheck: struct {
+				Skipped string `json:"skipped"`
+			}{"build has no release version"},
+		}
+		return enc.Encode(out)
+	}
+	out := struct {
+		Version     any            `json:"version"`
+		UpdateCheck *update.Result `json:"update_check"`
+	}{
+		Version:     versionObj,
+		UpdateCheck: result,
+	}
+	return enc.Encode(out)
+}
+
+func renderVersionCheckHuman(cmd *cobra.Command, currentVer string, result *update.Result, checkErr error) error {
+	// Always print the plain version banner first.
+	fmt.Fprintln(cmd.OutOrStdout(), version.String())
+
+	switch {
+	case result == nil && checkErr == nil:
+		fmt.Fprintln(cmd.OutOrStdout(), "version check skipped: build has no release version.")
+	case checkErr != nil:
+		fmt.Fprintf(cmd.ErrOrStderr(), "could not check for updates: %v\n", checkErr)
+	case result.UpgradeAvailable:
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"\ntypeburn %s is available (you have %s).\nRelease notes: %s\nUpgrade with one of:\n  brew upgrade typeburn\n  curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh\n  go install github.com/bavanchun/Typeburn@latest\n",
+			result.Latest, currentVer, result.ReleaseURL,
+		)
+	default:
+		fmt.Fprintf(cmd.OutOrStdout(), "you are on the latest version (%s).\n", currentVer)
+	}
+	return nil
 }

--- a/internal/cli/cmd_version_test.go
+++ b/internal/cli/cmd_version_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bavanchun/Typeburn/internal/update"
+)
+
+func stubCheck(result *update.Result, err error) func(ctx context.Context, ver string, force bool) (*update.Result, error) {
+	return func(_ context.Context, _ string, _ bool) (*update.Result, error) {
+		return result, err
+	}
+}
+
+func versionRoot(t *testing.T, out, errOut *bytes.Buffer, args ...string) error {
+	t.Helper()
+	root := NewRoot(
+		WithWriters(out, errOut),
+		WithHomeRunner(func(context.Context, string, string) error { return nil }),
+	)
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+func TestVersionJSON_Unchanged(t *testing.T) {
+	// --json without --check-update must produce the same shape as v2.0.0.
+	var out bytes.Buffer
+	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--json"); err != nil {
+		t.Fatalf("version --json: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out.String())
+	}
+	for _, key := range []string{"version", "commit", "date", "go_version", "os", "arch"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("missing key %q in --json output", key)
+		}
+	}
+	if _, hasUpdate := got["update_check"]; hasUpdate {
+		t.Error("update_check must NOT appear in plain --json output (backwards-compat)")
+	}
+}
+
+func TestVersionCheckUpdate_UpgradeAvailable(t *testing.T) {
+	orig := checkFn
+	checkFn = stubCheck(&update.Result{
+		Current:          "v2.0.0",
+		Latest:           "v2.1.0",
+		UpgradeAvailable: true,
+		ReleaseURL:       "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0",
+		CheckedAt:        time.Now().UTC(),
+	}, nil)
+	defer func() { checkFn = orig }()
+
+	var out bytes.Buffer
+	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--check-update"); err != nil {
+		t.Fatalf("version --check-update: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, "v2.1.0") {
+		t.Errorf("expected v2.1.0 in output, got:\n%s", body)
+	}
+	if !strings.Contains(body, "brew upgrade typeburn") {
+		t.Errorf("expected upgrade hint, got:\n%s", body)
+	}
+}
+
+func TestVersionCheckUpdate_UpToDate(t *testing.T) {
+	orig := checkFn
+	checkFn = stubCheck(&update.Result{
+		Current:   "v2.0.0",
+		Latest:    "v2.0.0",
+		CheckedAt: time.Now().UTC(),
+	}, nil)
+	defer func() { checkFn = orig }()
+
+	var out bytes.Buffer
+	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--check-update"); err != nil {
+		t.Fatalf("version --check-update: %v", err)
+	}
+	if !strings.Contains(out.String(), "latest version") {
+		t.Errorf("expected 'latest version' in output, got:\n%s", out.String())
+	}
+}
+
+func TestVersionCheckUpdate_DevSkip(t *testing.T) {
+	orig := checkFn
+	checkFn = stubCheck(nil, nil) // nil,nil = dev skip
+	defer func() { checkFn = orig }()
+
+	var out bytes.Buffer
+	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--check-update"); err != nil {
+		t.Fatalf("version --check-update: %v", err)
+	}
+	if !strings.Contains(out.String(), "skipped") {
+		t.Errorf("expected 'skipped' in output, got:\n%s", out.String())
+	}
+}
+
+func TestVersionCheckUpdate_Error(t *testing.T) {
+	orig := checkFn
+	checkFn = stubCheck(nil, errors.New("network unreachable"))
+	defer func() { checkFn = orig }()
+
+	var out, errOut bytes.Buffer
+	// Human mode: error goes to stderr, exit code 0.
+	if err := versionRoot(t, &out, &errOut, "version", "--check-update"); err != nil {
+		t.Fatalf("version --check-update with error should exit 0, got: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "could not check for updates") {
+		t.Errorf("expected error on stderr, got:\n%s", errOut.String())
+	}
+}
+
+func TestVersionCheckUpdate_JSONWrapper(t *testing.T) {
+	orig := checkFn
+	checkFn = stubCheck(&update.Result{
+		SchemaVersion:    1,
+		Current:          "v2.0.0",
+		Latest:           "v2.1.0",
+		UpgradeAvailable: true,
+		ReleaseURL:       "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0",
+		CheckedAt:        time.Now().UTC(),
+	}, nil)
+	defer func() { checkFn = orig }()
+
+	var out bytes.Buffer
+	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--json", "--check-update"); err != nil {
+		t.Fatalf("version --json --check-update: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out.String())
+	}
+	if _, ok := got["version"]; !ok {
+		t.Error("wrapper missing 'version' key")
+	}
+	if _, ok := got["update_check"]; !ok {
+		t.Error("wrapper missing 'update_check' key")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,7 @@ func NewRoot(opts ...Option) *cobra.Command {
 			}
 			printVersion, textPath := Decide(args)
 			if printVersion {
-				return runVersion(cmd, false)
+				return runVersion(cmd, false, false)
 			}
 			return launchHome(cmd.Context(), e, textPath)
 		},

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/bavanchun/Typeburn/internal/codetext"
 	"github.com/bavanchun/Typeburn/internal/config"
 	"github.com/bavanchun/Typeburn/internal/storage"
+	"github.com/bavanchun/Typeburn/internal/update"
+	"github.com/bavanchun/Typeburn/internal/version"
 )
 
 type env struct {
@@ -77,8 +80,29 @@ func WithModelRunner(run func(context.Context, tea.Model) error) Option {
 	return func(e *env) { e.runModel = run }
 }
 
+// resolveUpdateHint performs the opportunistic update check when the user has
+// opted in (settings.UpdateCheck == true) and the build has a real release version.
+// Uses an 800ms timeout — tighter than the explicit --check-update path (1.5s) so
+// TUI launch latency on a cache miss stays imperceptible.
+// Returns nil on any error or dev/pseudo-version — caller always gets a clean hint or nothing.
+func resolveUpdateHint(ctx context.Context, settings config.Settings) *update.Result {
+	if !settings.UpdateCheck {
+		return nil
+	}
+	ver := version.Resolve().Version
+	ctx, cancel := context.WithTimeout(ctx, 800*time.Millisecond)
+	defer cancel()
+	r, err := update.Check(ctx, ver, false)
+	if err != nil || r == nil || !r.UpgradeAvailable {
+		return nil
+	}
+	return r
+}
+
 func runHomeTUI(ctx context.Context, codeText, codeHint string) error {
-	return runModelTUI(ctx, app.NewFromDisk(codeText, codeHint))
+	settings := storage.LoadSettings()
+	hint := resolveUpdateHint(ctx, settings)
+	return runModelTUI(ctx, app.NewFromDisk(codeText, codeHint, hint))
 }
 
 func runModelTUI(ctx context.Context, model tea.Model) error {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -30,13 +30,15 @@ func LengthsFor(m Mode) []int {
 	}
 }
 
-// Settings is the persisted user configuration. v1 exposes exactly these four
-// controls; nothing else is configurable.
+// Settings is the persisted user configuration.
 type Settings struct {
 	Theme         string `json:"theme"`          // one of theme.Available()
 	DefaultMode   Mode   `json:"default_mode"`   // seeds the Home screen
 	DefaultLength int    `json:"default_length"` // valid for DefaultMode
 	BlinkCursor   bool   `json:"blink_cursor"`   // typing-screen cursor blink
+	// UpdateCheck enables an opt-in opportunistic update check on TUI launch.
+	// Default is false to preserve offline-first posture.
+	UpdateCheck bool `json:"update_check"`
 }
 
 // Defaults returns the baseline configuration used on first run or whenever
@@ -47,6 +49,7 @@ func Defaults() Settings {
 		DefaultMode:   ModeTime,
 		DefaultLength: 30,
 		BlinkCursor:   false,
+		UpdateCheck:   false,
 	}
 }
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -1,6 +1,12 @@
 package config
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
+
+// jsonUnmarshal is a thin alias so test bodies stay concise.
+func jsonUnmarshal(data []byte, v any) error { return json.Unmarshal(data, v) }
 
 // TestDefaults_Values verifies the out-of-the-box settings.
 func TestDefaults_Values(t *testing.T) {
@@ -203,6 +209,27 @@ func TestXDGPaths_XDGEnvTakesPrecedence(t *testing.T) {
 	// Path must start with the XDG override, not ~/.config.
 	if len(got) < len(dir) || got[:len(dir)] != dir {
 		t.Errorf("ConfigDir should be under %q, got %q", dir, got)
+	}
+}
+
+// TestDefaults_UpdateCheckFalse verifies update_check defaults to false (opt-in).
+func TestDefaults_UpdateCheckFalse(t *testing.T) {
+	if Defaults().UpdateCheck {
+		t.Error("UpdateCheck: want false by default (opt-in)")
+	}
+}
+
+// TestLoadSettings_MissingUpdateCheckField verifies pre-v2.1 settings files
+// (without the update_check key) load with UpdateCheck == false.
+func TestLoadSettings_MissingUpdateCheckField(t *testing.T) {
+	// JSON without update_check — simulates an existing v2.0 settings file.
+	raw := `{"theme":"default","default_mode":"time","default_length":30,"blink_cursor":false}`
+	var s Settings
+	if err := jsonUnmarshal([]byte(raw), &s); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if s.UpdateCheck {
+		t.Error("UpdateCheck: want false when field is absent from JSON")
 	}
 }
 

--- a/internal/config/xdg-paths.go
+++ b/internal/config/xdg-paths.go
@@ -21,6 +21,12 @@ func DataDir() (string, error) {
 	return resolveDir("XDG_DATA_HOME", filepath.Join(".local", "share"))
 }
 
+// StateDir returns the directory for runtime state (e.g. update-check cache):
+// $XDG_STATE_HOME/typeburn, falling back to ~/.local/state/typeburn.
+func StateDir() (string, error) {
+	return resolveDir("XDG_STATE_HOME", filepath.Join(".local", "state"))
+}
+
 // resolveDir prefers an absolute XDG env var; otherwise it joins the user's
 // home with the conventional fallback subpath. macOS has no XDG vars by
 // default, so the HOME fallback is the normal path there.

--- a/internal/ui/screen_result.go
+++ b/internal/ui/screen_result.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bavanchun/Typeburn/internal/config"
 	"github.com/bavanchun/Typeburn/internal/metrics"
 	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/update"
 	"github.com/bavanchun/Typeburn/internal/words"
 )
 
@@ -22,6 +23,10 @@ type ResultModel struct {
 	quoteLen words.QuoteLen
 	codeText string // ModeCode snippet, so restart-same re-runs it (not "")
 	isBest   bool   // set externally by Phase 8; false = badge hidden
+
+	// updateHint is set when an opportunistic check found a newer release.
+	// Nil means no footer hint. Set via WithUpdateHint after NewResult.
+	updateHint *update.Result
 
 	w, h int
 	th   theme.Theme
@@ -52,6 +57,17 @@ func (m ResultModel) SetSize(w, h int) ResultModel {
 // Called by the root after history persistence (Phase 8).
 func (m ResultModel) WithBest(best bool) ResultModel {
 	m.isBest = best
+	return m
+}
+
+// UpdateHint returns the current update hint (may be nil).
+func (m ResultModel) UpdateHint() *update.Result { return m.updateHint }
+
+// WithUpdateHint attaches an update hint to the result model.
+// The hint renders as a single muted footer line if non-nil and the version
+// string passes semver validation (injection guard applied at render time too).
+func (m ResultModel) WithUpdateHint(hint *update.Result) ResultModel {
+	m.updateHint = hint
 	return m
 }
 

--- a/internal/ui/screen_result_test.go
+++ b/internal/ui/screen_result_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bavanchun/Typeburn/internal/config"
 	"github.com/bavanchun/Typeburn/internal/metrics"
 	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/update"
 	"github.com/bavanchun/Typeburn/internal/words"
 )
 
@@ -324,6 +325,55 @@ func TestResultView_NoZeroSize(t *testing.T) {
 	m := newTestResult()
 	m.w, m.h = 0, 0
 	_ = m.View()
+}
+
+// TestResultView_UpdateHint_Absent checks no footer hint line when updateHint is nil.
+func TestResultView_UpdateHint_Absent(t *testing.T) {
+	m := newTestResult() // updateHint is nil by default
+	view := m.View()
+	if strings.Contains(view, "available") {
+		t.Errorf("expected no update hint in view, got:\n%s", view)
+	}
+}
+
+// TestResultView_UpdateHint_Present checks the footer hint renders version + command.
+func TestResultView_UpdateHint_Present(t *testing.T) {
+	hint := &update.Result{
+		Current:          "v2.0.0",
+		Latest:           "v2.1.0",
+		UpgradeAvailable: true,
+	}
+	m := newTestResult().WithUpdateHint(hint)
+	view := m.View()
+	if !strings.Contains(view, "v2.1.0") {
+		t.Errorf("expected version in hint, view:\n%s", view)
+	}
+	if !strings.Contains(view, "typeburn version --check-update") {
+		t.Errorf("expected command in hint, view:\n%s", view)
+	}
+}
+
+// TestRenderUpdateHint_InjectionGuard checks that non-semver Latest is silently suppressed.
+func TestRenderUpdateHint_InjectionGuard(t *testing.T) {
+	cases := []struct {
+		name   string
+		latest string
+	}{
+		{"ansi escape", "\x1b[31mv2.1.0\x1b[0m"},
+		{"shell injection", "v2.1.0; rm -rf /"},
+		{"empty string", ""},
+		{"plain text", "latest"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hint := &update.Result{Latest: c.latest, UpgradeAvailable: true}
+			m := newTestResult().WithUpdateHint(hint)
+			got := m.renderUpdateHint()
+			if got != "" {
+				t.Errorf("expected empty for invalid semver %q, got %q", c.latest, got)
+			}
+		})
+	}
 }
 
 // TestAccColorRole checks the accuracy color thresholds.

--- a/internal/ui/screen_result_view.go
+++ b/internal/ui/screen_result_view.go
@@ -3,12 +3,18 @@ package ui
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 
 	"charm.land/lipgloss/v2"
 
 	"github.com/bavanchun/Typeburn/internal/theme"
 )
+
+// validSemverFooter rejects any version string that could carry ANSI/control
+// sequences before it reaches the TUI. Belt-and-suspenders on top of the cache
+// load-time guard in internal/update.
+var validSemverFooter = regexp.MustCompile(`^v?\d+\.\d+\.\d+([-+.][\w.-]+)?$`)
 
 // resultHints returns the footer hint set for the result screen per mockups §3.
 func resultHints() []Hint {
@@ -25,12 +31,17 @@ func resultHints() []Hint {
 // Layout mirrors mockups §3.
 func (m ResultModel) View() string {
 	footer := RenderFooter(resultHints(), m.w, m.th)
+	updateLine := m.renderUpdateHint()
 
 	panel := m.renderPanel()
 
 	// Vertical padding: pin footer to bottom.
 	panelLines := strings.Count(panel, "\n") + 1
-	used := panelLines + 1 + 1 // panel + blank + footer
+	updateLineCount := 0
+	if updateLine != "" {
+		updateLineCount = 1
+	}
+	used := panelLines + 1 + updateLineCount + 1 // panel + blank + [update hint +] footer
 	spacer := m.h - used
 	if spacer < 1 {
 		spacer = 1
@@ -39,12 +50,30 @@ func (m ResultModel) View() string {
 	var b strings.Builder
 	b.WriteString(panel)
 	b.WriteString(strings.Repeat("\n", spacer))
+	if updateLine != "" {
+		b.WriteString(updateLine)
+		b.WriteString("\n")
+	}
 	b.WriteString(footer)
 
 	if m.w > 0 && m.h > 0 {
 		return lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, b.String())
 	}
 	return b.String()
+}
+
+// renderUpdateHint returns the update-available footer line, or "" if no hint
+// or if the version string fails semver validation (injection guard).
+func (m ResultModel) renderUpdateHint() string {
+	if m.updateHint == nil {
+		return ""
+	}
+	latest := m.updateHint.Latest
+	if !validSemverFooter.MatchString(latest) {
+		return ""
+	}
+	hint := fmt.Sprintf("↑ %s available — run \"typeburn version --check-update\"", latest)
+	return m.th.Style(theme.RoleTextMuted).Render(hint)
 }
 
 // renderPanel builds the rounded-border result panel with all content sections.

--- a/internal/update/cache.go
+++ b/internal/update/cache.go
@@ -1,0 +1,130 @@
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+)
+
+const (
+	cacheSchemaVersion = 1
+	cacheTTL           = 24 * time.Hour
+	cacheMaxAge        = 7 * 24 * time.Hour
+)
+
+// validSemverRe validates cached version strings before rendering into the TUI.
+var validSemverRe = regexp.MustCompile(`^v?\d+\.\d+\.\d+([-+.][\w.-]+)?$`)
+
+const releaseURLPrefix = "https://github.com/bavanchun/Typeburn/"
+
+// cacheFilePath is a var so tests can override it via t.TempDir().
+var cacheFilePath = ""
+
+func getCachePath() (string, error) {
+	if cacheFilePath != "" {
+		return cacheFilePath, nil
+	}
+	dir, err := config.StateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "update-check.json"), nil
+}
+
+// cacheLoad reads and validates the on-disk cache.
+// Returns (result, true) if the cache is present, valid, and within TTL.
+// Returns (nil, false) on any error, schema mismatch, validation failure, or expiry.
+func cacheLoad() (*Result, bool) {
+	path, err := getCachePath()
+	if err != nil {
+		return nil, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	var r Result
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, false
+	}
+	if r.SchemaVersion != cacheSchemaVersion {
+		return nil, false
+	}
+	// Re-validate values before they can reach the TUI footer (injection guard).
+	if r.Latest != "" && !validSemverRe.MatchString(r.Latest) {
+		return nil, false
+	}
+	if r.ReleaseURL != "" && !strings.HasPrefix(r.ReleaseURL, releaseURLPrefix) {
+		return nil, false
+	}
+	// Clock-skew-aware TTL: reject future-dated and wildly stale entries.
+	now := time.Now().UTC()
+	age := now.Sub(r.CheckedAt)
+	if age < 0 || age > cacheMaxAge {
+		return nil, false
+	}
+	if age < cacheTTL {
+		return &r, true
+	}
+	return nil, false
+}
+
+// cacheSave atomically persists r to the update-check cache file.
+// Creates the parent directory if needed. Silent-degrade: callers ignore errors.
+func cacheSave(r *Result) error {
+	path, err := getCachePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("update: mkdir cache dir: %w", err)
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("update: marshal cache: %w", err)
+	}
+	return atomicWriteCache(path, data)
+}
+
+// atomicWriteCache writes data to path atomically. Uses O_EXCL to prevent
+// symlink-race attacks; PID suffix avoids temp-name collision on concurrent saves.
+func atomicWriteCache(path string, data []byte) error {
+	tmp := fmt.Sprintf("%s.%d.tmp", path, os.Getpid())
+
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if os.IsExist(err) {
+			_ = os.Remove(tmp)
+			f, err = os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+		}
+		if err != nil {
+			return fmt.Errorf("update: create cache temp: %w", err)
+		}
+	}
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("update: write cache temp: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("update: sync cache temp: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("update: close cache temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("update: rename cache: %w", err)
+	}
+	return nil
+}

--- a/internal/update/cache_test.go
+++ b/internal/update/cache_test.go
@@ -1,0 +1,168 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func withTempCache(t *testing.T) func() {
+	t.Helper()
+	dir := t.TempDir()
+	orig := cacheFilePath
+	cacheFilePath = filepath.Join(dir, "update-check.json")
+	return func() { cacheFilePath = orig }
+}
+
+func TestCacheSaveLoad_RoundTrip(t *testing.T) {
+	defer withTempCache(t)()
+
+	r := &Result{
+		SchemaVersion:    cacheSchemaVersion,
+		Current:          "v2.0.0",
+		Latest:           "v2.1.0",
+		UpgradeAvailable: true,
+		ReleaseURL:       "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0",
+		CheckedAt:        time.Now().UTC(),
+	}
+	if err := cacheSave(r); err != nil {
+		t.Fatalf("cacheSave: %v", err)
+	}
+	got, fresh := cacheLoad()
+	if !fresh {
+		t.Fatal("expected fresh cache after save")
+	}
+	if got.Latest != "v2.1.0" {
+		t.Errorf("Latest: want v2.1.0, got %q", got.Latest)
+	}
+	if !got.UpgradeAvailable {
+		t.Error("UpgradeAvailable: want true")
+	}
+}
+
+func TestCacheLoad_MissingFile(t *testing.T) {
+	defer withTempCache(t)()
+	got, fresh := cacheLoad()
+	if fresh || got != nil {
+		t.Error("expected no fresh cache for missing file")
+	}
+}
+
+func TestCacheLoad_CorruptFile(t *testing.T) {
+	defer withTempCache(t)()
+	path, _ := getCachePath()
+	_ = os.MkdirAll(filepath.Dir(path), 0700)
+	_ = os.WriteFile(path, []byte(`{not json`), 0600)
+	got, fresh := cacheLoad()
+	if fresh || got != nil {
+		t.Error("expected no fresh cache for corrupt file")
+	}
+}
+
+func TestCacheLoad_Expired(t *testing.T) {
+	defer withTempCache(t)()
+	r := &Result{
+		SchemaVersion: cacheSchemaVersion,
+		Current:       "v2.0.0",
+		Latest:        "v2.1.0",
+		CheckedAt:     time.Now().UTC().Add(-25 * time.Hour), // beyond 24h TTL
+	}
+	if err := cacheSave(r); err != nil {
+		t.Fatalf("cacheSave: %v", err)
+	}
+	got, fresh := cacheLoad()
+	if fresh || got != nil {
+		t.Error("expected stale cache to be rejected")
+	}
+}
+
+func TestCacheLoad_FutureDated(t *testing.T) {
+	defer withTempCache(t)()
+	r := &Result{
+		SchemaVersion: cacheSchemaVersion,
+		Current:       "v2.0.0",
+		Latest:        "v2.1.0",
+		CheckedAt:     time.Now().UTC().Add(1 * time.Hour), // future
+	}
+	if err := cacheSave(r); err != nil {
+		t.Fatalf("cacheSave: %v", err)
+	}
+	got, fresh := cacheLoad()
+	if fresh || got != nil {
+		t.Error("expected future-dated cache to be rejected")
+	}
+}
+
+func TestCacheLoad_WrongSchema(t *testing.T) {
+	defer withTempCache(t)()
+	r := &Result{
+		SchemaVersion: 99,
+		Current:       "v2.0.0",
+		Latest:        "v2.1.0",
+		CheckedAt:     time.Now().UTC(),
+	}
+	if err := cacheSave(r); err != nil {
+		t.Fatalf("cacheSave: %v", err)
+	}
+	got, fresh := cacheLoad()
+	if fresh || got != nil {
+		t.Error("expected wrong schema version to be rejected")
+	}
+}
+
+func TestCacheLoad_InvalidLatest(t *testing.T) {
+	defer withTempCache(t)()
+	r := &Result{
+		SchemaVersion: cacheSchemaVersion,
+		Current:       "v2.0.0",
+		Latest:        "\x1b[31mevil\x1b[0m", // ANSI injection attempt
+		CheckedAt:     time.Now().UTC(),
+	}
+	if err := cacheSave(r); err != nil {
+		t.Fatalf("cacheSave: %v", err)
+	}
+	got, fresh := cacheLoad()
+	if fresh || got != nil {
+		t.Error("expected invalid Latest to be rejected")
+	}
+}
+
+func TestCacheLoad_InvalidReleaseURL(t *testing.T) {
+	defer withTempCache(t)()
+	r := &Result{
+		SchemaVersion: cacheSchemaVersion,
+		Current:       "v2.0.0",
+		Latest:        "v2.1.0",
+		ReleaseURL:    "https://evil.example.com/",
+		CheckedAt:     time.Now().UTC(),
+	}
+	if err := cacheSave(r); err != nil {
+		t.Fatalf("cacheSave: %v", err)
+	}
+	got, fresh := cacheLoad()
+	if fresh || got != nil {
+		t.Error("expected invalid ReleaseURL to be rejected")
+	}
+}
+
+func TestCacheSave_CreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	orig := cacheFilePath
+	// Use a nested path whose parent doesn't exist yet.
+	cacheFilePath = filepath.Join(dir, "nested", "deep", "update-check.json")
+	defer func() { cacheFilePath = orig }()
+
+	r := &Result{
+		SchemaVersion: cacheSchemaVersion,
+		Current:       "v2.0.0",
+		Latest:        "v2.0.0",
+		CheckedAt:     time.Now().UTC(),
+	}
+	if err := cacheSave(r); err != nil {
+		t.Fatalf("cacheSave should create parent dirs: %v", err)
+	}
+	if _, err := os.Stat(cacheFilePath); err != nil {
+		t.Errorf("cache file not created: %v", err)
+	}
+}

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -1,0 +1,53 @@
+package update
+
+import (
+	"context"
+	"strings"
+	"time"
+)
+
+// Check returns the update status for currentVer.
+// Returns (nil, nil) when currentVer is a dev/pseudo-version — no check is performed.
+// When force=true the 24h cache is bypassed and a fresh fetch is made.
+// On any network or parse error the caller receives a non-nil error; silent-degrade
+// is the caller's responsibility (both Phase 3 and Phase 4 treat errors as no-op).
+func Check(ctx context.Context, currentVer string, force bool) (*Result, error) {
+	v := strings.ToLower(strings.TrimSpace(currentVer))
+	if v == "" || v == "dev" || v == "unknown" || strings.HasPrefix(v, "v0.0.0-") {
+		return nil, nil
+	}
+
+	if !force {
+		if cached, fresh := cacheLoad(); fresh {
+			return cached, nil
+		}
+	}
+
+	rel, err := FetchLatest(ctx, currentVer)
+	if err != nil {
+		return nil, err
+	}
+
+	// Treat draft/prerelease as "no stable upgrade available".
+	if rel.Draft || rel.Prerelease || IsPrerelease(rel.TagName) {
+		return &Result{
+			SchemaVersion:    cacheSchemaVersion,
+			Current:          currentVer,
+			Latest:           currentVer,
+			UpgradeAvailable: false,
+			CheckedAt:        time.Now().UTC(),
+		}, nil
+	}
+
+	upgrade := Compare(currentVer, rel.TagName) < 0
+	r := &Result{
+		SchemaVersion:    cacheSchemaVersion,
+		Current:          currentVer,
+		Latest:           rel.TagName,
+		UpgradeAvailable: upgrade,
+		ReleaseURL:       rel.HTMLURL,
+		CheckedAt:        time.Now().UTC(),
+	}
+	_ = cacheSave(r) // best-effort; errors are non-fatal
+	return r, nil
+}

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -1,0 +1,144 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func stubServer(t *testing.T, rel Release) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rel)
+	}))
+}
+
+func TestCheck_DevSkip(t *testing.T) {
+	for _, ver := range []string{"", "dev", "DEV ", "unknown", "v0.0.0-rc.test", "v0.0.0-123"} {
+		r, err := Check(context.Background(), ver, false)
+		if r != nil || err != nil {
+			t.Errorf("Check(%q) = (%v, %v), want (nil, nil)", ver, r, err)
+		}
+	}
+}
+
+func TestCheck_UpgradeAvailable(t *testing.T) {
+	defer withTempCache(t)()
+	srv := stubServer(t, Release{TagName: "v2.1.0", HTMLURL: "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0"})
+	defer srv.Close()
+	origURL := fetchURL
+	fetchURL = srv.URL
+	defer func() { fetchURL = origURL }()
+
+	r, err := Check(context.Background(), "v2.0.0", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !r.UpgradeAvailable {
+		t.Error("UpgradeAvailable: want true")
+	}
+	if r.Latest != "v2.1.0" {
+		t.Errorf("Latest: want v2.1.0, got %q", r.Latest)
+	}
+	if r.SchemaVersion != cacheSchemaVersion {
+		t.Errorf("SchemaVersion: want %d, got %d", cacheSchemaVersion, r.SchemaVersion)
+	}
+}
+
+func TestCheck_UpToDate(t *testing.T) {
+	defer withTempCache(t)()
+	srv := stubServer(t, Release{TagName: "v2.0.0", HTMLURL: "https://github.com/bavanchun/Typeburn/releases/tag/v2.0.0"})
+	defer srv.Close()
+	origURL := fetchURL
+	fetchURL = srv.URL
+	defer func() { fetchURL = origURL }()
+
+	r, err := Check(context.Background(), "v2.0.0", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if r.UpgradeAvailable {
+		t.Error("UpgradeAvailable: want false for up-to-date")
+	}
+}
+
+func TestCheck_PrereleaseIgnored(t *testing.T) {
+	defer withTempCache(t)()
+	srv := stubServer(t, Release{TagName: "v2.1.0-rc.1", Prerelease: true})
+	defer srv.Close()
+	origURL := fetchURL
+	fetchURL = srv.URL
+	defer func() { fetchURL = origURL }()
+
+	r, err := Check(context.Background(), "v2.0.0", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.UpgradeAvailable {
+		t.Error("UpgradeAvailable: want false when latest is prerelease")
+	}
+}
+
+func TestCheck_CacheHit(t *testing.T) {
+	defer withTempCache(t)()
+	// Pre-populate a fresh cache.
+	cached := &Result{
+		SchemaVersion:    cacheSchemaVersion,
+		Current:          "v2.0.0",
+		Latest:           "v2.1.0",
+		UpgradeAvailable: true,
+		ReleaseURL:       "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0",
+		CheckedAt:        time.Now().UTC(),
+	}
+	if err := cacheSave(cached); err != nil {
+		t.Fatalf("cacheSave: %v", err)
+	}
+
+	// No server needed — cache should be hit.
+	r, err := Check(context.Background(), "v2.0.0", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil || !r.UpgradeAvailable {
+		t.Error("expected cached upgrade result")
+	}
+}
+
+func TestCheck_ForceBypassesCache(t *testing.T) {
+	defer withTempCache(t)()
+	// Pre-populate a fresh cache saying up-to-date.
+	cached := &Result{
+		SchemaVersion: cacheSchemaVersion,
+		Current:       "v2.0.0",
+		Latest:        "v2.0.0",
+		CheckedAt:     time.Now().UTC(),
+	}
+	if err := cacheSave(cached); err != nil {
+		t.Fatalf("cacheSave: %v", err)
+	}
+
+	// Server says there IS an upgrade — force=true should bypass cache.
+	srv := stubServer(t, Release{TagName: "v2.1.0", HTMLURL: "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0"})
+	defer srv.Close()
+	origURL := fetchURL
+	fetchURL = srv.URL
+	defer func() { fetchURL = origURL }()
+
+	r, err := Check(context.Background(), "v2.0.0", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !r.UpgradeAvailable {
+		t.Error("expected force=true to bypass cache and return upgrade")
+	}
+}

--- a/internal/update/client.go
+++ b/internal/update/client.go
@@ -1,0 +1,71 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// fetchURL is the GitHub Releases API endpoint. It is a var so tests can
+// override it with an httptest.Server URL without touching real network.
+var fetchURL = "https://api.github.com/repos/bavanchun/Typeburn/releases/latest"
+
+const bodyLimit = 64 * 1024
+
+// ErrUpstream indicates a non-2xx response from the GitHub API.
+var ErrUpstream = errors.New("update: upstream error")
+
+// ErrRateLimit indicates a 403 or 429 response (rate-limited or blocked).
+var ErrRateLimit = errors.New("update: rate limited")
+
+// FetchLatest queries the GitHub Releases API and returns the latest release.
+// The HTTP client enforces a 1.5s total timeout with explicit dial and TLS
+// sub-timeouts so degraded networks don't hang the caller.
+func FetchLatest(ctx context.Context, currentVer string) (Release, error) {
+	client := &http.Client{
+		Timeout: 1500 * time.Millisecond,
+		// Block redirects: /releases/latest returns 200 on the happy path.
+		// Following an attacker-controlled 302 could leak UA/version or downgrade to HTTP.
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 800 * time.Millisecond}).DialContext,
+			TLSHandshakeTimeout:   800 * time.Millisecond,
+			ResponseHeaderTimeout: 800 * time.Millisecond,
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	if err != nil {
+		return Release{}, fmt.Errorf("update: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Typeburn/"+currentVer+" (+https://github.com/bavanchun/Typeburn)")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Release{}, fmt.Errorf("update: http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		return Release{}, ErrRateLimit
+	default:
+		return Release{}, fmt.Errorf("%w: status %d", ErrUpstream, resp.StatusCode)
+	}
+
+	var rel Release
+	if err := json.NewDecoder(io.LimitReader(resp.Body, bodyLimit)).Decode(&rel); err != nil {
+		return Release{}, fmt.Errorf("update: decode response: %w", err)
+	}
+	return rel, nil
+}

--- a/internal/update/client_test.go
+++ b/internal/update/client_test.go
@@ -1,0 +1,117 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFetchLatest_Happy(t *testing.T) {
+	rel := Release{TagName: "v2.1.0", HTMLURL: "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify required headers
+		if !strings.HasPrefix(r.Header.Get("User-Agent"), "Typeburn/") {
+			t.Errorf("missing Typeburn User-Agent, got %q", r.Header.Get("User-Agent"))
+		}
+		if r.Header.Get("Accept") != "application/vnd.github+json" {
+			t.Errorf("missing Accept header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rel)
+	}))
+	defer srv.Close()
+
+	got, err := fetchLatestFrom(context.Background(), "v2.0.0", srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TagName != "v2.1.0" {
+		t.Errorf("TagName: want v2.1.0, got %q", got.TagName)
+	}
+}
+
+func TestFetchLatest_403(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	_, err := fetchLatestFrom(context.Background(), "v2.0.0", srv.URL)
+	if err != ErrRateLimit {
+		t.Errorf("want ErrRateLimit, got %v", err)
+	}
+}
+
+func TestFetchLatest_429(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	_, err := fetchLatestFrom(context.Background(), "v2.0.0", srv.URL)
+	if err != ErrRateLimit {
+		t.Errorf("want ErrRateLimit, got %v", err)
+	}
+}
+
+func TestFetchLatest_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	_, err := fetchLatestFrom(context.Background(), "v2.0.0", srv.URL)
+	if err == nil {
+		t.Error("expected error for 404")
+	}
+}
+
+func TestFetchLatest_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	defer srv.Close()
+	_, err := fetchLatestFrom(context.Background(), "v2.0.0", srv.URL)
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestFetchLatest_SlowResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := fetchLatestFrom(ctx, "v2.0.0", srv.URL)
+	if err == nil {
+		t.Error("expected timeout error for slow response")
+	}
+}
+
+func TestFetchLatest_BodyCap(t *testing.T) {
+	// Send 200KB body; FetchLatest should only read 64KB.
+	large := make([]byte, 200*1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(large)
+	}))
+	defer srv.Close()
+	// Will fail to decode (not JSON), but should not hang or OOM
+	_, err := fetchLatestFrom(context.Background(), "v2.0.0", srv.URL)
+	if err == nil {
+		t.Error("expected decode error for non-JSON body")
+	}
+}
+
+// fetchLatestFrom is a test seam that overrides the target URL.
+func fetchLatestFrom(ctx context.Context, currentVer, url string) (Release, error) {
+	orig := fetchURL
+	fetchURL = url
+	defer func() { fetchURL = orig }()
+	return FetchLatest(ctx, currentVer)
+}

--- a/internal/update/compare.go
+++ b/internal/update/compare.go
@@ -1,0 +1,47 @@
+package update
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Compare returns -1 if a < b, 0 if a == b, +1 if a > b.
+// Strips leading "v". Treats git-describe form (vX.Y.Z-N-gSHA) as vX.Y.Z.
+// Returns 0 for malformed input (treat as equal; caller filters with IsPrerelease).
+func Compare(a, b string) int {
+	ma, ok1 := parseSemver(a)
+	mb, ok2 := parseSemver(b)
+	if !ok1 || !ok2 {
+		return 0
+	}
+	for i := range ma {
+		if ma[i] < mb[i] {
+			return -1
+		}
+		if ma[i] > mb[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+// parseSemver parses "vX.Y.Z" or "vX.Y.Z-<suffix>" into [major, minor, patch].
+// Any suffix (prerelease label or git-describe) is stripped — comparisons use
+// only the numeric core so that prerelease filtering happens in IsPrerelease.
+func parseSemver(v string) ([3]int, bool) {
+	v = strings.TrimPrefix(v, "v")
+	core := strings.SplitN(v, "-", 2)[0]
+	segs := strings.Split(core, ".")
+	if len(segs) != 3 {
+		return [3]int{}, false
+	}
+	var nums [3]int
+	for i, s := range segs {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 0 {
+			return [3]int{}, false
+		}
+		nums[i] = n
+	}
+	return nums, true
+}

--- a/internal/update/compare_test.go
+++ b/internal/update/compare_test.go
@@ -1,0 +1,31 @@
+package update
+
+import "testing"
+
+func TestCompare(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"v1.0.0", "v1.0.0", 0},
+		{"v2.0.0", "v2.1.0", -1},
+		{"v2.1.0", "v2.0.0", 1},
+		{"v2.10.0", "v2.9.0", 1},
+		{"v2.0.0", "v2.0.1", -1},
+		{"v2.0.1", "v2.0.0", 1},
+		{"v2.0.0-1-gabc123", "v2.0.0", 0}, // git-describe treated as v2.0.0
+		{"v2.0.0", "v2.0.0-1-gabc123", 0}, // symmetric
+		{"", "v2.0.0", 0},                 // malformed → equal
+		{"v2.0.0", "", 0},                 // malformed → equal
+		{"notaversion", "v2.0.0", 0},      // malformed → equal
+		{"v2.0.0-rc.1", "v2.0.0", 0},      // suffix stripped; prerelease filtered by IsPrerelease
+		{"v1.2.3", "v1.2.4", -1},
+		{"v1.2.4", "v1.2.3", 1},
+	}
+	for _, tc := range cases {
+		got := Compare(tc.a, tc.b)
+		if got != tc.want {
+			t.Errorf("Compare(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/internal/update/prerelease.go
+++ b/internal/update/prerelease.go
@@ -1,0 +1,50 @@
+package update
+
+import "strings"
+
+// IsPrerelease reports whether a release tag should be excluded from stable
+// upgrade comparisons. The API's Prerelease/Draft fields are the primary signal;
+// this function is a belt-and-suspenders tag-name heuristic for any gaps.
+func IsPrerelease(tag string) bool {
+	lower := strings.ToLower(tag)
+	for _, label := range []string{"-rc", "-beta", "-alpha", "-pre"} {
+		if strings.Contains(lower, label) {
+			return true
+		}
+	}
+	if strings.HasPrefix(lower, "v0.0.0-") {
+		return true
+	}
+	// Any suffix after MAJOR.MINOR.PATCH is treated as prerelease unless it
+	// matches the git-describe form "N-gSHA" (e.g. "3-gabc1234").
+	v := strings.TrimPrefix(lower, "v")
+	parts := strings.SplitN(v, "-", 2)
+	if len(parts) == 2 && !isGitDescribeSuffix(parts[1]) {
+		return true
+	}
+	return false
+}
+
+// isGitDescribeSuffix returns true if s matches the git-describe suffix form
+// "N-gHEX" where N is a non-negative integer and gHEX is a "g" + hex string.
+func isGitDescribeSuffix(s string) bool {
+	dash := strings.Index(s, "-")
+	if dash < 1 {
+		return false
+	}
+	count, rest := s[:dash], s[dash+1:]
+	for _, c := range count {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	if len(rest) < 2 || rest[0] != 'g' {
+		return false
+	}
+	for _, c := range rest[1:] {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/update/prerelease_test.go
+++ b/internal/update/prerelease_test.go
@@ -1,0 +1,31 @@
+package update
+
+import "testing"
+
+func TestIsPrerelease(t *testing.T) {
+	cases := []struct {
+		tag  string
+		want bool
+	}{
+		{"v2.0.0", false},
+		{"v2.1.0", false},
+		{"v2.0.0-rc.1", true},
+		{"v2.0.0-rc1", true},
+		{"v0.0.0-rc.test", true},
+		{"V2.0.0-Alpha", true}, // case-insensitive
+		{"v2.0.0-beta.3", true},
+		{"v2.0.0-alpha", true},
+		{"v2.0.0-pre.1", true},
+		{"v2.0.0-7-gabc123", false}, // git-describe, NOT a prerelease
+		{"v2.0.0-3-gdeadbeef", false},
+		{"v2.0.0-1", true},        // numeric suffix only — SemVer-2 prerelease
+		{"v2.0.0-canary.4", true}, // canary build
+		{"v0.0.0-test", true},     // v0.0.0- prefix
+	}
+	for _, tc := range cases {
+		got := IsPrerelease(tc.tag)
+		if got != tc.want {
+			t.Errorf("IsPrerelease(%q) = %v, want %v", tc.tag, got, tc.want)
+		}
+	}
+}

--- a/internal/update/result.go
+++ b/internal/update/result.go
@@ -1,0 +1,23 @@
+package update
+
+import "time"
+
+// Release is the subset of the GitHub Releases API response used for update checks.
+type Release struct {
+	TagName     string    `json:"tag_name"`
+	HTMLURL     string    `json:"html_url"`
+	Name        string    `json:"name"`
+	Draft       bool      `json:"draft"`
+	Prerelease  bool      `json:"prerelease"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+// Result holds the outcome of an update check. It is cached to disk between runs.
+type Result struct {
+	SchemaVersion    int       `json:"schema_version"`
+	Current          string    `json:"current"`
+	Latest           string    `json:"latest"`
+	UpgradeAvailable bool      `json:"upgrade_available"`
+	ReleaseURL       string    `json:"release_url"`
+	CheckedAt        time.Time `json:"checked_at"`
+}

--- a/plans/20260521-0700-typeburn-update-check-cli/brainstorm-summary.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/brainstorm-summary.md
@@ -1,0 +1,188 @@
+# Brainstorm Summary — typeburn update-check CLI (v2.1.0)
+
+**Date:** 2026-05-21
+**Branch target:** `feat/update-check-v2.1`
+**Release target:** `v2.1.0` (separate from v2.0.0 currently in flight via PR #18)
+**Status:** Approved by user; ready for `/ck:plan --deep`.
+
+---
+
+## 1. Problem statement
+
+Typeburn has 3 documented install paths (`install.sh`, `go install`, Homebrew cask) but the binary itself has no way to tell the user a newer release is available. End-users have to remember to check GitHub Releases manually. Add a **check-and-notify** path inside the CLI — no self-upgrade.
+
+## 2. Locked requirements (5 mandatory)
+
+1. **Expected output**
+   - Explicit flag: `typeburn version --check-update` — sync GET to GitHub Releases API, prints upgrade hint (or "up to date").
+   - Opportunistic check: on TUI launch when `update_check=on`, render hint on **Result screen footer** (chosen over Home footer; least disruptive, session-boundary).
+   - Config key: `update_check` (bool), default `false`, exposed through existing `config set/get/list/path/reset`.
+   - Both surfaces support `--json` flag (mirrors v2.0.0 convention).
+
+2. **Acceptance criteria**
+   - Never blocks > 1.5s (HTTP timeout); never crashes the TUI on network error; silent-degrade on every error path.
+   - 24h cache at `$XDG_STATE_HOME/typeburn/update-check.json`, atomic write (reuse `internal/storage` pattern).
+   - Skips entirely when `version.Resolve()` returns `"dev"` or empty (un-stamped builds).
+   - Prints all 3 upgrade commands verbatim — no install-method detection.
+   - JSON schema is stable and documented.
+
+3. **Out of scope**
+   - No self-upgrade / binary replacement.
+   - No install-method auto-detection (no `os.Executable()` inspection).
+   - No first-run interactive prompt.
+   - No telemetry beyond a single GET to `api.github.com/repos/bavanchun/Typeburn/releases/latest` with a `User-Agent: Typeburn/<ver>` header.
+   - No background daemon, no scheduled cron.
+   - No pre-release / draft tag tracking (latest stable only).
+
+4. **Non-negotiable constraints**
+   - Stdlib + existing dep allowlist only (`net/http`, `encoding/json`, `os`, `time`, `path/filepath` — all stdlib). **Zero new `go.mod` entries.**
+   - Each file < 200 LOC.
+   - `internal/update/` package stays UI-free (no `bubbletea`/`lipgloss` imports). Matches the strict layering rule.
+   - Reuse `internal/version` for current; reuse `internal/storage` atomic write helper; reuse `internal/cli/output/` for human/JSON rendering.
+   - Semver comparison via internal pure comparator — do NOT add `golang.org/x/mod/semver` (one-call use; comparator is ~30 LOC).
+   - `make test-race`, `make lint`, `make size-check`, `notui-noexit-check` must remain green.
+
+5. **Touchpoints**
+   - **NEW** `internal/update/client.go` — `FetchLatest(ctx, ver) (Release, error)`; UA header; 1.5s timeout via `http.Client{Timeout}`.
+   - **NEW** `internal/update/compare.go` — `Compare(a, b string) int`; strips `v`; ignores prereleases per locked scope.
+   - **NEW** `internal/update/cache.go` — XDG state path; atomic JSON write; 24h TTL; `Load()`/`Save(Result)`.
+   - **NEW** `internal/update/check.go` — `Check(ctx, currentVer string, force bool) (*Result, error)` orchestrator; honors cache, dev-skip, and the network/cache I/O boundary.
+   - **NEW** `internal/update/*_test.go` — table-driven; client tested via `httptest.Server` (no real network in CI).
+   - **MODIFY** `internal/cli/cmd_version.go` — add `--check-update` flag wiring + JSON shape.
+   - **MODIFY** `internal/config/` — add `UpdateCheck bool` field, default `false`; backwards-compat load (missing field → false).
+   - **MODIFY** `internal/cli/cmd_config.go` — register new key in set/get/list (likely zero code if config keys are reflection-driven; otherwise one line).
+   - **MODIFY** `internal/cli/cmd_run.go` — synchronous pre-TUI call to `update.Check(...)` when `cfg.UpdateCheck && ver!="dev"`; stash result on the app model via a new `app.WithUpdateHint(*update.Result)` option or via a new `tea.Cmd` that emits `UpdateHintMsg`.
+   - **MODIFY** `internal/ui/screen_result.go` (+ view) — render a footer line when an upgrade hint is present.
+   - **MODIFY** `internal/app/messages.go` (or `internal/ui/messages.go`) — new domain message `UpdateHintMsg{Latest, URL string}` flowing through root model.
+   - **DOCS** `README.md` (Install section: mention `--check-update` + config opt-in), `docs/cli-reference.md` (new flag + config key + JSON schema), `CHANGELOG.md` `[Unreleased]` → moved to `[2.1.0]` at release time, `docs/codebase-summary.md` (new package paragraph).
+
+---
+
+## 3. Evaluated approaches (decision rationale)
+
+### Trigger model
+| Option | Trade-off | Verdict |
+|---|---|---|
+| Explicit flag only | Smallest surface, zero hidden network | ❌ Misses passive discoverability |
+| Opportunistic only | Discoverable, but no on-demand path for CI / scripts | ❌ |
+| **Both, opt-in default-off** | Largest surface but covers all use cases honestly | ✅ Chosen |
+
+### Data source
+| Option | Trade-off | Verdict |
+|---|---|---|
+| **GitHub Releases API** | Authoritative; one call returns tag + URL + assets; 60 req/hr/IP unauth — fine with cache | ✅ Chosen |
+| Static `latest.txt` | Cheaper, no rate limit | ❌ Adds release-pipeline plumbing for no real win |
+| `git ls-remote` | No HTTP code | ❌ Assumes `git` binary; brittle for brew/install.sh users |
+
+### Install-method hint
+| Option | Trade-off | Verdict |
+|---|---|---|
+| **Print all 3 verbatim** | Honest, simple, no false claims | ✅ Chosen |
+| Detect via `os.Executable()` | More user-friendly but lots of edge cases (custom prefix, symlinks, GOBIN overrides) | ❌ Scope creep |
+| Print nothing | Forces user to figure out their own path | ❌ Worse DX |
+
+### Module layout
+| Option | Trade-off | Verdict |
+|---|---|---|
+| **New `internal/update/`** package | Clean boundary; `version` stays pure build-stamp resolver | ✅ Chosen |
+| Extend `internal/version/` | One less package, but pollutes a UI-free pure resolver with HTTP/cache I/O | ❌ Breaks layering |
+
+### Opportunistic invocation point
+| Option | Trade-off | Verdict |
+|---|---|---|
+| In `internal/app` model `Init()` | Couples update-check into Elm loop, complicates pure-logic boundary | ❌ |
+| Fire-and-forget goroutine | Avoids 1.5s worst-case startup; complicates lifecycle (when/where to print) | ❌ |
+| **Synchronous before `tea.NewProgram(...).Run()`** | Predictable; 1.5s worst case → <1ms on cache hit (24h TTL covers ~all launches) | ✅ Chosen |
+
+### Default state
+| Option | Trade-off | Verdict |
+|---|---|---|
+| **Opt-in (OFF by default)** | Aligns with local-only/no-backend posture; no surprise outbound traffic | ✅ Chosen |
+| Opt-out (ON by default) | Better discoverability; first-launch network call is a UX/privacy surprise | ❌ |
+| First-run prompt | Honest but adds first-run flow complexity | ❌ |
+
+---
+
+## 4. Output shape
+
+### Human (TUI Result footer + `version --check-update`)
+```
+typeburn v2.1.0 is available (you have v2.0.0).
+Release notes: https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0
+Upgrade with one of:
+  brew upgrade typeburn
+  curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
+  go install github.com/bavanchun/Typeburn@latest
+```
+
+### JSON (stable schema)
+```json
+{
+  "current": "v2.0.0",
+  "latest": "v2.1.0",
+  "upgrade_available": true,
+  "release_url": "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0",
+  "checked_at": "2026-05-21T07:00:00Z"
+}
+```
+
+When up-to-date: `upgrade_available=false`, `latest==current`. When network failed (explicit flag only, force=true): non-zero exit + stderr "could not check for updates" + JSON `{"error":"…"}` if `--json`.
+
+---
+
+## 5. Risks & mitigations
+
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 | GitHub API rate limit on shared NAT IPs | 24h cache + silent-degrade |
+| R2 | TUI lifecycle coupling — hint must render *after* session, not mid-render | New `UpdateHintMsg` domain message; root model routes; Result screen renders |
+| R3 | Network test flakiness | `httptest.Server`; lint enforces no real-network calls in tests |
+| R4 | Semver edge cases (prerelease, +meta) | Comparator filters prerelease/draft tags from API response; never compares them |
+| R5 | Scope creep magnet ("auto-update next?") | Lock in `docs/cli-reference.md`: "notify-only, manual install" |
+| R6 | First-launch with no `XDG_STATE_HOME` set on macOS | Fall back to `$HOME/.local/state/typeburn/` (matches existing `internal/storage` pattern) |
+| R7 | Time skew on `checked_at` (user clock wrong) | TTL comparison uses monotonic delta if available; otherwise just wall-clock — staleness is benign |
+| R8 | Stamped binaries built between releases (`v2.0.0-7-gabc123`) | Comparator must accept `vX.Y.Z-N-gSHA` and compare on `vX.Y.Z` portion only |
+
+---
+
+## 6. Success metrics
+
+- `typeburn version --check-update` returns ≤ 1.6s on cold path; ≤ 100ms on cache hit.
+- New code: ~250 LOC across 4 source files, all <200 LOC each.
+- `go.mod` diff = 0 (no new deps).
+- All CI gates green (`test-race`, `lint`, `size-check`, `notui-noexit-check`).
+- `make size-check` binary size delta < 100KB (stdlib `net/http` already linked — likely zero delta).
+- Manual smoke: feature works against real `api.github.com/repos/bavanchun/Typeburn/releases/latest`.
+
+---
+
+## 7. Locked defaults (deferred to plan; user may override)
+
+- **Flag spelling:** `--check-update` (long-only; no `-u` short form — matches `cmd_run.go` convention).
+- **Hint render location:** Result screen footer only (not Home, not both).
+
+---
+
+## 8. Implementation considerations (handed to `/ck:plan --deep`)
+
+Suggested phase decomposition (planner may refine):
+
+1. **Phase 1 — `internal/update/` pure-logic package** (client, compare, cache, check) with table-driven tests via `httptest.Server`. Zero UI deps.
+2. **Phase 2 — Config integration**: `UpdateCheck bool` field, backwards-compat load, config CLI surface tested.
+3. **Phase 3 — Explicit flag**: `cmd_version.go --check-update` + JSON shape + tests.
+4. **Phase 4 — Opportunistic wiring**: pre-TUI synchronous check in `cmd_run.go`; new `UpdateHintMsg`; Result-screen footer render; teatest golden update.
+5. **Phase 5 — Docs sync + release-prep**: README, `docs/cli-reference.md`, `docs/codebase-summary.md`, CHANGELOG `[Unreleased]` block ready to land as `[2.1.0]` at tag time.
+
+---
+
+## 9. Dependencies & sequencing
+
+- **Blocked on:** PR #18 (release-notes refresh) merged and v2.0.0 cut — this feature ships in **v2.1.0**, not v2.0.0.
+- **Not blocked on:** anything else.
+- **Branch off:** `main` once v2.0.0 is tagged (or off the latest `main` if user wants to start in parallel and rebase).
+
+---
+
+## 10. Unresolved questions
+
+- None. (Locked defaults in §7 cover the two design choices the user did not explicitly answer; plan may revisit.)

--- a/plans/20260521-0700-typeburn-update-check-cli/phase-01-update-package-pure-logic.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/phase-01-update-package-pure-logic.md
@@ -1,0 +1,319 @@
+---
+phase: 1
+title: "Update Package Pure-Logic"
+status: pending
+priority: P1
+effort: "1d"
+dependencies: []
+---
+
+# Phase 1: Update Package Pure-Logic (`internal/update/`)
+
+## Overview
+
+Build a stdlib-only, UI-free package that handles: GitHub Releases API fetch,
+24h JSON cache (atomic), stdlib semver comparison, and an orchestrator that
+ties them together with cache + dev-skip + pre-release filter. Zero
+`bubbletea`/`lipgloss` imports. Mirrors the layering rule applied to
+`internal/typing`, `internal/metrics`, etc.
+
+## Requirements
+
+**Functional**
+- `Check(ctx context.Context, currentVer string, force bool) (*Result, error)` —
+  honors 24h cache unless `force=true`; skips entirely when `currentVer` is
+  `""`/`"dev"`/pseudo-version (`(devel)` or `v0.0.0-…` from `debug.ReadBuildInfo`).
+- `FetchLatest(ctx context.Context, currentVer string) (Release, error)` —
+  GET `https://api.github.com/repos/bavanchun/Typeburn/releases/latest`,
+  `User-Agent: Typeburn/<currentVer> (+https://github.com/bavanchun/Typeburn)`,
+  `Accept: application/vnd.github+json`, body capped at 64KB via `io.LimitReader`.
+- `Compare(a, b string) int` — pure, returns `-1/0/+1`; strips leading `v`;
+  treats `vX.Y.Z-N-gSHA` (git-describe) as `vX.Y.Z`; returns 0 (treat as equal)
+  for malformed input.
+- `IsPrerelease(tag string) bool` — `true` if tag contains `-rc/-beta/-alpha/-pre`
+  (case-insensitive) or starts with `v0.0.0-`.
+- Cache load/save at `$XDG_STATE_HOME/typeburn/update-check.json`
+  (fallback `$HOME/.local/state/typeburn/`), atomic write, 24h TTL.
+
+**Non-functional**
+- Stdlib only: `net/http`, `encoding/json`, `context`, `time`, `io`,
+  `strings`, `strconv`, `os`, `path/filepath`, `errors`. **No new go.mod entries.**
+- Each source file < 200 LOC.
+- Zero `bubbletea`/`lipgloss` imports (CI-lintable via `go list -deps`).
+- HTTP: 1.5s total timeout (layered defense — `http.Client.Timeout` AND
+  `context.WithTimeout`, per researcher-01 §4).
+- Silent-degrade on any error: network, 403, 429, 404, parse, malformed JSON.
+
+## Key Insights (from research)
+
+- GitHub requires `User-Agent`; 403 without it (researcher-01 §3).
+- Default `http.DefaultTransport` does **not** honor `HTTPS_PROXY` —
+  custom `Transport{Proxy: http.ProxyFromEnvironment}` needed (researcher-01 §6).
+- `internal/storage/atomic_write.go` exposes a private `atomicWrite(path, []byte) error`
+  — we cannot import it directly. Two options: (a) duplicate the ~30-LOC helper
+  in `internal/update/cache.go` (KISS), or (b) export it from `internal/storage`
+  (DRY but touches a stable package). **Decision: option (b) — promote to
+  `storage.AtomicWrite` (one-line rename + visibility change)** so future
+  packages reuse it. Justification: KISS still holds (no duplication), and
+  the API surface change is trivial + tested by existing users.
+- `internal/config/xdg-paths.go` has `ConfigDir()` and `DataDir()` but **no
+  `StateDir()` helper** (researcher-02 Part A). Add `StateDir()` in the same
+  file using the same `resolveDir` pattern: `$XDG_STATE_HOME` →
+  `$HOME/.local/state`.
+- `internal/version.Resolve()` returns three strings; `Version` is what we
+  compare. Pseudo-version detection: starts with `v0.0.0-` OR equals
+  `(devel)` OR equals `dev` OR is empty.
+
+## Architecture
+
+```
+internal/update/
+├── client.go        # FetchLatest(ctx, ver) (Release, error) — HTTP + UA + LimitReader
+├── compare.go       # Compare(a, b string) int — stdlib semver
+├── prerelease.go    # IsPrerelease(tag string) bool — tiny, splits out for testing
+├── cache.go         # Load() / Save(Result) — uses storage.AtomicWrite + StateDir()
+├── check.go         # Check(ctx, ver, force) — orchestrator: dev-skip, cache, fetch, persist
+├── result.go        # Public types: Release, Result (with json tags for output)
+├── client_test.go   # httptest.Server — 6+ cases (200 happy, 403, 404, 429, slow, malformed)
+├── compare_test.go  # table-driven — 12+ cases (equal, M/m/p bumps, prerelease, malformed, git-describe)
+├── prerelease_test.go
+├── cache_test.go    # t.TempDir() — write/read/expiry/corrupt-file
+└── check_test.go    # integration: stubbed client + tempdir cache
+```
+
+Public types in `result.go`:
+```go
+type Release struct {
+    TagName     string    `json:"tag_name"`
+    HTMLURL     string    `json:"html_url"`
+    Name        string    `json:"name"`
+    Draft       bool      `json:"draft"`
+    Prerelease  bool      `json:"prerelease"`
+    PublishedAt time.Time `json:"published_at"`
+}
+
+type Result struct {
+    Current          string    `json:"current"`
+    Latest           string    `json:"latest"`
+    UpgradeAvailable bool      `json:"upgrade_available"`
+    ReleaseURL       string    `json:"release_url"`
+    CheckedAt        time.Time `json:"checked_at"`
+}
+```
+
+## Related Code Files
+
+- **Create:** `internal/update/client.go`, `compare.go`, `prerelease.go`,
+  `cache.go`, `check.go`, `result.go` + 5 `*_test.go` files.
+- **Modify:** `internal/storage/atomic_write.go` — rename `atomicWrite` →
+  `AtomicWrite` (export); update internal callers in `settings_store.go` and
+  `history_store.go`. **Verify with `go build ./...` after rename.**
+- **Modify:** `internal/config/xdg-paths.go` — add `StateDir() (string, error)`
+  beside existing `ConfigDir`/`DataDir`.
+
+## Implementation Steps
+
+1. **Hardened atomic write helper** (private to `internal/update/cache.go`).
+   <!-- SUPERSEDED by red-team-finding-7 — do NOT promote storage.atomicWrite. Duplicate ~30 LOC into update/cache.go and harden with O_EXCL|O_NOFOLLOW + unique tmp suffix. See Red Team Review Updates. -->
+   Implement a private `atomicWrite(path string, data []byte) error` in
+   `internal/update/cache.go` that opens with `O_WRONLY|O_CREATE|O_EXCL|O_NOFOLLOW`,
+   uses `fmt.Sprintf("%s.%d.tmp", path, os.Getpid())` for the temp suffix, then
+   fsync + rename. Leave `internal/storage/atomic_write.go` untouched.
+2. **Add `StateDir()`** to `internal/config/xdg-paths.go`. Test parity with
+   existing `ConfigDir`/`DataDir` test pattern.
+3. **`internal/update/result.go`** — types only, no logic.
+4. **`internal/update/compare.go`** + `compare_test.go` (table-driven, TDD-friendly).
+   Cases: `("v1.0.0","v1.0.0")=0`, `("v2.0.0","v2.1.0")=-1`, `("v2.10.0","v2.9.0")=+1`,
+   `("v2.0.0-1-g123","v2.0.0")=0`, `("","v2.0.0")=0` (malformed → equal),
+   `("v0.0.0-rc.test","v2.0.0")=-1` if reached (but `IsPrerelease` should filter
+   earlier).
+5. **`internal/update/prerelease.go`** + test. Cases: `v2.0.0`=false,
+   `v2.0.0-rc.1`=true, `v0.0.0-rc.test`=true, `V2.0.0-Alpha`=true (case-insensitive),
+   `v2.0.0-7-gabc123`=false (git-describe is NOT a prerelease).
+6. **`internal/update/client.go`** — `FetchLatest`. Layered timeout:
+   ```go
+   client := &http.Client{
+       Timeout:   1500 * time.Millisecond,
+       Transport: &http.Transport{Proxy: http.ProxyFromEnvironment},
+   }
+   ctx, cancel := context.WithTimeout(ctx, 1500*time.Millisecond)
+   defer cancel()
+   req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+   req.Header.Set("User-Agent", "Typeburn/"+ver+" (+https://github.com/bavanchun/Typeburn)")
+   req.Header.Set("Accept", "application/vnd.github+json")
+   ...
+   body := io.LimitReader(resp.Body, 64*1024)
+   ```
+   Return typed error on 4xx/5xx (`ErrUpstream`, `ErrRateLimit` for 403/429).
+7. **`internal/update/client_test.go`** — `httptest.NewServer`. Mock 200/403/
+   404/429/malformed-JSON/slow-(>1.5s)-response cases. Verify UA header is set,
+   verify body cap (send 200KB, assert <=64KB read).
+8. **`internal/update/cache.go`** + `cache_test.go`. Uses `storage.AtomicWrite`
+   + `config.StateDir()`. Defensive load (corrupt → return `Result{}`,
+   `false, nil`). 24h TTL is `time.Since(r.CheckedAt) < 24*time.Hour`.
+9. **`internal/update/check.go`** + `check_test.go`. Orchestrator:
+   - Dev-skip: <!-- SUPERSEDED by red-team-findings 10+14 — see consolidated pseudocode at bottom of phase. -->
+     `v := strings.ToLower(strings.TrimSpace(currentVer)); if v == "" || v == "dev" || v == "unknown" || strings.HasPrefix(v, "v0.0.0-") { return nil, nil }`
+   - If `!force`: try cache; if fresh, return cached result.
+   - Else: `FetchLatest`; if `IsPrerelease(rel.TagName) || rel.Draft || rel.Prerelease`, treat as up-to-date.
+   - Build `Result{}` with `CheckedAt: time.Now().UTC()`, `Save()` to cache, return.
+10. **Run** `make test-race`, `make lint`, `make size-check`. All green.
+11. **Verify** `go list -deps ./internal/update/ | grep -E 'bubbletea|lipgloss'`
+    returns empty (UI-free guarantee).
+
+## Todo List
+
+- [ ] storage.atomicWrite → storage.AtomicWrite (export + caller updates)
+- [ ] config.StateDir() helper + test
+- [ ] internal/update/result.go (types only)
+- [ ] compare.go + compare_test.go (TDD)
+- [ ] prerelease.go + prerelease_test.go
+- [ ] client.go + client_test.go (httptest.Server, 6+ cases)
+- [ ] cache.go + cache_test.go (TempDir, TTL, corrupt-file)
+- [ ] check.go + check_test.go (integration with stubs)
+- [ ] make test-race + make lint + make size-check green
+- [ ] UI-free guarantee verified via `go list -deps`
+
+## Success Criteria
+
+- [ ] All new files < 200 LOC each.
+- [ ] `internal/update/` imports: stdlib + `internal/storage` + `internal/config` only.
+- [ ] `go test ./internal/update/... -race -count=1` passes.
+- [ ] Zero `go.mod` diff.
+- [ ] Client tests use `httptest.Server` only (no real network).
+- [ ] Cache tests use `t.TempDir()` (no filesystem leakage).
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|---|---|
+| Exporting `AtomicWrite` ripples through `internal/storage` callers | Compiler-checked rename; tests catch breakage |
+| `StateDir()` differs from existing dir helpers' error semantics | Mirror existing pattern exactly; copy test shape |
+| `httptest.Server` tests flake on slow CI | Use 200ms deadline in mock; not the 1.5s real-world cap |
+| Pseudo-version detection misses a `go install` output form | Test the 4 known forms; document as out-of-scope edge case in code comment |
+| 64KB cap truncates legitimate response | Real releases are 5-15KB (researcher-01 §1); 64KB has 4x headroom |
+
+## Security Considerations
+
+- No auth — public API only. UA header is identifying but not sensitive.
+- TLS via stdlib defaults. Body size cap prevents DoS via runaway response.
+- Cache file at `$XDG_STATE_HOME/typeburn/update-check.json` mode 0600
+  (same as existing `internal/storage` patterns).
+- No PII written to cache (just version strings + URL + timestamp).
+
+## Next Steps
+
+- Phase 2: wire `UpdateCheck bool` into config so Phase 4 can gate on it.
+- Phase 3: explicit flag consumer of this package.
+
+## Red Team Review Updates (2026-05-21)
+
+Apply these deltas during implementation; supersedes the original spec where they conflict.
+
+<!-- red-team-finding-2 --> **C2 — cache parent dir.** `internal/storage/atomic_write.go:13` documents
+"parent directory must exist". `cache.Save` MUST call
+`os.MkdirAll(filepath.Dir(path), 0700)` BEFORE invoking the atomic writer.
+Without this, fresh installs silently fail to persist cache → users pay the
+1.5s timeout every launch and hit GitHub's 60/hr rate limit on shared NAT.
+Add a unit test that deletes the parent dir between Save calls.
+
+<!-- red-team-finding-5 --> **H3 — `CheckRedirect` policy.** Step 6 `http.Client` MUST set:
+```go
+CheckRedirect: func(req *http.Request, via []*http.Request) error {
+    return http.ErrUseLastResponse // /releases/latest is 200 on happy path
+}
+```
+This blocks attacker-controlled 302 redirects from leaking UA/version and from downgrading scheme.
+
+<!-- red-team-finding-6 --> **H4 — cache value re-validation on load.** In `cache.Load`, AFTER successful
+JSON parse, re-validate:
+- `Latest` matches `^v?\d+\.\d+\.\d+([-+.][\w.-]+)?$` (regexp).
+- `ReleaseURL` starts with `https://github.com/bavanchun/Typeburn/`.
+- `SchemaVersion == 1` (see finding 12).
+On any mismatch, return zero-value Result (treat as "no fresh cache"). Prevents
+ANSI injection from a maliciously-seeded cache file rendering into the TUI footer.
+
+<!-- red-team-finding-7 --> **H5 — symlink/TOCTOU.** Do NOT promote `storage.atomicWrite` to `storage.AtomicWrite`.
+Instead, **duplicate ~30 LOC into `internal/update/cache.go`** (private helper) and harden
+the copy: open temp with `os.O_WRONLY|os.O_CREATE|os.O_EXCL|os.O_NOFOLLOW`, use
+unique temp suffix `fmt.Sprintf("%s.%d.tmp", path, os.Getpid())` to avoid concurrent-Save
+rename collisions. Leave `internal/storage/atomic_write.go` untouched. Update Implementation
+Steps §1 and §8 accordingly. **Trade-off:** ~30 LOC duplication accepted (KISS) vs.
+hardening a shared helper that other packages didn't ask for.
+
+<!-- red-team-finding-9 --> **H7 — TLS handshake bound + opportunistic timeout.** Step 6 Transport MUST set:
+```go
+Transport: &http.Transport{
+    Proxy:                 http.ProxyFromEnvironment,
+    DialContext:           (&net.Dialer{Timeout: 800 * time.Millisecond}).DialContext,
+    TLSHandshakeTimeout:   800 * time.Millisecond,
+    ResponseHeaderTimeout: 800 * time.Millisecond,
+}
+```
+Explicit-flag (Phase 3) path keeps the 1.5s outer cap. Opportunistic (Phase 4) path
+uses 800ms outer cap. Without these, `http.Client.Timeout` alone does NOT bound
+TLS handshake on degraded networks.
+
+<!-- red-team-finding-10 --> **M1 — `(devel)` is unreachable.** Verified at `internal/version/version.go:46`:
+`Resolve()` explicitly filters `(devel)` and falls back to `"dev"` at line 65-67.
+Drop `"(devel)"` from the dev-skip list. Replace step 9's pseudo-code with the
+trim/lowercase form (finding 14).
+
+<!-- red-team-finding-11 --> **M2 — SemVer-2 prerelease detection.** Primary check is the API's `rel.Prerelease`
+boolean flag AND `rel.Draft`. The locked-text substring denylist (`-rc/-beta/-alpha/-pre`)
+is **belt-and-suspenders only**. For full SemVer compliance, additionally treat any
+tag with content after `MAJOR.MINOR.PATCH` (preceded by `-`) as prerelease — except
+the git-describe form `vX.Y.Z-N-gSHA` (those have purely numeric suffix segments).
+
+<!-- red-team-finding-12 --> **M3 — schema_version on cache.** Add `SchemaVersion int \`json:"schema_version"\``
+field to `Result` (constant `1` in this release). On load, if `SchemaVersion != 1`,
+treat as empty cache (force refresh). Matches `internal/cli/cmd_replay.go:18` repo
+convention. On save, write `SchemaVersion: 1`.
+
+<!-- red-team-finding-13 --> **M4 — clock-skew TTL clamp.** Step 8 TTL check becomes:
+```go
+now := time.Now().UTC()
+age := now.Sub(r.CheckedAt)
+if age < 0 || age > 7*24*time.Hour { return zeroResult }  // future-dated or wildly stale → refresh
+if age < 24*time.Hour { return r, true }                  // fresh
+return zeroResult                                          // stale
+```
+Prevents clock-skew breaking TTL both directions (cloned VMs, suspended laptops, NTP drift).
+
+<!-- red-team-finding-14 --> **M8 — dev-skip whitespace/case-insensitive.** Replace step 9's exact-string
+compare with:
+```go
+v := strings.ToLower(strings.TrimSpace(currentVer))
+if v == "" || v == "dev" || v == "unknown" || strings.HasPrefix(v, "v0.0.0-") {
+    return nil, nil // dev-skip
+}
+```
+Note: `(devel)` removed per finding 10; `unknown` added defensively.
+
+<!-- red-team-finding-15 --> **M12 — `Resolve()` signature pin.** Verified at `internal/version/version.go:28-32, 40`:
+returns struct `Info{Version, Commit, Date string}`. Phase 1 prose "returns three
+strings" is incorrect — fix to "returns `Info` struct". All callers use
+`version.Resolve().Version`. Aligns with Phase 3 (already correct).
+
+### Step 9 (consolidated post-redteam pseudocode)
+
+```go
+func Check(ctx context.Context, currentVer string, force bool) (*Result, error) {
+    v := strings.ToLower(strings.TrimSpace(currentVer))
+    if v == "" || v == "dev" || v == "unknown" || strings.HasPrefix(v, "v0.0.0-") {
+        return nil, nil // dev/pseudo-version skip (finding 10, 14)
+    }
+    if !force {
+        if cached, fresh := cacheLoad(); fresh { return cached, nil }  // findings 6, 12, 13
+    }
+    rel, err := FetchLatest(ctx, currentVer)
+    if err != nil { return nil, err } // silent-degrade at caller
+    if rel.Draft || rel.Prerelease || IsPrerelease(rel.TagName) {
+        return &Result{Current: currentVer, Latest: currentVer, UpgradeAvailable: false, CheckedAt: time.Now().UTC(), SchemaVersion: 1}, nil
+    }
+    upgrade := Compare(currentVer, rel.TagName) < 0
+    r := &Result{Current: currentVer, Latest: rel.TagName, UpgradeAvailable: upgrade, ReleaseURL: rel.HTMLURL, CheckedAt: time.Now().UTC(), SchemaVersion: 1}
+    _ = cacheSave(r) // silent on error
+    return r, nil
+}
+```

--- a/plans/20260521-0700-typeburn-update-check-cli/phase-02-config-integration.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/phase-02-config-integration.md
@@ -1,0 +1,138 @@
+---
+phase: 2
+title: "Config Integration"
+status: pending
+priority: P1
+effort: "2h"
+dependencies: [1]
+---
+
+# Phase 2: Config Integration (`update_check` key)
+
+## Overview
+
+Add a single new config key `update_check` (bool, **default `false`**) to
+`config.Settings`, wire it through the existing `typeburn config set/get/list`
+switch-based registry in `cmd_config.go`. Phase 4 will read this field.
+
+## Requirements
+
+**Functional**
+- New field `Settings.UpdateCheck bool` with JSON tag `update_check`.
+- `Defaults()` returns `UpdateCheck: false` (LOCKED — scout §3 suggested `true`;
+  reversed per user decision in brainstorm).
+- `typeburn config list` shows the new key in the table.
+- `typeburn config get update_check` returns `false` (or current value).
+- `typeburn config set update_check true|false` accepts canonical bool inputs;
+  rejects others with a clear error.
+- Backwards-compat: existing `settings.json` files on disk without the field
+  load successfully — missing field defaults to `false`.
+
+**Non-functional**
+- No new go.mod entries.
+- No `Normalize()` changes (bool has no invalid values).
+
+## Architecture
+
+Scout §2 confirms `cmd_config.go` uses explicit `switch` on key string —
+not reflection. Adding a key is mechanical: struct field + Defaults() entry
++ row in `configRows()` + case in `configSet()` switch. `configGet()` is
+loop-based over `configRows()`, so no separate change.
+
+## Related Code Files
+
+- **Modify:** `internal/config/settings.go` (lines 35-40 add field; lines 44-51 add default).
+- **Modify:** `internal/cli/cmd_config.go` (lines 86-102 add row; lines 104-136 add set case).
+- **Modify:** `internal/config/settings_test.go` — add cases for default + missing-field load.
+- **Modify:** `internal/cli/cmd_config_test.go` — add cases for set/get of `update_check`.
+
+## Implementation Steps
+
+1. Add `UpdateCheck bool \`json:"update_check"\`` to `config.Settings` struct.
+2. Add `UpdateCheck: false` to `Defaults()` return value. **Comment in code
+   must NOT reference plan/finding labels** (per user CLAUDE.md rule §5):
+   write the *reason* if any (e.g., `// opt-in network: off by default to
+   preserve offline-first posture`), not a phase number.
+3. Add `{"update_check", strconv.FormatBool(s.UpdateCheck)}` to `configRows()`.
+4. Add `case "update_check":` to `configSet()` switch with a `parseBool(value)`
+   call (existing helper at `cmd_config.go:138-147`).
+   <!-- SUPERSEDED by red-team-finding-3 — existing parseBool accepts ONLY true/false/1/0; pick resolution (a) extend to accept on/off/yes/no, OR (b) drop on/off from docs and success criteria. See Red Team Review Updates. -->
+   If resolution (a): also update `parseBool` to accept `on/off`/`yes/no`.
+5. **Tests:**
+   - `settings_test.go`: assert `Defaults().UpdateCheck == false`; load a JSON
+     file missing the field, assert result `.UpdateCheck == false`.
+   - `cmd_config_test.go`: `set update_check true` → `get update_check` returns
+     `true`; invalid value (e.g., `"maybe"`) returns a parse error.
+6. Run `make test-race && make lint`. Confirm `go.mod` unchanged.
+
+## Todo List
+
+- [ ] Add `UpdateCheck bool` field to `Settings` struct
+- [ ] Add `UpdateCheck: false` to `Defaults()`
+- [ ] Add row to `configRows()`
+- [ ] Add `case "update_check":` to `configSet()` switch
+- [ ] settings_test.go cases
+- [ ] cmd_config_test.go cases
+- [ ] Backwards-compat load test (missing field → false)
+- [ ] All gates green
+
+## Success Criteria
+
+- [ ] `typeburn config list` includes `update_check  false` row.
+- [ ] `typeburn config set update_check on` works (`strconv.ParseBool` accepts `on/off/true/false/1/0`).
+- [ ] `typeburn config set update_check maybe` returns error.
+- [ ] Loading a pre-v2.1 settings file (no `update_check` key) yields `false`.
+- [ ] `go test ./internal/config/... ./internal/cli/...` passes.
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|---|---|
+| Default-true drift (scout/auditor pressure) | Plan §"Locked decisions" explicit; code comment justifies; CI does not enforce default — code review must catch flips |
+| `parseBool` helper name collides with existing | Search before adding; reuse if present |
+| JSON tag mismatch (camelCase vs snake_case) | Existing keys use snake_case (`default_mode`); follow that |
+
+## Security Considerations
+
+None — bool config field, no PII, no network.
+
+## Next Steps
+
+- Phase 3 consumes this field indirectly via `update.Check()`; explicit flag
+  bypasses the gate (always runs when user passes `--check-update`).
+- Phase 4 gates the opportunistic check on `cfg.UpdateCheck`.
+
+## Red Team Review Updates (2026-05-21)
+
+<!-- red-team-finding-3 --> **H1 — `parseBool` does NOT accept `on/off`.** Verified at
+`internal/cli/cmd_config.go:138-147`: existing `parseBool` accepts ONLY
+`true/false/1/0`. Plan's Success Criteria #2 ("`strconv.ParseBool` accepts
+`on/off/true/false/1/0`") and Phase 4's manual-smoke `typeburn config set update_check on`
+are both factually wrong — these commands would fail today.
+
+**Resolution — locked (a) by user 2026-05-21:**
+
+**(a)** Extend `parseBool` in `cmd_config.go` to accept `on/off` (also `yes/no` while we're at it for unix conventions):
+```go
+func parseBool(value string) (bool, bool) {
+    switch strings.ToLower(strings.TrimSpace(value)) {
+    case "true", "1", "on", "yes":  return true, true
+    case "false", "0", "off", "no": return false, true
+    default:                          return false, false
+    }
+}
+```
+Add tests for all new accepted forms AND backwards-compat (previous values still work).
+Update existing `blink_cursor` set behavior — same parser, so it inherits this.
+
+**(b)** ~~Keep `parseBool` as-is; rewrite plan + docs + Phase 4 smoke to use only
+`true/false`. Update README/cli-reference accordingly. Reject `on/off` in docs.~~
+**Not chosen.**
+
+**Implementation Step update** — Step 4 now reads: "Add `case \"update_check\":`
+to `configSet()` switch, calling the (possibly extended per resolution (a)) `parseBool`."
+
+**Success Criteria update** — replace criterion 2 with:
+- [ ] `typeburn config set update_check true` works.
+- [ ] `typeburn config set update_check on` works (only if resolution (a) chosen).
+- [ ] `typeburn config set update_check maybe` returns a clear error listing valid forms.

--- a/plans/20260521-0700-typeburn-update-check-cli/phase-03-version-check-update-flag.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/phase-03-version-check-update-flag.md
@@ -1,0 +1,158 @@
+---
+phase: 3
+title: "Version --check-update Flag"
+status: pending
+priority: P1
+effort: "3h"
+dependencies: [1]
+---
+
+# Phase 3: `typeburn version --check-update` Flag
+
+## Overview
+
+Add an explicit, synchronous update-check trigger as a flag on the existing
+`version` subcommand. Always runs (config-independent — user explicitly asked).
+Supports `--json`. Honors the same 1.5s timeout + silent-degrade rules but
+prints an honest "could not check" line on errors (or `{"error":"..."}` for JSON)
+because the user actively requested information.
+
+## Requirements
+
+**Functional**
+- New flag: `--check-update` (BoolVar, long-only, no short form).
+- When set, after the existing version output, call
+  `update.Check(ctx, version.Resolve().Version, force=true)`.
+- Human output:
+  - Up-to-date: `you are on the latest version (v2.1.0).`
+  - Upgrade available: full 3-line block (release URL + 3 verbatim commands).
+  - Dev/pseudo-version skip: `version check skipped: build has no release version.`
+  - Error: `could not check for updates: <reason>` to stderr; exit code 0
+    (do not fail the user's command).
+- `--json` output:
+  ```json
+  {
+    "current": "v2.0.0",
+    "latest": "v2.1.0",
+    "upgrade_available": true,
+    "release_url": "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0",
+    "checked_at": "2026-05-21T07:00:00Z"
+  }
+  ```
+  Error JSON: `{"error":"..."}` with non-zero exit code (scripting needs to detect).
+- Combined `--json` + `--check-update`: emit a single JSON object that includes
+  the existing version fields PLUS an `update_check` object — proposed wrapper:
+  ```json
+  {
+    "version": {"version":"v2.0.0","commit":"abc","date":"..."},
+    "update_check": {...}
+  }
+  ```
+  Decide between this and "two JSON objects on consecutive lines" — propose
+  **single object** for jq-friendliness.
+- Explicit flag bypasses the cache (`force=true`).
+
+**Non-functional**
+- New code path < 50 LOC delta in `cmd_version.go`.
+- Stdlib only.
+
+## Architecture
+
+Scout §1: existing `cmd_version.go:24` registers `--json` flag adjacent;
+add `--check-update` in the same block. The `runVersion` function gains a
+parameter and a conditional tail.
+
+For the JSON wrapper decision: changing the existing `--json` shape would
+break v2.0.0 scripts. **Decision:** when `--check-update` is set with `--json`,
+emit the wrapper. Without `--check-update`, the existing `--json` shape stays
+identical (backwards-compatible).
+
+## Related Code Files
+
+- **Modify:** `internal/cli/cmd_version.go` (lines 24, 29-31, 33-51).
+- **Modify:** `internal/cli/cmd_version_test.go` — add flag tests.
+- **Create:** Possibly `internal/cli/cmd_version_check.go` if `cmd_version.go`
+  exceeds 200 LOC after the addition. **First check current LOC; modularize
+  only if needed.**
+
+## Implementation Steps
+
+1. Add `var checkUpdate bool` and `cmd.Flags().BoolVar(&checkUpdate, "check-update", false, "check GitHub for a newer release")`.
+2. Refactor `runVersion(cmd, asJSON, checkUpdate)` signature.
+3. If `checkUpdate`:
+   - `ctx := cmd.Context()` (cobra provides; respects parent timeout if any).
+   - `currentVer := version.Resolve().Version`
+   - `result, err := update.Check(ctx, currentVer, true)`
+   - Branch on `result == nil && err == nil` (dev-skip), `err != nil` (error path),
+     `result.UpgradeAvailable` (upgrade path), else (up-to-date path).
+4. Render:
+   - Human path: `fmt.Fprintln(cmd.OutOrStdout(), ...)` for the 4 scenarios above.
+   - Upgrade hint block (locked verbatim):
+     ```
+     typeburn <latest> is available (you have <current>).
+     Release notes: <url>
+     Upgrade with one of:
+       brew upgrade typeburn
+       curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
+       go install github.com/bavanchun/Typeburn@latest
+     ```
+   - JSON wrapper path: build the `{version, update_check}` struct, pass to
+     `output.RenderJSON`.
+5. **Tests** (`cmd_version_test.go`):
+   - Inject a stub for `update.Check` via a package-level function var (test seam).
+     Pattern: `var checkFn = update.Check` at file top; tests overwrite.
+   - Cases: stable-upgrade, up-to-date, dev-skip, error, JSON wrapper shape.
+
+## Todo List
+
+- [ ] Register `--check-update` flag
+- [ ] Refactor `runVersion` signature + body
+- [ ] Add 4-branch rendering (skip/error/upgrade/up-to-date)
+- [ ] JSON wrapper struct
+- [ ] Test seam (`var checkFn = update.Check`)
+- [ ] Tests: stable-upgrade, up-to-date, dev-skip, error, JSON
+- [ ] LOC check (split if cmd_version.go ≥ 200)
+- [ ] Manual smoke: `./bin/typeburn version --check-update` against real API
+
+## Success Criteria
+
+- [ ] `typeburn version --check-update` against real `api.github.com` returns
+  ≤1.6s on cold, ≤100ms on warm cache (Phase 1 cache shared with Phase 4).
+- [ ] `typeburn version --check-update --json` emits valid JSON parseable by `jq`.
+- [ ] Existing `typeburn version --json` output is **unchanged** when
+  `--check-update` is NOT passed (backwards-compat).
+- [ ] Network failure prints to stderr, exits 0 (human) / non-zero (JSON
+  with `--json`).
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|---|---|
+| `cmd_version.go` exceeds 200 LOC | Split into `cmd_version_check.go` |
+| Test seam breaks production wiring | Seam is a `var` assignment at file top — compile-checked |
+| JSON wrapper breaks v2.0.0 scripts | Only emitted when `--check-update` is set; default JSON shape unchanged |
+| Real-API call in test suite (flake/rate-limit) | Tests use the seam, NOT the real API |
+| User confusion between explicit flag and config | Help text + docs (Phase 5) make it explicit |
+
+## Security Considerations
+
+- Stderr output may include URLs/error strings; sanitize: no user input
+  flows into error messages, so injection risk is nil.
+- Exit code policy: 0 for success/dev-skip/network-fail in human mode;
+  non-zero for `--json` errors to support `set -e` scripts.
+
+## Next Steps
+
+- Phase 4 reuses `update.Check` (with `force=false`) for the opportunistic
+  path; cache built here on warm-up benefits TUI launch.
+
+## Red Team Review Updates (2026-05-21)
+
+<!-- red-team-finding-15 --> **M12 — `Resolve()` signature pin.** Verified at `internal/version/version.go:28-32, 40`:
+`Resolve()` returns the `Info` struct `{Version, Commit, Date string}`. The Phase 3
+pseudo-code `currentVer := version.Resolve().Version` is correct (no change needed
+here). The contradiction was in Phase 1 prose only — corrected in that phase's
+red-team updates. Add a one-line comment in implementation to anchor for future readers:
+```go
+// version.Resolve() returns Info{Version, Commit, Date}; .Version is the resolved tag.
+```

--- a/plans/20260521-0700-typeburn-update-check-cli/phase-04-opportunistic-tui-wiring-result-footer.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/phase-04-opportunistic-tui-wiring-result-footer.md
@@ -1,0 +1,251 @@
+---
+phase: 4
+title: "Opportunistic TUI Wiring + Result Footer"
+status: pending
+priority: P1
+effort: "4h"
+dependencies: [1, 2]
+---
+
+# Phase 4: Opportunistic TUI Wiring + Result Footer
+
+## Overview
+
+When `update_check=on` AND the user launches the TUI (`typeburn` bare, or
+`typeburn run` without `--no-tui`), synchronously call
+`update.Check(ctx, ver, force=false)` before `tea.NewProgram(...).Run()`.
+On a cache hit (typical), this is sub-millisecond. On a cache miss, up to
+1.5s. If a result hints at an upgrade, pass it via a new `app.New()`
+parameter to the root model, which forwards it to `screen_result` for
+footer rendering after the typing session.
+
+**`--no-tui` path explicitly does NOT trigger** (locked decision; scout §11 Q1).
+
+## Requirements
+
+**Functional**
+- TUI launch path: `cmd_run.go` runTUICommand — sync `update.Check()` when
+  `settings.UpdateCheck == true` AND `version.Resolve().Version` is not a
+  dev/pseudo-version.
+- Bare `typeburn` (root-cmd fall-through to TUI): same gate applies.
+  Confirm `cmd_run.go` is the actual entry — if not, find the right spot.
+- Hint surfaces only on the Result screen footer (NOT Home, NOT during typing).
+- Footer text (locked verbatim):
+  `↑ v<latest> available — run "typeburn version --check-update"`
+  Single line, muted style, below existing hints. No release URL/upgrade
+  commands (those live in `version --check-update`; the TUI hint just points there).
+- If `update.Check` returns error or nil: no footer change, no log spam.
+
+**Non-functional**
+- New code in `cmd_run.go` ≤ 10 LOC.
+- New parameter on `app.New(...)` — confirm it doesn't break existing tests
+  (scout §6 shows the constructor; will need test updates).
+- `screen_result` LOC after change must stay < 200.
+- Result footer style: reuse `theme.RoleTextMuted` (scout §5 recommendation).
+
+## Architecture
+
+Scout §4 confirms insertion point: `internal/cli/cmd_run.go` between settings
+load (line 67) and `app.New(...)` call (line 84). The hint flows as a positional
+param into `app.New(...)`, then via a new `ResultModel.WithUpdateHint(*update.Result)`
+method when the root model transitions on `ResultMsg` (scout §6 lines 100-104).
+
+**Why pass via constructor, not a `tea.Cmd` emitting `UpdateHintMsg`?**
+- The check runs *before* `tea.NewProgram(...).Run()`, so a message-based
+  flow would require firing the cmd in the model's `Init()`, which adds an
+  async lifecycle to the TUI.
+- Result is known at startup; passing by value through New() is simpler,
+  predictable, and pure-Elm-compatible.
+- If a future requirement needs mid-session update detection (re-check while
+  user idles), promote to `UpdateHintMsg` then.
+
+Scout §6 step 4 also suggests "Option-pattern builder for app.New" — we will
+**not** introduce that for v2.1; just add a positional `*update.Result` param.
+Justification: KISS; current `New(theme, settings, codeText, codeHint)`
+signature is already positional; adding one more pointer param matches.
+
+## Related Code Files
+
+- **Modify:** `internal/cli/cmd_run.go` (lines 67-84): sync check + pass to app.New.
+- **Modify:** `internal/app/model.go` (lines 27, 60-77, 100-104): field, ctor param, hint forwarding.
+- **Modify:** `internal/ui/screen_result.go`: new field + `WithUpdateHint` method.
+- **Modify:** `internal/ui/screen_result_view.go`: render hint when set.
+- **Modify:** all existing call-sites of `app.New(...)`: add `nil` param.
+- **Modify:** existing tests touching `app.New(...)` and `ResultModel`.
+
+## Implementation Steps
+
+1. **`cmd_run.go` insertion** (between lines 83-84):
+   ```go
+   var updateHint *update.Result
+   if settings.UpdateCheck {
+       ctx, cancel := context.WithTimeout(cmd.Context(), 1500*time.Millisecond)
+       defer cancel()
+       if r, err := update.Check(ctx, version.Resolve().Version, false); err == nil && r != nil && r.UpgradeAvailable {
+           updateHint = r
+       }
+       // silent on any error — never block TUI launch
+   }
+   model := app.New(theme.Load(...), settings, codeText, "", updateHint)
+   ```
+2. **`app/model.go`:** Add `updateHint *update.Result` field; add param to
+   `New(...)` signature; assign in body; in `handleResultMsg` (line 100-104),
+   when constructing `ResultModel`, call `.WithUpdateHint(m.updateHint)`.
+3. **`screen_result.go`:** Add `updateHint *update.Result` field; add method
+   `WithUpdateHint(*update.Result) ResultModel` (returns updated copy, matches
+   existing `WithBest` chain pattern — scout §5 exemplar line 53-56).
+4. **`screen_result_view.go`:** After the panel (line 40), before footer hints,
+   insert:
+   ```go
+   if m.updateHint != nil {
+       hint := fmt.Sprintf("↑ %s available — run \"typeburn version --check-update\"", m.updateHint.Latest)
+       lines = append(lines, m.th.Style(theme.RoleTextMuted).Render(hint))
+   }
+   ```
+   Adapt to actual rendering shape from existing view code.
+5. **Update all `app.New(...)` callers** — <!-- SUPERSEDED by red-team-finding-4 (cmd_replay.go does NOT call app.New) and red-team-finding-1 (runtime.go:81 is the missed caller). See Red Team Review Updates below. -->
+   verified callers via `grep -rn "app\.New" --include="*.go"`:
+   - `internal/cli/cmd_run.go:84` — pass new param.
+   - `internal/cli/runtime.go:81` (`app.NewFromDisk`) — see finding 1 resolution.
+   - All `*_test.go` callers — grep before edit.
+6. **Tests:**
+   - `cmd_run_test.go`: new `buildRunRequest` does not change; mock the
+     update.Check call via test seam similar to Phase 3.
+   - `screen_result_test.go`: construct `ResultModel.WithUpdateHint(&update.Result{...})`,
+     assert View output contains the locked text.
+   - `app/model_test.go`: confirm hint forwards through `handleResultMsg`.
+7. **Manual smoke:**
+   - `typeburn config set update_check on`
+   - Pre-populate a stub cache file with a fake newer version (e.g., v9.0.0):
+     `echo '{"current":"v2.0.0","latest":"v9.0.0","upgrade_available":true,"release_url":"https://example.com","checked_at":"<now>"}' > ~/.local/state/typeburn/update-check.json`
+   - Launch `typeburn`, complete a quick test, verify the footer hint renders.
+   - Clear cache, set `update_check off`, relaunch, verify NO hint and no
+     outbound HTTP (use `tcpdump`/`lsof -i`/network log to confirm).
+8. **CI gates** green: `make test-race`, `make lint`, `make size-check`,
+   `notui-noexit-check`.
+
+## Todo List
+
+- [ ] cmd_run.go: conditional sync update.Check + hint capture
+- [ ] app/model.go: field + ctor param + handleResultMsg wiring
+- [ ] screen_result.go: field + WithUpdateHint method
+- [ ] screen_result_view.go: render locked footer hint
+- [ ] Update all app.New callers (cmd_run, cmd_replay, tests)
+- [ ] Tests for cmd_run, screen_result, app model
+- [ ] Manual smoke (stub cache + real launch)
+- [ ] Confirm --no-tui path does NOT call update.Check (gated by runTUICommand only)
+- [ ] All CI gates green
+
+## Success Criteria
+
+- [ ] With `update_check=off`: launching TUI does NOT call `api.github.com`
+  (verifiable via packet capture or `lsof`).
+- [ ] With `update_check=on` + stub cache showing newer version: Result
+  screen footer shows the locked hint text.
+- [ ] With `update_check=on` + dev build: NO check (silent skip).
+- [ ] `--no-tui` runner never triggers update check regardless of config.
+- [ ] All existing `app.New(...)` callers updated; build green.
+- [ ] `make test-race -count=1` passes.
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|---|---|
+| 1.5s startup latency on cold cache | Cache hit makes this near-zero after first call; opt-in default-OFF means most users never pay it |
+| `app.New(...)` signature change ripples broadly | Compiler-checked; one positional add at end; all callers grep-pable |
+| Hint renders on dev builds via stale cache | Phase 1 dev-skip happens BEFORE cache read; safe |
+| `--no-tui` accidentally inherits the check | runTUICommand vs runNoTUICommand are separate (scout §11); explicit gate |
+| Hint text changes break test goldens | No teatest goldens in repo (scout §10) — string-match tests only; just update assertions |
+| Bare `typeburn` (root fall-through) path skipped | Verify which function handles bare entry — same gate must apply |
+
+## Security Considerations
+
+- Outbound traffic only when user opted in. No first-launch surprise.
+- No PII in HTTP request or cache.
+- Hint text contains no remote-controllable strings — version is parsed/validated
+  by the comparator in Phase 1.
+
+## Next Steps
+
+- Phase 5: docs, CHANGELOG, manual install/upgrade README section refresh.
+
+## Red Team Review Updates (2026-05-21)
+
+<!-- red-team-finding-1 --> **C1 — bare `typeburn` path misses the check.** Verified at `internal/cli/runtime.go:80-82`:
+```go
+func runHomeTUI(ctx context.Context, codeText, codeHint string) error {
+    return runModelTUI(ctx, app.NewFromDisk(codeText, codeHint))
+}
+```
+Bare `typeburn` flows `root.go:62` → `runHomeTUI` → `app.NewFromDisk` — completely
+separate from `cmd_run.go:84`'s `app.New`. As-written, Phase 4 only patches
+`cmd_run.go`, so the most common launch path silently misses the opportunistic check.
+
+**Resolution — shared helper at the runtime layer:**
+
+1. Extract a helper `func resolveUpdateHint(ctx context.Context, settings config.Settings) *update.Result`
+   into `internal/cli/runtime.go` (or a sibling file). Returns nil unless
+   `settings.UpdateCheck && version.Resolve().Version` is non-dev. Wraps the
+   `update.Check(ctx, ver, false)` call with an 800ms `context.WithTimeout`
+   (per finding 9). Silent-degrade.
+2. Modify `runHomeTUI` to load settings (or accept them as a param from caller),
+   call `resolveUpdateHint`, then pass to `app.NewFromDisk`.
+3. Extend `app.NewFromDisk(codeText, codeHint, updateHint)` and propagate
+   `*update.Result` through to `Model`.
+4. `cmd_run.go` (the `typeburn run` path) calls the same helper, passes the result
+   to `app.New(...)` as the new 5th positional param.
+
+**Net result:** ONE call site for the update-check decision (runtime.go helper);
+TWO call paths that consume its result (bare `typeburn` and `typeburn run`).
+
+<!-- red-team-finding-4 --> **H2 — `cmd_replay.go` does NOT call `app.New`.** Verified by `grep -rn "app\.New" --include="*.go"`:
+only callers are `cmd_run.go:84` (app.New) and `runtime.go:81` (app.NewFromDisk).
+`cmd_replay.go` is a headless metrics replayer — imports `metrics`/`typing`/`output`/`config`
+only. **Strike the `cmd_replay.go` bullet from Implementation Step 5.** Replace with:
+- `internal/cli/runtime.go` — `runHomeTUI` + `NewFromDisk` (per finding 1).
+- `internal/cli/cmd_run.go` — `app.New` (Phase 4 main path).
+
+<!-- red-team-finding-6 --> **H4 — TUI footer re-validation.** Even with cache load-time validation (Phase 1
+finding 6), defense-in-depth: the screen_result_view footer SHOULD NOT use
+`fmt.Sprintf` interpolation with raw `m.updateHint.Latest`. Instead, run the same
+regex validation at render time and fall back to no-render on mismatch. Locked text becomes:
+```go
+if m.updateHint != nil {
+    latest := m.updateHint.Latest
+    if !validSemverRe.MatchString(latest) {
+        // load-time guard should have caught this; belt-and-suspenders
+        return ""
+    }
+    hint := fmt.Sprintf("↑ %s available — run \"typeburn version --check-update\"", latest)
+    lines = append(lines, m.th.Style(theme.RoleTextMuted).Render(hint))
+}
+```
+
+<!-- red-team-finding-9 --> **H7 — opportunistic timeout 800ms.** Per Phase 1 finding 9, the opportunistic
+path uses a tighter 800ms outer cap (vs 1.5s for explicit). Update Implementation
+Step 1 pseudo-code:
+```go
+ctx, cancel := context.WithTimeout(cmd.Context(), 800*time.Millisecond)
+```
+Trade-off: a cold-cache opportunistic check sees 800ms wall delay (acceptable for
+TUI launch); explicit `--check-update` users still get the full 1.5s budget. Most
+launches hit cache (sub-ms) once the first save persists (per Phase 1 finding 2).
+
+### Updated Implementation Step 5 (post-finding-1+4)
+
+Touch the following call sites — verified by `grep -rn "app\.New"`:
+- `internal/cli/cmd_run.go:84` — pass new 5th positional `*update.Result`.
+- `internal/cli/runtime.go:81` — refactor `NewFromDisk` signature OR plumb hint
+  via the new shared `resolveUpdateHint` helper (preferred — see finding 1).
+- `internal/app/model_settings.go` (wherever `NewFromDisk` is defined) — accept
+  the new optional parameter.
+- All `*_test.go` callers of `app.New` and `app.NewFromDisk` — grep before edit:
+  `grep -rn "app\.New\(\|app\.NewFromDisk\(" --include="*_test.go"`.
+
+### Updated Manual Smoke (Step 7)
+
+Pre-populate cache, then verify BOTH launch paths:
+- `typeburn` (bare) — should show hint after a typing session.
+- `typeburn run` — should show same hint.
+- `typeburn run --no-tui ...` — must NOT trigger any check (locked decision; verify
+  with `lsof -i` or packet capture).

--- a/plans/20260521-0700-typeburn-update-check-cli/phase-05-docs-sync-and-release-prep.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/phase-05-docs-sync-and-release-prep.md
@@ -1,0 +1,201 @@
+---
+phase: 5
+title: "Docs Sync and Release Prep"
+status: pending
+priority: P2
+effort: "2h"
+dependencies: [1, 2, 3, 4]
+---
+
+# Phase 5: Docs Sync and Release Prep
+
+## Overview
+
+Update every doc that mentions the CLI surface or upgrade flow; write
+`CHANGELOG.md [Unreleased]` content for v2.1.0; pre-stage `.github/release-notes.md`
+so the release pipeline never trips the "stale notes" trap that caught us
+during the v2.0.0 dry-run.
+
+## Requirements
+
+**Functional**
+- `README.md`: add `--check-update` flag mention in Install/Upgrade section;
+  document the `update_check` config key + opt-in nature; explicitly state
+  "no auto-update — manual install".
+- `docs/cli-reference.md`: new flag, new config key, JSON schema for
+  update-check output, exit-code policy.
+- `docs/codebase-summary.md`: new `internal/update/` package paragraph in the
+  per-package list; note the layering (UI-free, stdlib + storage + config).
+- `docs/system-architecture.md`: update if the diagram or layering description
+  needs the new package; otherwise leave alone.
+- `docs/project-roadmap.md`: mark M3 / v2.1 item complete (if tracked there).
+- `CHANGELOG.md`: add `[2.1.0]` section with `Added`/`Changed` bullets;
+  move from `[Unreleased]` at tag time.
+- `.github/release-notes.md`: pre-stage v2.1.0 body (one of the lessons from
+  the v2.0.0 dry-run was a stale notes file blocking release).
+
+**Non-functional**
+- Sacrifice grammar for concision (per CLAUDE.md project rule).
+- No code changes in this phase.
+
+## Architecture
+
+Doc precedence (CLAUDE.md): `CHANGELOG.md` is the authoritative source for
+release notes — extracted verbatim to `.github/release-notes.md`. We pre-stage
+the latter to match exactly, with the link reference at the bottom.
+
+## Related Code Files
+
+- **Modify:** `README.md`, `docs/cli-reference.md`, `docs/codebase-summary.md`,
+  `docs/project-roadmap.md`, `CHANGELOG.md`.
+- **Modify:** `.github/release-notes.md` (stage v2.1.0 content).
+- **Maybe modify:** `docs/system-architecture.md` (if package map changes warrant).
+- **Add:** `docs/journals/2026-MM-DD-update-check-v2.1.md` (post-merge, via /ck:journal).
+
+## Implementation Steps
+
+1. **CHANGELOG.md** — add `[Unreleased]` entries (will be promoted to `[2.1.0]`
+   at tag time):
+   ```markdown
+   ## [Unreleased]
+
+   ### Added
+
+   - `typeburn version --check-update`: explicit, synchronous check against
+     GitHub Releases for a newer version. Supports `--json` (wrapped output
+     under `update_check` key). Honors a 1.5s hard timeout and silent-degrades
+     on any network/parse error.
+   - Opt-in opportunistic update check on TUI launch (`typeburn config set
+     update_check on`). When enabled, a one-line "↑ vX.Y.Z available" hint
+     renders on the Result screen footer after a typing session. 24h cache.
+     `--no-tui` path is unaffected.
+   - New config key `update_check` (bool, default `false`). Exposed via
+     `typeburn config set/get/list update_check`.
+
+   ### Changed
+
+   - `internal/storage.atomicWrite` is now exported as `storage.AtomicWrite`
+     for reuse by the new `internal/update` package. Behavior unchanged.
+
+   ### Notes
+
+   - No self-upgrade: the check notifies only. Install methods unchanged —
+     `install.sh`, `brew upgrade`, and `go install ...@latest` are the three
+     upgrade paths printed verbatim in `--check-update` output.
+   - Zero new `go.mod` entries; stdlib-only implementation.
+   ```
+2. **`.github/release-notes.md`** — replace v2.0.0 content with the `[2.1.0]`
+   section above (with `## [2.1.0] - YYYY-MM-DD` header + trailing
+   `[2.1.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0` link).
+3. **`README.md`** — under Install/Upgrade section, add a subsection:
+   ```markdown
+   ### Check for updates
+
+   - `typeburn version --check-update` — explicit, on-demand. Adds `--json`
+     for scripting.
+   - Opt-in opportunistic notice on TUI launch:
+     `typeburn config set update_check on`. The TUI prints a footer hint
+     on the Result screen if a newer release exists. Disable any time with
+     `typeburn config set update_check off`.
+
+   The check is read-only: it reports a new version and prints upgrade
+   commands; it never modifies the binary. Default is **off** to keep
+   typeburn offline-first.
+   ```
+4. **`docs/cli-reference.md`** — add `--check-update` row to the `version`
+   subcommand table; add `update_check` row to the config keys section;
+   document the JSON wrapper schema:
+   ```json
+   {
+     "version": {"version": "...", "commit": "...", "date": "..."},
+     "update_check": {
+       "current": "v2.0.0",
+       "latest": "v2.1.0",
+       "upgrade_available": true,
+       "release_url": "https://...",
+       "checked_at": "2026-..."
+     }
+   }
+   ```
+   Document exit codes: 0 for human; non-zero for `--json` with error.
+5. **`docs/codebase-summary.md`** — under "Pure logic" list, add bullet:
+   ```
+   - `internal/update`: GitHub Releases API client + 24h JSON cache + stdlib
+     semver comparator + orchestrator. UI-free. Stdlib + storage + config only.
+   ```
+6. **`docs/project-roadmap.md`** — locate the v2.1 milestone (or add one)
+   and mark the update-check task complete.
+7. **Pre-PR review:** grep for `update_check` and `--check-update` across
+   docs to confirm every mention is consistent (snake_case for config key,
+   kebab-case for flag).
+
+## Todo List
+
+- [ ] CHANGELOG.md [Unreleased] block
+- [ ] .github/release-notes.md pre-staged for v2.1.0
+- [ ] README.md Install/Upgrade "Check for updates" subsection
+- [ ] docs/cli-reference.md flag + config + JSON shape
+- [ ] docs/codebase-summary.md new package entry
+- [ ] docs/project-roadmap.md v2.1 entry
+- [ ] grep -nE 'update_check|--check-update' across all docs for consistency
+- [ ] Optionally update docs/system-architecture.md if package map relevant
+
+## Success Criteria
+
+- [ ] Every mention of the feature in `./docs` matches the locked text in
+  Phases 3-4 (footer hint text, 3 upgrade commands, JSON schema).
+- [ ] `.github/release-notes.md` matches `CHANGELOG.md [2.1.0]` body verbatim
+  before tagging.
+- [ ] No `chore:` or `docs:` in commit messages for `.claude/` (per project
+  CLAUDE.md). For `.github/release-notes.md` and `docs/`, use `docs:` or
+  `feat(docs):` as fits.
+- [ ] CI green.
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|---|---|
+| Docs drift between `CHANGELOG.md` and `.github/release-notes.md` | Pre-stage both at the same time; grep verification step |
+| Footer hint text in docs goes stale if Phase 4 changes wording | Lock text in Phase 4 plan; reference Phase 4 file in this phase |
+| Roadmap doesn't track v2.1 | Add it if missing; do not silently skip |
+
+## Security Considerations
+
+None — docs only.
+
+## Next Steps
+
+- After PR merge to `main`: tag `v2.1.0` via the standard release runbook
+  (dry-run `v0.0.0-rc.test` → verify 7 assets + correct notes body → delete
+  → annotated v2.1.0 tag in a separate push).
+- Run `/ck:journal` for session reflection + decision record.
+
+## Red Team Review Updates (2026-05-21)
+
+<!-- red-team-finding-8 --> **H6 — release-notes ordering hard precondition.** Phase 5 Step 2 instructs
+replacing `.github/release-notes.md` content with `[2.1.0]`. CLAUDE.md release
+engineering rules + plan.md Dependencies require this happens ONLY after v2.0.0
+is published. Risk: if the feature branch updates `release-notes.md` before
+v2.0.0 is tagged, and an unrelated v2.0.0 dry-run/tag fires from main with the
+v2.1.0 content present, v2.0.0's GitHub Release publishes v2.1.0 notes — the
+exact trap the v2.0.0 dry-run already caught once.
+
+**Hard precondition added to Todo List:**
+
+- [ ] **GATE — do not start Phase 5 Step 2 until ALL of:**
+  - `v2.0.0` tag exists at `https://github.com/bavanchun/Typeburn/releases/tag/v2.0.0`.
+  - The `v2.0.0` GitHub Release body matches `CHANGELOG.md [2.0.0]` (i.e., PR #18 landed).
+  - Feature branch `feat/update-check-v2.1` was rebased onto `main` post-v2.0.0 tag.
+
+If PR #18 stalls > 7 days, escalate: cut `feat/update-check-v2.1` from current `main`
+HEAD anyway; defer Phase 5 docs Step 2 until v2.0.0 ships. Phase 5 CHANGELOG.md
+edits must **rebase** (preserve prior `[2.0.0]` entries), not overwrite.
+
+### Updated Step 2 wording
+
+Replace "replace v2.0.0 content" with:
+> "After the v2.0.0 tag is published, **append** the `[2.1.0]` content to
+> `.github/release-notes.md` and remove the now-published `[2.0.0]` block —
+> the file should always reflect the *next* release's body, not the prior one.
+> Verify the rendered v2.0.0 GitHub Release page is unchanged (release.yml has
+> already consumed its notes by tag time)."

--- a/plans/20260521-0700-typeburn-update-check-cli/plan.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/plan.md
@@ -1,0 +1,135 @@
+---
+title: "Typeburn Update-Check CLI (v2.1.0)"
+description: >-
+  Add a stdlib-only update notifier: `typeburn version --check-update`
+  (explicit, sync, human + JSON) plus an opt-in opportunistic check on TUI
+  launch (24h cache, 1.5s timeout, silent-degrade) rendering on the Result
+  screen footer. Pure-logic `internal/update/` package mirrors existing
+  `internal/storage` atomic patterns. Zero new go.mod entries.
+  Locked: opt-in default-OFF, all three install methods printed verbatim,
+  pre-releases filtered, dev-build skip, no self-upgrade. Ships in v2.1.0
+  (separate from v2.0.0 in flight via PR #18).
+status: pending
+priority: P2
+branch: "feat/update-check-v2.1"
+tags: [feature, cli, network, release]
+blockedBy: []
+blocks: []
+created: "2026-05-21T06:52:29.557Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Typeburn Update-Check CLI (v2.1.0)
+
+## Overview
+
+Notify users of newer releases via two surfaces — both stdlib-only, both
+silent-degrade, both opt-in or explicit. No self-upgrade. Ships **after**
+v2.0.0 is tagged.
+
+## Context Links
+
+- Brainstorm summary: [brainstorm-summary.md](./brainstorm-summary.md)
+- Research: GitHub API/HTTP — [researcher-01](./research/researcher-01-github-api-http.md)
+- Research: XDG/storage/semver — [researcher-02](./research/researcher-02-xdg-storage-semver.md)
+- Scout: per-phase touchpoints — [scout-touchpoints.md](./research/scout-touchpoints.md)
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Update Package Pure-Logic](./phase-01-update-package-pure-logic.md) | Pending |
+| 2 | [Config Integration](./phase-02-config-integration.md) | Pending |
+| 3 | [Version --check-update Flag](./phase-03-version-check-update-flag.md) | Pending |
+| 4 | [Opportunistic TUI Wiring + Result Footer](./phase-04-opportunistic-tui-wiring-result-footer.md) | Pending |
+| 5 | [Docs Sync and Release Prep](./phase-05-docs-sync-and-release-prep.md) | Pending |
+
+## Locked decisions (user-confirmed during brainstorm — do NOT reverse)
+
+- **Default state:** `update_check` = **false** (opt-in). Scout §3 suggested
+  `true`; that is reversed per user decision. Plan enforces `false`.
+- **Zero new go.mod entries.** Scout §11 Q4 mentioned `Masterminds/semver/v3`;
+  reversed. Stdlib comparator only (~30 LOC; see researcher-02 Part B).
+- **Cache TTL** 24h, **HTTP timeout** 1.5s, silent on any error.
+- **Both triggers:** explicit (`version --check-update`) AND opportunistic
+  (config-gated). Render on Result screen footer only.
+- **All 3 upgrade commands printed verbatim** — no install-method detection.
+- **Pre-release / draft filter:** API responses with `prerelease=true` or
+  tags matching `-rc/-beta/-alpha/-pre` or `v0.0.0-*` are treated as
+  "no stable release available."
+- **Dev-build skip:** when `version.Resolve()` returns `dev`/empty/pseudo-version
+  (`debug.ReadBuildInfo` (devel) form), check is skipped entirely.
+- **`--no-tui` path does NOT trigger the opportunistic check.** Scout §11 Q1
+  flagged this; decision: keep no-TUI scriptable / outbound-traffic-free.
+
+## Dependencies
+
+- **Blocked on:** PR #18 (release-notes v2.0.0 refresh) merged and v2.0.0
+  tagged. Branch this work off `main` after v2.0.0 ships.
+- **Cross-plan:** none. pro-cli-v2 plan is `status: completed`.
+
+## Success criteria (whole-plan)
+
+- `typeburn version --check-update` returns within 1.6s on cache miss,
+  ≤100ms on cache hit, prints the locked 3-command hint or a clean
+  "up to date".
+- Opportunistic check fires only when `update_check=on` AND a TUI is
+  launched AND version is real (not `dev`/pseudo-version).
+- All CI gates green: `make test-race`, `make lint`, `make size-check`,
+  `notui-noexit-check`.
+- `go.mod` diff = zero new direct dependencies.
+- Binary size delta < 100KB (stdlib `net/http` already linked elsewhere).
+- Each new/modified Go file < 200 LOC.
+- `internal/update/` package has **zero** imports of `bubbletea`/`lipgloss`.
+
+## Red Team Review
+
+### Session — 2026-05-21
+**Findings:** 15 (15 accepted, 0 rejected from cap of 15; 3 below-cap rejections logged)
+**Severity breakdown:** 2 Critical, 7 High, 6 Medium
+**Reviewers:** Security Adversary, Failure Mode Analyst, Assumption Destroyer (3 hostile lenses, Full-tier verification)
+
+| # | Finding | Severity | Disposition | Applied To |
+|---|---------|----------|-------------|------------|
+| 1 | Bare `typeburn` uses `runtime.go:81 → app.NewFromDisk`, NOT `cmd_run.go`'s `app.New`; Phase 4 misses it | Critical | Accept | Phase 4 |
+| 2 | `storage.atomicWrite` requires parent dir to exist; `cache.Save` will silently fail on fresh installs | Critical | Accept | Phase 1 |
+| 3 | `strconv.ParseBool` does NOT accept `on/off`; existing `parseBool` (cmd_config.go:138-147) only takes `true/false/1/0` | High | Accept | Phase 2 |
+| 4 | `cmd_replay.go` does NOT call `app.New`; Phase 4 Step 5 lists it incorrectly | High | Accept | Phase 4 |
+| 5 | No `http.Client.CheckRedirect` — hostile 302 could exfiltrate UA, downgrade scheme | High | Accept | Phase 1 |
+| 6 | Cached `Latest`/`ReleaseURL` rendered without re-validation; seeded cache → ANSI/text injection in TUI footer | High | Accept | Phase 1+4 |
+| 7 | `storage.AtomicWrite` export widens TOCTOU/symlink blast radius (no `O_EXCL`/`O_NOFOLLOW`) | High | Accept (modified) | Phase 1 |
+| 8 | Phase 5 `.github/release-notes.md` pre-stage can leak v2.1 notes into v2.0 release if ordering not strict | High | Accept | Phase 5 |
+| 9 | Opportunistic 1.5s + TLS-handshake hang; no `Transport.TLSHandshakeTimeout`/`DialContext` | High | Accept | Phase 1+4 |
+| 10 | `"(devel)"` sentinel unreachable — `internal/version.go:46` filters it out (dead branch) | Medium | Accept | Phase 1 |
+| 11 | Prerelease filter denylist misses SemVer-2 numeric/canary forms (`v2.0.0-1`, `v2.0.0-canary.4`) | Medium | Accept | Phase 1 |
+| 12 | Cache schema not versioned — repo convention is `schema_version: 1` (cmd_replay.go:18) | Medium | Accept | Phase 1 |
+| 13 | Clock-skew breaks 24h TTL — future-dated cache = fresh forever; backward jump = stale forever | Medium | Accept | Phase 1 |
+| 14 | Dev-skip not whitespace/case-insensitive — `"dev "` bypasses | Medium | Accept | Phase 1 |
+| 15 | `internal/version.Resolve()` shape contradiction within plan (Phase 1 prose says "three strings"; verified struct `Info{Version,Commit,Date}` at version.go:28-32) | Medium | Accept | Phase 1+3 |
+
+**Below-cap rejections (logged, not applied):**
+- `TYPEBURN_OFFLINE=1` env override — scope creep; user explicitly invokes `--check-update` knowing they want a network call.
+- UA-strip-build-version privacy concern — low impact; opt-in default-OFF already mitigates fingerprinting.
+- `DisallowUnknownFields` on JSON decoder — would reject GitHub's normal multi-field response.
+
+### Whole-Plan Consistency Sweep
+
+After applying findings, re-read every plan file to reconcile cross-phase claims:
+
+- ✓ `app.New(...)` ctor change spec is consistent across Phase 4 and any phase mentioning callers (only Phase 4 mentions, fixed in finding 4).
+- ✓ `Resolve()` accessor pattern unified — now both Phase 1 and Phase 3 use `version.Resolve().Version`.
+- ✓ Dev-skip predicate spec is single-sourced — Phase 1 step 9 normalized; plan.md "Locked decisions" updated accordingly (see finding 10 + 14 application).
+- ✓ Cache schema version (`schema_version: 1`) referenced consistently in Phase 1 + Phase 5 (docs).
+- ✓ Phase 5 release-notes ordering precondition aligned with plan.md "Dependencies" (v2.0.0 tag must exist on GitHub).
+- ✓ `update_check` config syntax: plan now standardizes on `true/false` (or extends parseBool to accept on/off per finding 3 decision) — verify docs in Phase 5 match the implementation in Phase 2.
+- ✓ Inline supersession markers added at 4 highest-impact contradiction sites: Phase 1 Step 1 (atomic helper), Phase 1 Step 9 (dev-skip pseudocode), Phase 2 Step 4 (parseBool), Phase 4 Step 5 (caller list). Lower-impact prose (HTTP client snippet, TTL math, opportunistic timeout, release-notes wording) retains its original form for context but is fully superseded by the Red Team Review Updates sections at the end of each phase — implementers MUST read the red-team section before coding.
+
+### Decisions locked post-red-team
+
+- **Phase 2 finding 3 — `on/off` semantics:** resolution **(a) extend `parseBool`**
+  to accept `on/off/yes/no` (locked by user 2026-05-21). Phase 2 implementation
+  must update both the new `update_check` set path AND the existing `blink_cursor`
+  set path (they share the parser).
+
+No unresolved contradictions remain.

--- a/plans/20260521-0700-typeburn-update-check-cli/research/researcher-01-github-api-http.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/research/researcher-01-github-api-http.md
@@ -1,0 +1,237 @@
+# Research: GitHub Releases API & Stdlib HTTP Client Patterns for Offline-Tolerant Update Checker
+
+**Date:** 2026-05-21  
+**Work Context:** `/Users/vchun/Codes/My-projects/Typeburn`
+
+## 1. GitHub Releases API Response Shape
+
+### Endpoint
+```
+GET https://api.github.com/repos/{owner}/{repo}/releases/latest
+```
+
+### Minimal Fields Needed (extract only these)
+Per [GitHub REST Releases API](https://docs.github.com/en/rest/releases/releases):
+
+- **`tag_name`** (string) — semantic version identifier (`v2.1.0`)
+- **`html_url`** (string, URI) — link to release page on GitHub
+- **`name`** (string or null) — human-readable release name
+- **`draft`** (boolean) — if true, exclude from latest
+- **`prerelease`** (boolean) — if true, exclude unless already on pre-release
+- **`published_at`** (string or null, ISO 8601) — release timestamp
+
+Full response is 20-50+ fields (assets, reactions, author, etc.); cap body read at 64KB to prevent parse bloat from hostile or malformed responses.
+
+## 2. Rate Limiting Reality
+
+### Unauthenticated Limits
+**60 requests per hour per IP** (GitHub REST API rate limits, [verified](https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api)).
+
+### Rate-Limit Headers (in every response)
+- `X-RateLimit-Limit` — max requests per hour (60 for unauth)
+- `X-RateLimit-Remaining` — requests left in window
+- `X-RateLimit-Reset` — UTC epoch seconds when window resets
+- `X-RateLimit-Used` — requests consumed this window
+- `X-RateLimit-Resource` — which bucket this counted against (e.g., "core")
+
+### Detection: 403 + Rate-Limited
+**Response code:** 403 or 429  
+**Header check:** `X-RateLimit-Remaining: 0`  
+**Silent degradation:** Do not parse body on 403; treat as "check failed, use stale version."
+
+## 3. User-Agent Header
+
+### Requirement
+GitHub API **rejects all requests without a valid User-Agent header** (returns 403). Per [GitHub API resource overview](https://docs.github.com/en/rest/overview/resources-in-the-rest-api):
+
+> "All API requests must include a valid User-Agent header"
+
+### Recommended Format
+```
+User-Agent: Typeburn/<version> (+https://github.com/bavanchun/Typeburn)
+```
+
+Example:
+```
+User-Agent: Typeburn/2.1.0 (+https://github.com/bavanchun/Typeburn)
+User-Agent: Typeburn/dev (+https://github.com/bavanchun/Typeburn)  [for bare go install]
+```
+
+This format is compliant with the spec ("Awesome-Octocat-App" pattern) and identifies the app + link.
+
+## 4. Idiomatic Stdlib HTTP Client: Timeout Strategy
+
+### Two Mechanisms
+
+1. **`http.Client{Timeout: 1500ms}`** — blanket timeout on entire request (connect + redirect + read body). Timer continues running after `Do()` returns. Per [Go net/http docs](https://pkg.go.dev/net/http#Client.Timeout).
+
+2. **`context.WithTimeout()` + `http.NewRequestWithContext()`** — request-level deadline, cancellable, integrates with Go cancellation patterns.
+
+### Recommendation for This Use Case
+**Use BOTH (layered defense):**
+
+```go
+// Client-level safety net (catch all requests)
+client := &http.Client{
+    Timeout: 1500 * time.Millisecond,
+    Transport: &http.Transport{
+        Proxy: http.ProxyFromEnvironment,  // Honor HTTPS_PROXY, NO_PROXY
+    },
+}
+
+// Request-level deadline (explicit control)
+ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+defer cancel()
+
+req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+req.Header.Set("User-Agent", "Typeburn/"+version+" (+https://github.com/bavanchun/Typeburn)")
+
+resp, err := client.Do(req)
+```
+
+**Why both:**
+- `Client.Timeout` is a blanket safety net; catches runaway reads.
+- `context.WithTimeout` is explicit and composable; signals intent clearly.
+- Layering ensures: if context deadline fires, client timeout still backs it up.
+
+## 5. Response Body Size Cap
+
+### Pattern: `io.LimitReader`
+Per [Go io.LimitReader docs](https://pkg.go.dev/io#LimitReader):
+
+```go
+resp, _ := client.Do(req)
+defer resp.Body.Close()
+
+// Cap at 64 KB; releases JSON is ~5-15 KB
+limitedBody := io.LimitReader(resp.Body, 64*1024)
+
+// Parse from limited reader
+var release struct {
+    TagName   string `json:"tag_name"`
+    HtmlUrl   string `json:"html_url"`
+    Draft     bool   `json:"draft"`
+    Prerelease bool  `json:"prerelease"`
+}
+err := json.NewDecoder(limitedBody).Decode(&release)
+```
+
+**Cap choice: 64 KB** — safe margin above typical release JSON (~5-15 KB), protects against malicious/runaway responses, negligible memory cost.
+
+## 6. TLS, Proxy, & Accept Headers
+
+### Environment Proxy Support
+`http.DefaultTransport` does **NOT** automatically honor `HTTPS_PROXY`, `NO_PROXY` env vars. Must explicitly configure:
+
+```go
+Transport: &http.Transport{
+    Proxy: http.ProxyFromEnvironment,  // Enables env var proxy support
+}
+```
+
+This respects `HTTPS_PROXY`, `NO_PROXY` (case-insensitive), and skips proxy for localhost.
+
+### Accept Header
+GitHub Releases API does **not require** `Accept: application/vnd.github+json`. Default content negotiation works; optional header does not change response format for `/releases/latest`. Omit unless explicitly needed.
+
+### X-GitHub-Api-Version Header
+**Not required.** Requests without this header default to version `2022-11-28` (stable). Current latest is `2026-03-10`. For update checking, the stable default is sufficient; no need to pin.
+
+## 7. httptest.Server Test Pattern
+
+### Mock API for CI Testing
+
+```go
+import (
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestCheckUpdate(t *testing.T) {
+    // Mock server returns a release response
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // Verify request headers
+        if ua := r.Header.Get("User-Agent"); ua == "" {
+            w.WriteHeader(http.StatusForbidden)
+            return
+        }
+
+        // Return controlled response
+        w.Header().Set("Content-Type", "application/json")
+        w.Header().Set("X-RateLimit-Remaining", "59")
+        json.NewEncoder(w).Encode(map[string]interface{}{
+            "tag_name":   "v2.2.0",
+            "html_url":   "https://github.com/bavanchun/Typeburn/releases/tag/v2.2.0",
+            "draft":      false,
+            "prerelease": false,
+        })
+    }))
+    defer ts.Close()
+
+    // Test against mock (replace real URL with ts.URL)
+    release, err := CheckLatestRelease(ts.URL + "/repos/bavanchun/Typeburn/releases/latest")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if release.TagName != "v2.2.0" {
+        t.Errorf("got %s, want v2.2.0", release.TagName)
+    }
+}
+```
+
+**Key points:**
+- `httptest.NewServer(handler)` starts immediately; use `ts.URL` for requests.
+- Handler receives `*http.Request` for inspection (headers, method, path).
+- Use `httptest.NewRecorder()` for unit tests without full server (faster, no network).
+- Always `defer ts.Close()`.
+
+## 8. Edge Cases Worth Handling
+
+### 8.1 Repo Has Zero Published Releases Yet
+**Response:** 404 with `{"message": "Not Found"}`  
+**Handle:** Treat as "no update available" — silent, no error logged.
+
+### 8.2 Latest Is Pre-Release Only (No Stable)
+**Scenario:** `/releases/latest` returns `"prerelease": true`, and no stable release exists.  
+**Handle:** 
+- If current version is also pre-release (git-describe output like `v2.0.0-7-gabc123`), compare.
+- If current is stable, ignore pre-release; no update suggested.
+
+### 8.3 DNS Failure, Connection Refused, Slow TLS Handshake
+**All are `context` timeout violations** — hits the 1500ms deadline.  
+**Handle:** `context.Err()` or `net.Error{Timeout: true}` — catch and return "check failed."
+
+### 8.4 Version Comparison: `v2.0.0-7-gabc123` (Git-Describe)
+**Source:** `internal/version` injects `Version` from ldflags (Makefile) or `debug.ReadBuildInfo()` fallback.  
+**Comparator:** Semantic versioning libraries (e.g., `go-semver`) do NOT handle `-7-gabc123` — that's Git output, not SemVer.  
+**Design choice:** Store *latest stable* as SemVer; compare against current *major.minor.patch only* (strip git suffix if present).  
+**Example:**
+- Installed: `v2.0.0-7-gabc123` → normalize to `v2.0.0` for comparison.
+- Latest: `v2.1.0` → update available.
+- Latest: `v2.0.0` → no update.
+
+This avoids pulling in semver parsers and keeps the checker simple.
+
+---
+
+## Unresolved Questions
+
+1. **Comparator library:** Should we use `go-semver` (charmbracelet-compatible) or implement a naive string-based major.minor.patch comparison? (Defer to planner.)
+2. **Version format in binary:** Confirm `internal/version` always provides clean SemVer or git-describe suffix that needs stripping. (Inspect at implementation time.)
+3. **Cache/persistence:** Should the checker cache the "last checked" time (e.g., 24h) to avoid API spam on repeated TUI launches? (Defer to feature scope.)
+
+---
+
+## Sources
+
+- [GitHub REST Releases API](https://docs.github.com/en/rest/releases/releases)
+- [GitHub REST Rate Limiting](https://docs.github.com/en/rest/overview/rate-limits-for-the-rest-api)
+- [GitHub REST API Resources Overview](https://docs.github.com/en/rest/overview/resources-in-the-rest-api)
+- [Go net/http Client Timeout](https://pkg.go.dev/net/http#Client.Timeout)
+- [Go context.WithTimeout](https://pkg.go.dev/context#WithTimeout)
+- [Go io.LimitReader](https://pkg.go.dev/io#LimitReader)
+- [Go http.Transport Proxy](https://pkg.go.dev/net/http#Transport.Proxy)
+- [Go httptest.Server](https://pkg.go.dev/net/http/httptest#Server)
+- [Go net/http ProxyFromEnvironment](https://pkg.go.dev/net/http#ProxyFromEnvironment)

--- a/plans/20260521-0700-typeburn-update-check-cli/research/researcher-02-xdg-storage-semver.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/research/researcher-02-xdg-storage-semver.md
@@ -1,0 +1,197 @@
+---
+name: xdg-storage-semver-research
+description: XDG storage patterns, state-dir strategy, and stdlib-only semver comparator design
+---
+
+## Part A: Existing Storage Architecture
+
+### A.1 Atomic Write Pattern
+
+**Location:** `internal/storage/atomic_write.go:14-45`
+
+Signature (unexported):
+```go
+func atomicWrite(path string, data []byte) error
+```
+
+Pattern: Write to `path + ".tmp"` → fsync → rename over target. Parent dir created by callers (e.g., `SaveSettings` at line 59). Mode 0600, never panics on corrupt input. Public API: `SaveSettings(config.Settings)`, `AppendHistory(Record)`.
+
+Key defensive behavior (settings_store.go:21-46): Missing/corrupt JSON → return `config.Defaults()` (never error, never panic). Caller logic validates fields via `Normalize()` to repair out-of-range enums.
+
+### A.2 XDG Directory Resolution
+
+**Location:** `internal/config/xdg-paths.go`
+
+Functions exist:
+- `ConfigDir()` → `$XDG_CONFIG_HOME/typeburn` (fallback `~/.config/typeburn`)
+- `DataDir()` → `$XDG_DATA_HOME/typeburn` (fallback `~/.local/share/typeburn`)
+
+Helper: `resolveDir(env, homeRel)` (line 27-36) — if env var is absolute, use it; else `$HOME/homeRel/appDir`. macOS has no XDG by default; HOME fallback is the normal path.
+
+**CRITICAL GAP:** No `StateDir()` or `CacheDir()` exists. Must add one.
+
+### A.3 Directory Spec (XDG Base Directory)
+
+- `XDG_CONFIG_HOME` (default `~/.config`): settings.json — infrequently written, user-facing configuration.
+- `XDG_DATA_HOME` (default `~/.local/share`): history.json — user data, append-only after tests.
+- `XDG_STATE_HOME` (default `~/.local/state`): **correct for update-check.json** — transient cache, high-frequency reads, auto-invalidate by age.
+- `XDG_CACHE_HOME` (default `~/.cache`): alternative for update-check; less stable (user may `rm ~/.cache` anytime).
+
+**Decision:** Use `XDG_STATE_HOME`. It's the standard for session-like state (not user-facing settings, not long-term data, not throw-away cache). Existing codebase has no state-dir yet; must extend `internal/config/xdg-paths.go` with:
+```go
+func StateDir() (string, error) {
+    return resolveDir("XDG_STATE_HOME", filepath.Join(".local", "state"))
+}
+```
+
+## Part B: Version.Resolve() Behavior & Git-Describe Format
+
+**Location:** `internal/version/version.go:34-69`
+
+Signature:
+```go
+func Resolve() Info  // returns {Version, Commit, Date}
+func (i Info) String() string  // formats banner
+```
+
+Precedence chain:
+1. ldflags-injected `Version` var (set by Makefile: `-X github.com/bavanchun/Typeburn/internal/version.Version=...`)
+2. If empty, read `debug.ReadBuildInfo()`: `Main.Version` for version, vcs.revision/vcs.time for commit/date
+3. If `Main.Version` is `"(devel)"`, treat as empty (skip to step 3)
+4. Final fallback: `Version = "dev"`
+
+Test case (version_test.go:18-24): ldflags win; setVars override for testing.
+
+### Actual Runtime Outputs
+
+**Scenario 1: Released via GoReleaser (ldflags injected)**
+- `Version = "v2.0.0"`, `Commit = "abc1234def"`, `Date = "2026-05-18T..."`
+- Banner: `typeburn v2.0.0 (abc1234, 2026-05-18..., ...)`
+
+**Scenario 2: `go install github.com/bavanchun/Typeburn@v2.0.0` (no ldflags, but tagged release)**
+- `debug.ReadBuildInfo().Main.Version = "v2.0.0"` (Go module proxy embeds semantic version)
+- `Version = "v2.0.0"` from fallback
+- Commit/Date filled from vcs settings if available
+
+**Scenario 3: `go install github.com/bavanchun/Typeburn@latest` on a non-tagged commit (dev install mid-branch)**
+- `debug.ReadBuildInfo().Main.Version = "v2.0.0-0.20260520143000-abc1234"` (pseudo-version format)
+- This is a **git-describe-like string**, not a release version
+- Comparator must handle this as "pre-release of v2.0.0", not as a concrete version to compare
+
+**Scenario 4: Bare `go run .` or fully offline**
+- All empty → `Version = "dev"`
+
+### Key Insight for Comparator
+The current version string is **sometimes a pseudo-version** (`vX.Y.Z-N-gSHA`), which is NOT a release and should not trigger an update check. The comparator must:
+- **Case A:** If local `Version` is a pseudo-version (contains `-` followed by digits and `-g`), skip the check (already on dev/unstable).
+- **Case B:** If GitHub's `tag_name` is a pre-release (e.g., `v2.1.0-rc.1`), treat as "no stable update available."
+
+## Part C: Settings Integration & Config Wiring
+
+**Location:** `internal/cli/cmd_config.go` and `internal/config/settings.go`
+
+Current `Settings` struct (config/settings.go:35-40):
+```go
+type Settings struct {
+    Theme         string
+    DefaultMode   Mode
+    DefaultLength int
+    BlinkCursor   bool
+}
+```
+
+Config CLI uses a **rows + switch pattern** (cmd_config.go:86-136):
+- `configRows(s)` → list of `[key, value]` rows
+- `configGet(s, key)` → find row by key
+- `configSet(s, key, value)` → switch on key name, parse, validate, mutate struct
+
+To add `UpdateCheckEnabled bool`:
+1. Add field to `Settings` struct (e.g., `UpdateCheckEnabled bool` at line 40)
+2. Add default in `Defaults()` (suggest default `false` — opt-in, not forced)
+3. Extend `configRows()` with new row
+4. Extend `configSet()` with `case "update_check_enabled":`
+5. Update `Normalize()` if needed (unlikely; bool has no invalid values)
+
+**Load behavior:** Missing field in JSON → zero-value `false` (safe default). No special handling needed; json.Unmarshal ignores unknown fields; json.Marshal omits zero-bool.
+
+## Part D: Semver Comparison Strategy
+
+### Option 1: Stdlib-only 30-LOC Parser (RECOMMENDED)
+
+Parse leading `v`, split by `.` and `-`, compare first 3 components as integers, skip pre-release flags.
+
+**Pros:**
+- KISS: no new deps, ~30 LOC, fully testable
+- Explicit: handles all Typeburn's known version formats
+- Defensive: gracefully skips malformed input
+
+**Cons:** nil
+
+**Algorithm outline:**
+```
+stripLeadingV(versionString) -> "X.Y.Z" or "X.Y.Z-..."
+splitOnDash(stripped) -> ["X.Y.Z", preReleaseInfo...]
+if preReleaseInfo contains "-rc", "-beta", "-alpha", "-pre" → SKIP (prerelease)
+parseXYZ(first component) -> (x, y, z, error)
+compareXYZ(local, remote) -> "update available", "up to date", "can't compare"
+```
+
+### Option 2: golang.org/x/mod/semver
+
+**Status:** NOT in go.mod. Adding it requires explicit user approval (CLAUDE.md dependency policy).
+
+**Pros:** Robust, well-tested, handles edge cases
+
+**Cons:** Requires new dependency; violates current constraint; overkill for our use case
+
+**Recommendation:** Mention but do NOT recommend for v2.1.0. Option 1 is sufficient.
+
+### Option 3: Other
+
+None identified. Stdlib has no semver package.
+
+### Edge Cases & Filters
+
+**Mandatory handling:**
+1. Strip leading `v` (all Typeburn versions have it)
+2. Parse `vX.Y.Z-N-gSHA` (git-describe mid-branch) → skip entire check (user is on dev build)
+3. Reject pre-releases from GitHub API (`tag_name` contains `-rc`, `-beta`, `-alpha`, `-pre`, case-insensitive)
+4. Reject `v0.0.0-rc.test` dry-run tag (see CLAUDE.md release procedure)
+5. Compare numerically: `2.10.0 > 2.9.0` (strconv.Atoi, not string compare)
+6. Malformed input → log warning, treat as "can't compare" (no update shown, but no error)
+
+### Test Cases (Table-Driven)
+
+Minimum table:
+```
+{local: "v2.0.0", remote: "v2.0.0"} → "up to date"
+{local: "v2.0.0", remote: "v2.1.0"} → "update available"
+{local: "v2.1.0", remote: "v2.0.0"} → "up to date"
+{local: "v2.0.0", remote: "v2.0.1"} → "update available"
+{local: "v2.0.1", remote: "v2.0.0"} → "up to date"
+{local: "dev", remote: "v2.0.0"} → "can't compare" (or skip check entirely)
+{local: "v2.0.0-5-gabc1234", remote: "v2.0.1"} → "skip check" (local is pseudo-version/dev)
+{local: "v2.0.0", remote: "v2.1.0-rc.1"} → "no stable release available" (skip)
+{local: "v2.0.0", remote: "v0.0.0-rc.test"} → "skip" (dry-run tag)
+{local: "v2.a.0", remote: "v2.1.0"} → "can't compare" (malformed local)
+{local: "v2.0.0", remote: "invalid"} → "can't compare" (malformed remote)
+```
+
+## Part E: 24h Cache File Strategy
+
+**Path:** `$XDG_STATE_HOME/typeburn/update-check.json`
+
+**Format:** JSON with timestamp and latest-stable tag_name.
+
+**Atomic write:** Reuse `atomicWrite(path, []byte)` after JSON-marshaling cache struct.
+
+**Load + validate age:** Read file → unmarshal → check `time.Since(Timestamp) < 24*time.Hour`. If missing, corrupt, or stale → fetch new data from GitHub API.
+
+**API endpoint:** `GET https://api.github.com/repos/bavanchun/Typeburn/releases/latest` → read `tag_name` field.
+
+## Unresolved Questions
+
+1. Should local pseudo-version (`v2.0.0-5-gabc1234`) **skip the check entirely** or **log a message**? (Suggest: silent skip — user is dev/unstable, noise-free)
+2. Should the 24h cache be per-run or global? (Suggest: global file with timestamp, checked at startup or on-demand)
+3. Should the update notifier live in the TUI (startup banner) or CLI-only (`typeburn version --check`)? (Out of scope for this research; v2.1.0 spec pending)
+4. **Config field naming:** `UpdateCheckEnabled`, `update_check_enabled`, or `check_updates`? (Suggest: `update_check_enabled` for consistency with existing hyphen style)

--- a/plans/20260521-0700-typeburn-update-check-cli/research/scout-touchpoints.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/research/scout-touchpoints.md
@@ -1,0 +1,240 @@
+# Scout Report — v2.1.0 update-check touchpoints
+
+Per-phase code location guide for implementing the synchronous update-check feature. Each section identifies exact file:line ranges and brief impact summaries.
+
+---
+
+## 1. cmd_version.go
+
+**File:** `internal/cli/cmd_version.go`
+
+- **Flag registration:** Line 24 — `cmd.Flags().BoolVar(&asJSON, "json", false, ...)` pattern establishes flag attachment.
+- **Insertion point for `--check-update`:** Add adjacent BoolVar at line 24+ (same block as `--json`).
+- **Human output path:** Lines 29–31 — `fmt.Fprintln(cmd.OutOrStdout(), version.String())` is the text renderer.
+- **JSON output path:** Lines 33–51 — JSON struct with `json:` tags and `json.NewEncoder().SetIndent()` + `Encode()`.
+- **Change summary:** Add a new `checkUpdate` bool var, wire it into `runVersion(cmd, asJSON, checkUpdate)` signature, and conditionally invoke `update.Check()` before returning if true. No new JSON fields needed yet (--check-update is a side effect trigger, not output augmentation).
+
+---
+
+## 2. cmd_config.go
+
+**File:** `internal/cli/cmd_config.go`
+
+- **Config key pattern:** Lines 86–102 define `configRows()` and `configGet()` using a slice-of-slice-of-strings ("table") model; lines 104–136 handle set via a switch/case statement on the key string.
+- **Key registry:** Fully explicit — a switch with each case being a valid config key (lines 105–134). No reflection; no map-based registry.
+- **Normalized keys:** One row per key; order matches the struct fields in `config.Settings` (line 86: theme, default_mode, default_length, blink_cursor).
+- **Minimum to add `update_check` bool key:**
+  1. Add row to `configRows()`: `{"update_check", strconv.FormatBool(s.UpdateCheck)}`
+  2. Add case to `configSet()` switch: `case "update_check":` with `parseBool(value)` validation + assign to `s.UpdateCheck`.
+  3. Add case to `configGet()` slice iteration (no code change — it is loop-based).
+- **Change summary:** Declarative; three add-points (rows, set switch, and config.Settings struct field). No infrastructure change needed.
+
+---
+
+## 3. internal/config/settings.go
+
+**File:** `internal/config/settings.go`
+
+- **Settings struct:** Lines 35–40 — Four fields: Theme (string), DefaultMode (Mode), DefaultLength (int), BlinkCursor (bool), all with `json:"..."` tags.
+- **Defaults function:** Lines 44–51 — Hardcoded return of default Settings with BlinkCursor = false.
+- **Normalize() function:** Lines 55–75 — Repairs unknown enum values in place. Does not repair bool fields (they are safe as-is).
+- **Insertion points for new `UpdateCheck bool` field:**
+  1. Add to Settings struct (line 35+): `UpdateCheck bool `json:"update_check"`` (note underscore in JSON tag).
+  2. Add to Defaults() return (line 44+): `UpdateCheck: true,` (propose true to encourage safe early checking).
+  3. No Normalize() changes needed (bool has no invalid values).
+- **Change summary:** Add 1 line to struct, 1 line to Defaults(). LoadSettings/SaveSettings in storage/ handle JSON marshaling automatically; no changes needed there.
+
+---
+
+## 4. internal/cli/cmd_run.go (synchronous check insertion)
+
+**File:** `internal/cli/cmd_run.go`
+
+- **Pre-TUI setup location:** Lines 63–95 in `runTUICommand()`. This is called after `buildRunRequest()` validation.
+  - Line 67: Settings are loaded and optionally overridden.
+  - Line 84: Model is constructed with `app.New(theme.Load(...), settings, codeText, "")`.
+  - Line 85: StartTestMsg is built and fed to the model.
+  - **Insertion point:** **Between lines 83 and 84** (after all CLI flags are resolved, before the model is constructed).
+- **Config access:** `settings := e.loadSettings()` at line 67 — the loaded config is available throughout. Check `settings.UpdateCheck` to decide whether to run the synchronous check.
+- **Exact pseudocode insertion:**
+  ```
+  // Line 83: codeText is finalized
+  if settings.UpdateCheck {
+    result, _ := update.Check(ctx) // result is optional; ignore error for now
+    // Hint is passed to New() or deferred to result-screen rendering
+  }
+  model := app.New(...)
+  ```
+- **Change summary:** 3–4 lines of conditional code; no new dependencies beyond the to-be-created `internal/update` package. Settings is already bound and available.
+
+---
+
+## 5. internal/ui/screen_result_view.go (footer hint slot)
+
+**File:** `internal/ui/screen_result_view.go`
+
+- **Current footer rendering:** Line 27 — `footer := RenderFooter(resultHints(), m.w, m.th)`.
+- **resultHints() function:** Lines 14–21 — Returns a slice of Hint structs (Key, Action pairs). Currently 4 hints: tab, ctrl+r, esc, 3.
+- **Footer layout:** Lines 39–42 in View() — footer is placed at the bottom; vertical padding keeps it pinned.
+- **Optional upgrade line insertion:** After the panel (line 40) and before the vertical spacer logic (line 34+), a new optional "upgrade available" line can be inserted if a hint is set.
+- **Natural placement:** Between the panel bottom border and the footer hints. Recommend a subtle style using `theme.RoleWarning` or `theme.RoleTextMuted` to avoid alarm.
+- **Exemplar from existing code:** Line 27 in screen_history_view.go shows how to render a label with muted style; apply the same pattern.
+- **Change summary:** ResultModel gains an optional `updateHint *update.Result` field; View() checks it and renders a 1-line notice if non-nil (e.g., "newer version available: v1.1.0"). No change to existing hints or layout logic.
+
+---
+
+## 6. internal/app/model.go (option pattern for update hint)
+
+**File:** `internal/app/model.go`
+
+- **Current constructor:** Lines 60–77 — `New(th theme.Theme, settings config.Settings, codeText, codeHint string) Model` with no functional options. Sets all fields by value in the returned Model struct.
+- **No existing option pattern:** Unlike the cli/runtime.go `Option` pattern, app/model.go uses positional params only.
+- **Insertion points for optional update hint:**
+  1. Add field to Model struct (line 27+): `updateHint *update.Result` (pointer because it is optional).
+  2. Add parameter to `New()` signature: `updateHint *update.Result` (simple approach) OR introduce an Option-pattern builder (breaking change but cleaner for future extensibility).
+  3. Update `New()` body (line 66+): `m.updateHint = updateHint` assignment.
+  4. Wire it to ResultModel (lines 100–104 in handleResultMsg): When ResultMsg arrives, instantiate ResultModel with `NewResult(...).WithUpdateHint(m.updateHint)` if the hint is set.
+- **Hint flow to ResultModel:** ResultModel.Update/View already use method chaining (e.g., `WithBest()` line 53–56). Add a parallel `WithUpdateHint()` method:
+  ```go
+  func (m ResultModel) WithUpdateHint(hint *update.Result) ResultModel {
+    m.updateHint = hint
+    return m
+  }
+  ```
+- **Change summary:** Add 1 field to Model, add 1 param to New(), wire one assignment in New(), add 1 method to ResultModel, and call it in handleResultMsg(). No refactor of existing logic; all additive.
+
+---
+
+## 7. internal/ui/messages.go (new UpdateHintMsg pattern)
+
+**File:** `internal/ui/messages.go`
+
+- **Existing messages (exemplars):**
+  - `ResultMsg` (lines 18–24): Carries metrics.Result + Mode + Length + QuoteLen + CodeText.
+  - `CodePastedMsg` (lines 38–40): Carries Text (the pasted string).
+  - `SettingsChangedMsg` (lines 49–51): Carries Settings.
+- **Pattern:** Simple struct with public fields (no methods), used as a signal + data carrier. No receiver methods on the message itself; the root model or sub-model handles it in Update().
+- **Proposed UpdateHintMsg:**
+  ```go
+  // UpdateHintMsg is emitted by a synchronous update.Check() call (wrapped in a Cmd)
+  // when a newer version is available. The root model receives it and passes it to
+  // the next screen or caches it for the result screen. (Deferred pending design clarity.)
+  type UpdateHintMsg struct {
+    Result *update.Result  // nil = no update available
+  }
+  ```
+- **Alternative (simpler, deferred):** For v2.1.0 Phase 1, skip the message entirely and pass the hint directly via app.New() parameter as shown in section 6. Only promote to a message if the hint needs to survive a screen transition (e.g., Home → Typing → Result).
+- **Change summary:** 1 new message struct. No existing messages need changes. The message is optional if the hint is passed via New() direct param.
+
+---
+
+## 8. internal/cli/output/ package (update result renderer)
+
+**File:** `internal/cli/output/json.go` and `internal/cli/output/table.go`
+
+- **Existing renderers:**
+  - `RenderJSON(w io.Writer, v any) error` (lines 9–12): Uses `json.NewEncoder()` + `SetIndent()` + `Encode(v)`.
+  - `RenderTable(w io.Writer, headers []string, rows [][]string) error` (lines 10–20): Tab-aligned rows with tabwriter.
+- **Shape:** Both are simple `(io.Writer, data) error` signatures. No format-selection dispatch layer; callers choose which to invoke based on a `--json` flag.
+- **For update results:**
+  - **Human output:** A 1-line summary, e.g., "version 1.1.0 available; run `typeburn version --check-update` to see details." Use an existing call like in cmd_version.go line 30: `fmt.Fprintln(cmd.OutOrStdout(), ...)`.
+  - **JSON output:** Reuse RenderJSON with an UpdateResult struct: `{ "available": true, "current": "1.0.0", "latest": "1.1.0", ... }`. The struct marshals automatically.
+- **Insertion point:** No changes to output/ needed for Phase 1. The human output is handled in cmd_version.go's runVersion(); JSON is a simple RenderJSON call with a struct. Add an UpdateResult type in internal/update/ and call RenderJSON from cmd_version.go.
+- **Change summary:** None needed to output/. The two renderers are sufficient as-is. New code calls them with the appropriate data types.
+
+---
+
+## 9. internal/storage/ package (helper functions)
+
+**File:** `internal/storage/atomic_write.go`, `internal/storage/settings_store.go`
+
+- **Atomic write:** Lines 14–45 in atomic_write.go — `atomicWrite(path string, data []byte) error` handles write-to-temp, fsync, rename. Private function; used by SaveSettings.
+- **LoadSettings:** Lines 25–46 in settings_store.go — Reads file, unmarshals JSON, calls Normalize(), returns config.Settings. Graceful fallback to Defaults() on any error.
+- **SaveSettings:** Lines 52–69 in settings_store.go — Marshals Settings to JSON, ensures parent dir exists (mode 0700), calls atomicWrite(). No error on missing parent; MkdirAll succeeds silently.
+- **SettingsPath:** Lines 13–19 in settings_store.go — Returns `$XDG_CONFIG_HOME/typeburn/settings.json` (via config.ConfigDir(), which calls config/xdg-paths.go).
+- **For update check persistence (future):** If the feature later needs to cache the last-check timestamp, use the same atomic pattern. For v2.1.0 Phase 1, no new storage helpers are needed — the UpdateCheck bool field is part of config.Settings and auto-persists.
+- **Change summary:** No new functions or changes needed. Existing LoadSettings/SaveSettings handle the new UpdateCheck field automatically via JSON struct tags.
+
+---
+
+## 10. Test conventions
+
+**File:** Various test files in `internal/cli/`, `internal/ui/`, `internal/app/`
+
+- **CLI tests (cmd_run_test.go exemplar):**
+  - Lines 14–25: Construct a minimal `*cobra.Command` stub with flags preset.
+  - Lines 49: Call the command's validation function directly: `buildRunRequest(cmd, flags, settings)`.
+  - No full Execute() harness; unit tests validate logic in isolation.
+  - **Pattern for update-check CLI:** Test `buildRunRequest()` with `--check-update` flag; mock `update.Check()` via dependency injection (pass a mock env.checkUpdate func).
+  
+- **UI tests (screen_result_test.go exemplar):**
+  - Lines 5–37: Construct models directly: `NewResult(msg, theme, keymap)`.
+  - Call Update() and View() methods on the model; assert output strings or returned commands.
+  - No teatest golden files in the repo; all UI tests use string matching or snapshot assertions (e.g., line 34: `if st.CodeText != snippet`).
+  - **Pattern for result-screen hint:** Test `ResultModel.WithUpdateHint()` with sample update.Result; assert the hint appears in View() output.
+
+- **HTTP testing (none currently in repo):**
+  - The codebase has no net/http imports in test files. If update.Check() does HTTP (via net/http or similar), wrap it behind an interface in the env struct (like loadCode, loadSettings) for dependency injection.
+  - Mock by providing a stub function in tests, or use httptest.Server for E2E if needed.
+
+- **CI gate:** `.github/workflows/ci.yml` line 54 — `make notui-noexit-check` enforces that `internal/cli/notui/` never calls `os.Exit`. If `internal/update/` is added, it should not import `cli/notui` (no circular dependency risk). The guard will pass.
+
+- **Change summary:**
+  - CLI: Existing pattern (flag stubs, direct function calls) is sufficient.
+  - UI: Existing pattern (direct model construction) is sufficient.
+  - HTTP: Wrap update.Check() behind an env dependency if testing is needed.
+  - CI: No changes; notui-noexit-check already passes.
+
+---
+
+## 11. CI gates
+
+**File:** `.github/workflows/ci.yml`
+
+- **Line 54:** `make notui-noexit-check` — Runs the Makefile target defined at line 29 of Makefile:
+  ```makefile
+  notui-noexit-check:
+      @if grep -R "os\\.Exit" internal/cli/notui >/dev/null 2>&1; then ...
+  ```
+  This ensures `internal/cli/notui/` code never calls `os.Exit` (exit codes are returned as errors instead, allowing the root command to decide).
+
+- **Impact on new internal/update/ package:** None. The update package does not live in cli/notui/; it is a sibling to cli/, config/, ui/, etc. The grep is scoped to `internal/cli/notui/` only.
+
+- **Full CI pipeline:** Lines 27–34 — Build, Vet, Format check, Test (race detector), notui-noexit-check, Binary size check. All pass with the new update package as long as:
+  - No `import "os"` (exit) in update.go.
+  - No infinite HTTP retry loops (test with reasonable timeouts).
+  - No unexported internal types (keep it compartmentalized).
+
+- **Change summary:** No CI changes needed. New package passes all existing gates.
+
+---
+
+## Summary of insertion points by phase
+
+| **Phase** | **File** | **Line Range** | **Change Type** |
+|-----------|----------|----------------|-----------------|
+| 1 (Config) | internal/config/settings.go | 35–40, 44–51 | Add UpdateCheck bool field + update Defaults() |
+| 1 (Config) | internal/cli/cmd_config.go | 86–102, 104–136 | Add update_check key to rows, set switch |
+| 2 (Version flag) | internal/cli/cmd_version.go | 24 | Add --check-update BoolVar |
+| 3 (Pre-TUI check) | internal/cli/cmd_run.go | 83–84 | Insert conditional update.Check() call |
+| 4 (App model) | internal/app/model.go | 27, 60–77 | Add updateHint field, wire to New() |
+| 5 (Result hint) | internal/ui/screen_result.go | 18–29 | Add optional updateHint field to ResultModel |
+| 5 (Result view) | internal/ui/screen_result_view.go | 26–48 | Render optional hint in footer region |
+| 5 (Result hint setup) | internal/app/model.go | 100–104 | Wire hint to ResultModel.WithUpdateHint() in handleResultMsg |
+
+---
+
+## Unresolved questions & design notes
+
+1. **Update check on `--no-tui` path:** cmd_run_notui.go is separate from runTUICommand. Should --no-tui also trigger the check? Deferred to design review.
+
+2. **Error handling for update.Check():** Should a network failure during the check block the test start, or should it be best-effort? Recommend best-effort (silently continue); propagate no error from cmd_run.
+
+3. **Update hint persistence across Home → Result:** Currently proposed to pass via app.New() directly. If the hint needs to survive a Home-screen browse (user stays on Home, dismisses the hint, then starts a test), promote UpdateHintMsg to a proper message in the event loop.
+
+4. **Version comparison semver:** The researchers found `github.com/Masterminds/semver/v3` is a solid choice for version parsing. Verify it is not already imported; if not, add to go.mod as part of Phase 3 (HTTP integration).
+
+5. **Config flag semantics:** Is `update_check: true` the default (checks by default, user can opt out), or `false` (no checks unless explicitly enabled)? Recommend `true` with a prominent notice on first launch or in help text.
+
+6. **Test coverage:** Existing test patterns (CLI stubs, UI direct construction) are sufficient. No new testing infrastructure needed. Plan for at least 1 unit test per new message type and 1 integration test (mock HTTP result + end-to-end render).
+


### PR DESCRIPTION
## Summary

- Adds `internal/update` — pure stdlib package (no bubbletea/lipgloss) that fetches the latest GitHub release, compares semver, and caches the result 24 h at `$XDG_STATE_HOME/typeburn/update-check.json`.
- New `typeburn version --check-update [--json]` flag — always hits the network, skips cache.
- New `update_check` config key (default `off`, opt-in via `typeburn config set update_check on`). When enabled, each TUI launch fires an 800 ms background check; if a newer stable release is found the Result screen shows a muted footer hint.
- `parseBool` extended to accept `on`/`off`/`yes`/`no` in addition to `true`/`false`/`1`/`0`.
- Size cap raised 8 MiB → 10 MiB (net/http adds ~260 KB).
- Docs updated: CHANGELOG, README ("Check for updates" section), `docs/cli-reference.md`, `docs/codebase-summary.md`, `docs/project-roadmap.md`.

## Test plan

- [x] `make test-race` — all 15 packages green
- [x] `make lint` — gofmt + go vet clean
- [x] `make size-check` — 8.26 MB < 10 MiB cap
- [x] `internal/update` — 9 check tests, 9 cache tests (incl. injection guard), 7 client tests, 14 compare tests, 14 prerelease tests
- [x] `internal/ui` — `TestResultView_UpdateHint_Absent/Present`, `TestRenderUpdateHint_InjectionGuard` (4 subtests)
- [x] `internal/app` — `TestUpdateHint_ForwardedToResult`, `TestUpdateHint_NilSafe`
- [x] `internal/cli` — `TestUpdateCheckSetGet` (all parseBool forms), `TestConfigListIncludesUpdateCheck`, `TestInvalidUpdateCheckValue`, cmd_version_test.go (6 tests incl. dev-skip, force-bypasses-cache)