### PR TITLE
fix: 6 audited defects — notui perf, JSON error, CSI strip, prerelease cache, split-ESC, globals race

### DIFF
--- a/internal/cli/cmd_version.go
+++ b/internal/cli/cmd_version.go
@@ -1,17 +1,34 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"sync"
 
 	"github.com/bavanchun/Typeburn/internal/update"
 	"github.com/bavanchun/Typeburn/internal/version"
 	"github.com/spf13/cobra"
 )
 
-// checkFn is the update.Check function; overridden in tests via this seam.
-var checkFn = update.Check
+// checkFn is the update.Check function; overridden in tests via setCheckFn.
+var (
+	checkFnMu sync.Mutex
+	checkFn   = update.Check
+)
+
+func getCheckFn() func(context.Context, string, bool) (*update.Result, error) {
+	checkFnMu.Lock()
+	defer checkFnMu.Unlock()
+	return checkFn
+}
+
+func setCheckFn(fn func(context.Context, string, bool) (*update.Result, error)) {
+	checkFnMu.Lock()
+	defer checkFnMu.Unlock()
+	checkFn = fn
+}
 
 func newVersionCmd() *cobra.Command {
 	var asJSON, checkUpdate bool
@@ -43,7 +60,7 @@ func runVersion(cmd *cobra.Command, asJSON, checkUpdate bool) error {
 		return renderVersionJSON(cmd, info)
 	}
 
-	result, err := checkFn(cmd.Context(), info.Version, true)
+	result, err := getCheckFn()(cmd.Context(), info.Version, true)
 
 	if asJSON {
 		return renderVersionCheckJSON(cmd, info, result, err)

--- a/internal/cli/cmd_version.go
+++ b/internal/cli/cmd_version.go
@@ -101,8 +101,7 @@ func renderVersionCheckJSON(cmd *cobra.Command, info version.Info, result *updat
 				Error string `json:"error"`
 			}{checkErr.Error()},
 		}
-		_ = enc.Encode(out)
-		return checkErr
+		return enc.Encode(out)
 	}
 	if result == nil {
 		out := struct {

--- a/internal/cli/cmd_version_test.go
+++ b/internal/cli/cmd_version_test.go
@@ -119,6 +119,42 @@ func TestVersionCheckUpdate_Error(t *testing.T) {
 	}
 }
 
+func TestVersionCheckUpdate_JSONError(t *testing.T) {
+	// --json --check-update with a check error must emit valid JSON only,
+	// not JSON followed by the raw error string (the old double-emit bug).
+	orig := checkFn
+	checkFn = stubCheck(nil, errors.New("network unreachable"))
+	defer func() { checkFn = orig }()
+
+	var out, errOut bytes.Buffer
+	if err := versionRoot(t, &out, &errOut, "version", "--json", "--check-update"); err != nil {
+		t.Fatalf("version --json --check-update with error should exit 0, got: %v", err)
+	}
+	if errOut.Len() > 0 {
+		t.Errorf("no output on stderr expected in --json mode, got: %s", errOut.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("output must be valid JSON, got parse error: %v\noutput: %s", err, out.String())
+	}
+	for _, key := range []string{"version", "commit", "date", "go_version", "os", "arch"} {
+		v, ok := got["version"].(map[string]any)
+		if !ok {
+			t.Fatalf("version key must be an object, got: %T", got["version"])
+		}
+		if _, ok := v[key]; !ok {
+			t.Errorf("version object missing key %q", key)
+		}
+	}
+	uc, ok := got["update_check"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected update_check object, got: %v", got["update_check"])
+	}
+	if uc["error"] != "network unreachable" {
+		t.Errorf("update_check.error = %q, want %q", uc["error"], "network unreachable")
+	}
+}
+
 func TestVersionCheckUpdate_JSONWrapper(t *testing.T) {
 	orig := checkFn
 	checkFn = stubCheck(&update.Result{

--- a/internal/cli/cmd_version_test.go
+++ b/internal/cli/cmd_version_test.go
@@ -49,15 +49,15 @@ func TestVersionJSON_Unchanged(t *testing.T) {
 }
 
 func TestVersionCheckUpdate_UpgradeAvailable(t *testing.T) {
-	orig := checkFn
-	checkFn = stubCheck(&update.Result{
+	orig := getCheckFn()
+	setCheckFn(stubCheck(&update.Result{
 		Current:          "v2.0.0",
 		Latest:           "v2.1.0",
 		UpgradeAvailable: true,
 		ReleaseURL:       "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0",
 		CheckedAt:        time.Now().UTC(),
-	}, nil)
-	defer func() { checkFn = orig }()
+	}, nil))
+	defer setCheckFn(orig)
 
 	var out bytes.Buffer
 	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--check-update"); err != nil {
@@ -73,13 +73,13 @@ func TestVersionCheckUpdate_UpgradeAvailable(t *testing.T) {
 }
 
 func TestVersionCheckUpdate_UpToDate(t *testing.T) {
-	orig := checkFn
-	checkFn = stubCheck(&update.Result{
+	orig := getCheckFn()
+	setCheckFn(stubCheck(&update.Result{
 		Current:   "v2.0.0",
 		Latest:    "v2.0.0",
 		CheckedAt: time.Now().UTC(),
-	}, nil)
-	defer func() { checkFn = orig }()
+	}, nil))
+	defer setCheckFn(orig)
 
 	var out bytes.Buffer
 	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--check-update"); err != nil {
@@ -91,9 +91,9 @@ func TestVersionCheckUpdate_UpToDate(t *testing.T) {
 }
 
 func TestVersionCheckUpdate_DevSkip(t *testing.T) {
-	orig := checkFn
-	checkFn = stubCheck(nil, nil) // nil,nil = dev skip
-	defer func() { checkFn = orig }()
+	orig := getCheckFn()
+	setCheckFn(stubCheck(nil, nil)) // nil,nil = dev skip
+	defer setCheckFn(orig)
 
 	var out bytes.Buffer
 	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--check-update"); err != nil {
@@ -105,9 +105,9 @@ func TestVersionCheckUpdate_DevSkip(t *testing.T) {
 }
 
 func TestVersionCheckUpdate_Error(t *testing.T) {
-	orig := checkFn
-	checkFn = stubCheck(nil, errors.New("network unreachable"))
-	defer func() { checkFn = orig }()
+	orig := getCheckFn()
+	setCheckFn(stubCheck(nil, errors.New("network unreachable")))
+	defer setCheckFn(orig)
 
 	var out, errOut bytes.Buffer
 	// Human mode: error goes to stderr, exit code 0.
@@ -122,9 +122,9 @@ func TestVersionCheckUpdate_Error(t *testing.T) {
 func TestVersionCheckUpdate_JSONError(t *testing.T) {
 	// --json --check-update with a check error must emit valid JSON only,
 	// not JSON followed by the raw error string (the old double-emit bug).
-	orig := checkFn
-	checkFn = stubCheck(nil, errors.New("network unreachable"))
-	defer func() { checkFn = orig }()
+	orig := getCheckFn()
+	setCheckFn(stubCheck(nil, errors.New("network unreachable")))
+	defer setCheckFn(orig)
 
 	var out, errOut bytes.Buffer
 	if err := versionRoot(t, &out, &errOut, "version", "--json", "--check-update"); err != nil {
@@ -156,16 +156,16 @@ func TestVersionCheckUpdate_JSONError(t *testing.T) {
 }
 
 func TestVersionCheckUpdate_JSONWrapper(t *testing.T) {
-	orig := checkFn
-	checkFn = stubCheck(&update.Result{
+	orig := getCheckFn()
+	setCheckFn(stubCheck(&update.Result{
 		SchemaVersion:    1,
 		Current:          "v2.0.0",
 		Latest:           "v2.1.0",
 		UpgradeAvailable: true,
 		ReleaseURL:       "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0",
 		CheckedAt:        time.Now().UTC(),
-	}, nil)
-	defer func() { checkFn = orig }()
+	}, nil))
+	defer setCheckFn(orig)
 
 	var out bytes.Buffer
 	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--json", "--check-update"); err != nil {

--- a/internal/cli/notui/reader.go
+++ b/internal/cli/notui/reader.go
@@ -60,8 +60,22 @@ func ReadEvent(r *bufio.Reader) (Event, error) {
 }
 
 func discardEscape(r *bufio.Reader) {
-	for r.Buffered() > 0 {
-		b, err := r.ReadByte()
+	b, err := r.ReadByte() // always block — handles ESC arriving at a read-buffer boundary
+	if err != nil {
+		return
+	}
+	// Preserve abort/EOF signals so the outer ReadEvent loop can handle them.
+	// Without this, ESC then Ctrl-C would silently drop 0x03 and make the
+	// session un-abortable.
+	if b == 0x03 || b == 0x04 {
+		_ = r.UnreadByte()
+		return
+	}
+	if b != '[' && b != 'O' { // standalone ESC or 2-byte sequence — done
+		return
+	}
+	for {
+		b, err = r.ReadByte()
 		if err != nil {
 			return
 		}

--- a/internal/cli/notui/reader_test.go
+++ b/internal/cli/notui/reader_test.go
@@ -2,6 +2,7 @@ package notui
 
 import (
 	"bufio"
+	"io"
 	"strings"
 	"testing"
 )
@@ -19,6 +20,8 @@ func TestReadEvent(t *testing.T) {
 		{"backspace bs", string([]byte{0x08}), EventBackspace, 0},
 		{"escape", "\x1b[A", EventNone, 0},
 		{"ctrl-c", "\x03", EventAbort, 0},
+		{"ss3 f1", "\x1bOP", EventNone, 0},
+		{"csi tilde", "\x1b[3~", EventNone, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -30,5 +33,57 @@ func TestReadEvent(t *testing.T) {
 				t.Fatalf("want %v/%q, got %v/%q", tt.kind, tt.rune, ev.Kind, ev.Rune)
 			}
 		})
+	}
+}
+
+// TestReadEvent_SplitEscape verifies that an ESC arriving at the end of one
+// read buffer is correctly joined with the introducer/final bytes that arrive
+// in the next read. Under the old buffer-gated discardEscape, the '[' would
+// have been emitted as a stray EventRune.
+func TestReadEvent_SplitEscape(t *testing.T) {
+	r := bufio.NewReader(io.MultiReader(
+		strings.NewReader("\x1b"),
+		strings.NewReader("[Ax"),
+	))
+	ev, err := ReadEvent(r) // consumes ESC + [A across the buffer split
+	if err != nil || ev.Kind != EventNone {
+		t.Fatalf("escape: want EventNone, got %v (err %v)", ev.Kind, err)
+	}
+	ev, err = ReadEvent(r) // 'x' must be next — not a stray '['
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Kind != EventRune || ev.Rune != 'x' {
+		t.Fatalf("after split escape: want rune 'x', got %v/%q", ev.Kind, ev.Rune)
+	}
+}
+
+// TestReadEvent_StandaloneESC documents that the byte following a bare ESC is
+// consumed as the "introducer" and dropped. This is an accepted trade-off:
+// bare ESC is not a typing input in raw mode.
+func TestReadEvent_StandaloneESC(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("\x1bx"))
+	ev, err := ReadEvent(r)
+	if err != nil || ev.Kind != EventNone {
+		t.Fatalf("standalone ESC: want EventNone, got %v (err %v)", ev.Kind, err)
+	}
+	// 'x' was consumed as the introducer — stream is now empty.
+	_, err = ReadEvent(r)
+	if err == nil {
+		t.Fatal("expected EOF after standalone ESC consumed the next byte")
+	}
+}
+
+// TestReadEvent_EscThenCtrlC verifies that Ctrl-C pressed after ESC is
+// preserved: discardEscape unreads 0x03 so the outer loop returns EventAbort.
+func TestReadEvent_EscThenCtrlC(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("\x1b\x03"))
+	ev, err := ReadEvent(r) // ESC triggers discardEscape, which unreads 0x03
+	if err != nil || ev.Kind != EventNone {
+		t.Fatalf("ESC: want EventNone, got %v (err %v)", ev.Kind, err)
+	}
+	ev, err = ReadEvent(r) // 0x03 was unread — must come back as EventAbort
+	if err != nil || ev.Kind != EventAbort {
+		t.Fatalf("Ctrl-C after ESC: want EventAbort, got %v (err %v)", ev.Kind, err)
 	}
 }

--- a/internal/cli/notui/runner.go
+++ b/internal/cli/notui/runner.go
@@ -47,10 +47,7 @@ func runLoop(
 		}
 		done, total := session.Engine.Progress()
 		elapsed := nowMs - session.Engine.StartMs()
-		live := metrics.Compute(session.Engine.Log(), session.Mode, nowMs).NetWPM
-		if elapsed <= 0 {
-			live = 0
-		}
+		live := metrics.LiveWPM(session.Engine.Log(), elapsed)
 		RenderStatus(out, done, total, live)
 		if completed(session, nowMs) {
 			result := metrics.Compute(session.Engine.Log(), session.Mode, endMs(session, nowMs))

--- a/internal/metrics/live_wpm.go
+++ b/internal/metrics/live_wpm.go
@@ -1,0 +1,19 @@
+package metrics
+
+import "github.com/bavanchun/Typeburn/internal/typing"
+
+// LiveWPM estimates current net WPM from forward keystrokes in the log.
+// Returns 0 when elapsedMs < 500ms (too noisy) or the log is empty.
+// This is the cheap O(n) live-display estimate; full metrics come from Compute.
+func LiveWPM(log []typing.Keystroke, elapsedMs int64) float64 {
+	if elapsedMs < 500 || len(log) == 0 {
+		return 0
+	}
+	var forward int
+	for _, k := range log {
+		if k.Typed != 0 {
+			forward++
+		}
+	}
+	return float64(forward) / 5.0 / (float64(elapsedMs) / 60000.0)
+}

--- a/internal/metrics/live_wpm_test.go
+++ b/internal/metrics/live_wpm_test.go
@@ -1,0 +1,49 @@
+package metrics
+
+import (
+	"math"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+func TestLiveWPM(t *testing.T) {
+	fwd := func(r rune) typing.Keystroke { return typing.Keystroke{Typed: r} }
+	bsp := func() typing.Keystroke { return typing.Keystroke{Typed: 0} }
+
+	tests := []struct {
+		name      string
+		log       []typing.Keystroke
+		elapsedMs int64
+		want      float64
+	}{
+		{"empty_log", nil, 60000, 0},
+		{"below_500ms_guard", []typing.Keystroke{fwd('a'), fwd('b')}, 400, 0},
+		{"zero_elapsed", []typing.Keystroke{fwd('a')}, 0, 0},
+		{"negative_elapsed", []typing.Keystroke{fwd('a')}, -100, 0},
+		{
+			"forward_only",
+			[]typing.Keystroke{fwd('a'), fwd('b'), fwd('c'), fwd('d'), fwd('e'),
+				fwd('f'), fwd('g'), fwd('h'), fwd('i'), fwd('j')},
+			60000,
+			2.0, // 10 chars / 5 / (60000/60000) = 2.0 WPM
+		},
+		{
+			"with_backspaces",
+			[]typing.Keystroke{fwd('a'), fwd('b'), bsp(), fwd('c')},
+			60000,
+			// 3 forward keystrokes (backspace Typed==0 excluded), elapsed=60s → 3/5/1 = 0.6
+			0.6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LiveWPM(tt.log, tt.elapsedMs)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("LiveWPM(%d keystrokes, %dms) = %v, want %v",
+					len(tt.log), tt.elapsedMs, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/result_render_helpers.go
+++ b/internal/ui/result_render_helpers.go
@@ -71,21 +71,38 @@ func injectBorderTitle(panel, title string) string {
 	return string(newTop)
 }
 
-// stripANSI removes ANSI SGR escape sequences (ESC [ ... m) from s so the
-// visual character width can be measured accurately for border title injection.
+// stripANSI removes ANSI CSI escape sequences (ESC [ ... finalByte 0x40-0x7E)
+// from s so the visual character width can be measured accurately for border
+// title injection. Only CSI (ESC[) is handled; OSC/SS3 are not emitted by
+// lipgloss panel borders and are out of scope. A non-[ introducer (e.g. ESC M)
+// is treated as a 2-byte sequence and drops exactly one byte.
 func stripANSI(s string) string {
 	var out strings.Builder
-	inEsc := false
+	const (
+		stNorm = iota
+		stEsc  // saw ESC, expecting introducer
+		stCSI  // inside CSI params/intermediates, waiting for final byte
+	)
+	state := stNorm
 	for _, r := range s {
-		switch {
-		case r == '\x1b':
-			inEsc = true
-		case inEsc:
-			if r == 'm' {
-				inEsc = false
+		switch state {
+		case stNorm:
+			if r == '\x1b' {
+				state = stEsc
+			} else {
+				out.WriteRune(r)
 			}
-		default:
-			out.WriteRune(r)
+		case stEsc:
+			if r == '[' {
+				state = stCSI
+			} else {
+				state = stNorm // non-[ introducer: drop it, done with this escape
+			}
+		case stCSI:
+			if r >= '@' && r <= '~' { // CSI final byte 0x40..0x7E
+				state = stNorm
+			}
+			// else: param/intermediate byte — keep dropping
 		}
 	}
 	return out.String()

--- a/internal/ui/result_render_helpers_test.go
+++ b/internal/ui/result_render_helpers_test.go
@@ -1,0 +1,25 @@
+package ui
+
+import "testing"
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{"plain", "hello", "hello"},
+		{"sgr_color", "\x1b[31mred\x1b[0m", "red"},
+		{"sgr_multi", "\x1b[1;31mX\x1b[0m", "X"},
+		{"cursor_up", "a\x1b[Ab", "ab"},            // ESC[A non-SGR CSI
+		{"erase_screen", "a\x1b[2Jb", "ab"},        // ESC[2J
+		{"scroll_region", "a\x1b[1;5rb", "ab"},     // ESC[1;5r
+		{"trailing_csi", "x\x1b[A", "x"},           // CSI at end of string
+		{"trailing_incomplete_csi", "x\x1b[", "x"}, // ESC[ with no final byte (EOF in CSI)
+		{"two_byte_esc", "a\x1bMb", "ab"},          // ESC M (RI) 2-byte sequence
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripANSI(tt.in); got != tt.want {
+				t.Errorf("stripANSI(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/typing_log_helpers.go
+++ b/internal/ui/typing_log_helpers.go
@@ -1,21 +1,15 @@
 package ui
 
-import "github.com/bavanchun/Typeburn/internal/typing"
+import (
+	"github.com/bavanchun/Typeburn/internal/metrics"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
 
 // liveWPM estimates current WPM from forward keystrokes in the log.
 // Used for the live header display; returns 0 when elapsed < 500ms (too noisy).
 // Full accuracy is computed via metrics.Compute at test completion.
 func liveWPM(log []typing.Keystroke, elapsedMs int64) float64 {
-	if elapsedMs < 500 || len(log) == 0 {
-		return 0
-	}
-	var forward int
-	for _, k := range log {
-		if k.Typed != 0 {
-			forward++
-		}
-	}
-	return float64(forward) / 5.0 / (float64(elapsedMs) / 60000.0)
+	return metrics.LiveWPM(log, elapsedMs)
 }
 
 // typedFromLog reconstructs the current typed-rune slice by replaying the

--- a/internal/update/cache.go
+++ b/internal/update/cache.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bavanchun/Typeburn/internal/config"
@@ -23,12 +24,27 @@ var validSemverRe = regexp.MustCompile(`^v?\d+\.\d+\.\d+([-+.][\w.-]+)?$`)
 
 const releaseURLPrefix = "https://github.com/bavanchun/Typeburn/"
 
-// cacheFilePath is a var so tests can override it via t.TempDir().
-var cacheFilePath = ""
+// cacheFilePath is a var so tests can override it via setCacheFilePath.
+var (
+	cacheFileMu   sync.Mutex
+	cacheFilePath = ""
+)
+
+func getCacheFilePath() string {
+	cacheFileMu.Lock()
+	defer cacheFileMu.Unlock()
+	return cacheFilePath
+}
+
+func setCacheFilePath(p string) {
+	cacheFileMu.Lock()
+	defer cacheFileMu.Unlock()
+	cacheFilePath = p
+}
 
 func getCachePath() (string, error) {
-	if cacheFilePath != "" {
-		return cacheFilePath, nil
+	if p := getCacheFilePath(); p != "" {
+		return p, nil
 	}
 	dir, err := config.StateDir()
 	if err != nil {

--- a/internal/update/cache_test.go
+++ b/internal/update/cache_test.go
@@ -10,9 +10,9 @@ import (
 func withTempCache(t *testing.T) func() {
 	t.Helper()
 	dir := t.TempDir()
-	orig := cacheFilePath
-	cacheFilePath = filepath.Join(dir, "update-check.json")
-	return func() { cacheFilePath = orig }
+	orig := getCacheFilePath()
+	setCacheFilePath(filepath.Join(dir, "update-check.json"))
+	return func() { setCacheFilePath(orig) }
 }
 
 func TestCacheSaveLoad_RoundTrip(t *testing.T) {
@@ -148,10 +148,10 @@ func TestCacheLoad_InvalidReleaseURL(t *testing.T) {
 
 func TestCacheSave_CreatesParentDir(t *testing.T) {
 	dir := t.TempDir()
-	orig := cacheFilePath
+	orig := getCacheFilePath()
 	// Use a nested path whose parent doesn't exist yet.
-	cacheFilePath = filepath.Join(dir, "nested", "deep", "update-check.json")
-	defer func() { cacheFilePath = orig }()
+	setCacheFilePath(filepath.Join(dir, "nested", "deep", "update-check.json"))
+	defer setCacheFilePath(orig)
 
 	r := &Result{
 		SchemaVersion: cacheSchemaVersion,
@@ -162,7 +162,7 @@ func TestCacheSave_CreatesParentDir(t *testing.T) {
 	if err := cacheSave(r); err != nil {
 		t.Fatalf("cacheSave should create parent dirs: %v", err)
 	}
-	if _, err := os.Stat(cacheFilePath); err != nil {
+	if _, err := os.Stat(getCacheFilePath()); err != nil {
 		t.Errorf("cache file not created: %v", err)
 	}
 }

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -30,13 +30,15 @@ func Check(ctx context.Context, currentVer string, force bool) (*Result, error) 
 
 	// Treat draft/prerelease as "no stable upgrade available".
 	if rel.Draft || rel.Prerelease || IsPrerelease(rel.TagName) {
-		return &Result{
+		r := &Result{
 			SchemaVersion:    cacheSchemaVersion,
 			Current:          currentVer,
 			Latest:           currentVer,
 			UpgradeAvailable: false,
 			CheckedAt:        time.Now().UTC(),
-		}, nil
+		}
+		_ = cacheSave(r) // best-effort; TTL suppresses repeat network hits during prerelease windows
+		return r, nil
 	}
 
 	upgrade := Compare(currentVer, rel.TagName) < 0

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -30,9 +30,9 @@ func TestCheck_UpgradeAvailable(t *testing.T) {
 	defer withTempCache(t)()
 	srv := stubServer(t, Release{TagName: "v2.1.0", HTMLURL: "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0"})
 	defer srv.Close()
-	origURL := fetchURL
-	fetchURL = srv.URL
-	defer func() { fetchURL = origURL }()
+	origURL := getFetchURL()
+	setFetchURL(srv.URL)
+	defer setFetchURL(origURL)
 
 	r, err := Check(context.Background(), "v2.0.0", true)
 	if err != nil {
@@ -56,9 +56,9 @@ func TestCheck_UpToDate(t *testing.T) {
 	defer withTempCache(t)()
 	srv := stubServer(t, Release{TagName: "v2.0.0", HTMLURL: "https://github.com/bavanchun/Typeburn/releases/tag/v2.0.0"})
 	defer srv.Close()
-	origURL := fetchURL
-	fetchURL = srv.URL
-	defer func() { fetchURL = origURL }()
+	origURL := getFetchURL()
+	setFetchURL(srv.URL)
+	defer setFetchURL(origURL)
 
 	r, err := Check(context.Background(), "v2.0.0", true)
 	if err != nil {
@@ -76,9 +76,9 @@ func TestCheck_PrereleaseIgnored(t *testing.T) {
 	defer withTempCache(t)()
 	srv := stubServer(t, Release{TagName: "v2.1.0-rc.1", Prerelease: true})
 	defer srv.Close()
-	origURL := fetchURL
-	fetchURL = srv.URL
-	defer func() { fetchURL = origURL }()
+	origURL := getFetchURL()
+	setFetchURL(srv.URL)
+	defer setFetchURL(origURL)
 
 	r, err := Check(context.Background(), "v2.0.0", true)
 	if err != nil {
@@ -117,9 +117,9 @@ func TestCheck_CacheHit(t *testing.T) {
 func TestCheck_PrereleaseCached(t *testing.T) {
 	defer withTempCache(t)()
 	srv := stubServer(t, Release{TagName: "v2.1.0-rc.1", Prerelease: true})
-	origURL := fetchURL
-	fetchURL = srv.URL
-	defer func() { fetchURL = origURL }()
+	origURL := getFetchURL()
+	setFetchURL(srv.URL)
+	defer setFetchURL(origURL)
 
 	// force=true → fetch + (now) cache the synthetic no-upgrade result.
 	r1, err := Check(context.Background(), "v2.0.0", true)
@@ -158,9 +158,9 @@ func TestCheck_ForceBypassesCache(t *testing.T) {
 	// Server says there IS an upgrade — force=true should bypass cache.
 	srv := stubServer(t, Release{TagName: "v2.1.0", HTMLURL: "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0"})
 	defer srv.Close()
-	origURL := fetchURL
-	fetchURL = srv.URL
-	defer func() { fetchURL = origURL }()
+	origURL := getFetchURL()
+	setFetchURL(srv.URL)
+	defer setFetchURL(origURL)
 
 	r, err := Check(context.Background(), "v2.0.0", true)
 	if err != nil {

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -114,6 +114,34 @@ func TestCheck_CacheHit(t *testing.T) {
 	}
 }
 
+func TestCheck_PrereleaseCached(t *testing.T) {
+	defer withTempCache(t)()
+	srv := stubServer(t, Release{TagName: "v2.1.0-rc.1", Prerelease: true})
+	origURL := fetchURL
+	fetchURL = srv.URL
+	defer func() { fetchURL = origURL }()
+
+	// force=true → fetch + (now) cache the synthetic no-upgrade result.
+	r1, err := Check(context.Background(), "v2.0.0", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r1.UpgradeAvailable {
+		t.Error("prerelease must not be reported as an upgrade")
+	}
+
+	// Close the server now — the second call must succeed from cache without hitting the network.
+	srv.Close()
+
+	r2, err := Check(context.Background(), "v2.0.0", false)
+	if err != nil {
+		t.Fatalf("non-forced call after prerelease cache write must not error: %v", err)
+	}
+	if r2 == nil || r2.UpgradeAvailable {
+		t.Errorf("expected cached no-upgrade result, got %#v", r2)
+	}
+}
+
 func TestCheck_ForceBypassesCache(t *testing.T) {
 	defer withTempCache(t)()
 	// Pre-populate a fresh cache saying up-to-date.

--- a/internal/update/client.go
+++ b/internal/update/client.go
@@ -8,12 +8,28 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 )
 
 // fetchURL is the GitHub Releases API endpoint. It is a var so tests can
 // override it with an httptest.Server URL without touching real network.
-var fetchURL = "https://api.github.com/repos/bavanchun/Typeburn/releases/latest"
+var (
+	fetchURLMu sync.Mutex
+	fetchURL   = "https://api.github.com/repos/bavanchun/Typeburn/releases/latest"
+)
+
+func getFetchURL() string {
+	fetchURLMu.Lock()
+	defer fetchURLMu.Unlock()
+	return fetchURL
+}
+
+func setFetchURL(u string) {
+	fetchURLMu.Lock()
+	defer fetchURLMu.Unlock()
+	fetchURL = u
+}
 
 const bodyLimit = 64 * 1024
 
@@ -42,7 +58,7 @@ func FetchLatest(ctx context.Context, currentVer string) (Release, error) {
 		},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, getFetchURL(), nil)
 	if err != nil {
 		return Release{}, fmt.Errorf("update: build request: %w", err)
 	}

--- a/internal/update/client_test.go
+++ b/internal/update/client_test.go
@@ -110,8 +110,8 @@ func TestFetchLatest_BodyCap(t *testing.T) {
 
 // fetchLatestFrom is a test seam that overrides the target URL.
 func fetchLatestFrom(ctx context.Context, currentVer, url string) (Release, error) {
-	orig := fetchURL
-	fetchURL = url
-	defer func() { fetchURL = orig }()
+	orig := getFetchURL()
+	setFetchURL(url)
+	defer setFetchURL(orig)
 	return FetchLatest(ctx, currentVer)
 }


### PR DESCRIPTION
## Summary

- **Phase 1:** Extract `metrics.LiveWPM` into pure-logic package; fix O(n²) live WPM in `--no-tui` runner
- **Phase 2:** Fix `version --json --check-update` double-emitting error string after JSON object; return `enc.Encode` error directly
- **Phase 3:** Replace boolean `inEsc` with 3-state machine (stNorm/stEsc/stCSI) in `stripANSI`; non-SGR CSI sequences no longer eat visible runes
- **Phase 4:** Cache prerelease `Result` in `Check()`; eliminates repeated network hit during prerelease windows
- **Phase 5:** Rewrite `discardEscape` with blocking `ReadByte`; fixes split-read ESC at buffer boundary; `UnreadByte` preserves Ctrl-C/D
- **Phase 6:** Wrap `cacheFilePath`, `fetchURL`, `checkFn` test-seam globals in `sync.Mutex` accessor pairs; migrate 11 test sites

## Test plan

- [ ] `make test-race` — `go test ./... -race -count=1` — 15/15 packages green
- [ ] `go vet ./...` — clean
- [ ] `gofmt -l .` — empty
- [ ] No new external dependencies (`go.mod` unchanged)
- [ ] CI `ci.yml` passes on PR