### PR TITLE
feat: add /ck:obsidian-sync skill and vault bootstrap

### DIFF
--- a/.claude/skills/obsidian-sync/SKILL.md
+++ b/.claude/skills/obsidian-sync/SKILL.md
@@ -1,0 +1,41 @@
+# Obsidian Sync
+
+Sync this repo's `plans/` and `docs/` markdown files to the Obsidian vault at `Projects/Typeburn/` (one-way: repo → vault).
+
+## Vault prefix
+
+All files sync under `Projects/Typeburn/` in the vault:
+- Repo `plans/foo/plan.md` → vault `Projects/Typeburn/plans/foo/plan.md`
+- Repo `docs/project-roadmap.md` → vault `Projects/Typeburn/docs/project-roadmap.md`
+- Repo `docs/journals/foo.md` → vault `Projects/Typeburn/docs/journals/foo.md`
+
+## Steps
+
+`filepath` = relative path from repo root (e.g., `plans/foo/plan.md`). Apply all **Exclusions** rules on every file before pushing.
+
+1. **Sync plans** — Glob `plans/**/*.md` from repo root
+   - Skip files per the **Exclusions** section below
+   - For each file: Read content → `mcp__obsidian__obsidian_put_content("Projects/Typeburn/" + filepath, content)`
+   - Count files written
+
+2. **Sync docs** — Glob `docs/**/*.md` from repo root
+   - Skip files per the **Exclusions** section below (incl. `docs/wireframe` paths)
+   - For each file: Read content → `mcp__obsidian__obsidian_put_content("Projects/Typeburn/" + filepath, content)`
+   - Count files written
+
+3. **Report**
+   ```
+   ✓ obsidian-sync: N plans files, M docs files → Projects/Typeburn/
+   ```
+
+## Exclusions
+
+- `docs/wireframe/**` — binary/SVG assets, not useful in Obsidian
+- Files > 500 KB — skip with warning: `⚠ skipped <path> (>500 KB)`
+
+## Rules
+
+- Repo is always source of truth. Overwrite vault content without prompting.
+- Never write back from vault to repo.
+- MOC files (`Projects/Typeburn/MOC/`) are vault-only — never touch them during sync.
+- Idempotent: re-running is always safe.

--- a/plans/260525-1500-obsidian-vault-integration/phase-01-vault-bootstrap.md
+++ b/plans/260525-1500-obsidian-vault-integration/phase-01-vault-bootstrap.md
@@ -1,0 +1,67 @@
+---
+phase: 1
+title: "Vault Bootstrap"
+status: completed
+priority: P2
+effort: "30m"
+dependencies: []
+---
+
+# Phase 1: Vault Bootstrap
+
+## Overview
+
+Create the Obsidian vault directory structure at `~/Obsidian/Typeburn/` and verify the MCP obsidian server can write to it. No Obsidian-specific plugin config yet — just the folder skeleton and a smoke-test write.
+
+## Requirements
+
+- Functional: vault directory exists with `plans/`, `docs/`, `MOC/` subdirs; MCP can write a test file
+- Non-functional: idempotent — re-running must not destroy existing vault content
+
+## Architecture
+
+```
+~/Obsidian/Typeburn/          ← Obsidian vault root (NOT in repo)
+├── plans/                    ← synced from repo plans/*/plan.md + phase-*.md
+├── docs/
+│   └── journals/             ← synced from repo docs/journals/*.md
+├── MOC/                      ← Obsidian-only (kanban.md, dashboard.md)
+└── .obsidian/                ← created by Obsidian app; never synced to repo
+```
+
+The MCP obsidian server (`mcp__obsidian__*`) is already connected in Claude Code sessions. Vault path must match the path registered in the MCP server config.
+
+## Related Code Files
+
+- Create: none (vault is outside repo)
+- Verify: MCP server config — confirm vault path matches `~/Obsidian/Typeburn/`
+
+## Implementation Steps
+
+1. Check the MCP obsidian server's registered vault path:
+   - Use `mcp__obsidian__obsidian_list_files_in_vault` — if it succeeds, vault path is already configured
+   - Note the actual vault root returned; use that path everywhere in Phase 2
+2. Create subdirectories via MCP if they don't exist:
+   - Write a sentinel file `plans/.keep`, `docs/.keep`, `MOC/.keep` via `mcp__obsidian__obsidian_put_content`
+   - Writing a file implicitly creates parent dirs in Obsidian vaults
+3. Smoke test: write `MOC/README.md` with content:
+   ```markdown
+   # Typeburn — Project Management Vault
+   Source of truth: ~/Codes/My-projects/Typeburn (repo)
+   Sync direction: repo → vault (one-way, on-demand)
+   Plugins needed: Dataview, Kanban, Templater
+   ```
+4. Confirm file appears via `mcp__obsidian__obsidian_get_file_contents` on `MOC/README.md`
+
+## Success Criteria
+
+- [ ] `mcp__obsidian__obsidian_list_files_in_vault` returns without error
+- [ ] `MOC/README.md` readable via MCP after write
+- [ ] Vault path confirmed and documented for Phase 2
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| MCP vault path mismatch | Read actual path from MCP list response; don't hardcode `~/Obsidian/Typeburn/` |
+| Obsidian app not open | MCP server may need Obsidian running — verify or document prerequisite |

--- a/plans/260525-1500-obsidian-vault-integration/phase-02-obsidian-sync-skill.md
+++ b/plans/260525-1500-obsidian-vault-integration/phase-02-obsidian-sync-skill.md
@@ -1,0 +1,94 @@
+---
+phase: 2
+title: "Obsidian Sync Skill"
+status: completed
+priority: P2
+effort: "1h"
+dependencies: [1]
+---
+
+# Phase 2: Obsidian Sync Skill
+
+## Overview
+
+Build the `/ck:obsidian-sync` skill that reads all `plans/` and `docs/` markdown files from the repo and writes them to the Obsidian vault via MCP. Single command, idempotent, outputs a sync summary.
+
+## Requirements
+
+- Functional:
+  - Sync `plans/*/plan.md` and `plans/*/phase-*.md` → vault `plans/<dir>/`
+  - Sync `docs/journals/*.md` → vault `docs/journals/`
+  - Sync `docs/*.md` (roadmap, codebase-summary, etc.) → vault `docs/`
+  - Skip: `docs/wireframe/`, any non-`.md` files
+  - Output: summary of files written/skipped
+- Non-functional: idempotent; safe to run multiple times; no data loss in vault
+
+## Architecture
+
+The skill is a SKILL.md in `.claude/skills/obsidian-sync/` (in the **repo's** `.claude/skills/`, not `~/.claude/skills/`). It instructs Claude Code to use the MCP obsidian tools to iterate and push files.
+
+```
+.claude/skills/obsidian-sync/
+└── SKILL.md        ← skill instructions for Claude Code
+```
+
+Sync logic (Claude Code executes this when skill is invoked):
+1. `Glob("plans/**/*.md")` → for each: `mcp__obsidian__obsidian_put_content(path, content)`
+2. `Glob("docs/**/*.md")` → filter out `wireframe/` → same put_content call
+3. Print summary: `✓ synced N files`
+
+Vault path mapping:
+- Repo `plans/260522-0900-typeburn-defect-fixes/plan.md` → vault `plans/260522-0900-typeburn-defect-fixes/plan.md`
+- Repo `docs/journals/20260522-defect-fixes.md` → vault `docs/journals/20260522-defect-fixes.md`
+- Paths are relative in both systems; no transformation needed.
+
+## Related Code Files
+
+- Create: `.claude/skills/obsidian-sync/SKILL.md`
+
+## Implementation Steps
+
+1. Create `.claude/skills/obsidian-sync/SKILL.md` with:
+   - Skill name, description, trigger (invoked via `/ck:obsidian-sync`)
+   - Step-by-step sync instructions referencing the MCP tools
+   - File inclusion/exclusion rules
+   - Output format spec
+2. Test by invoking `/ck:obsidian-sync` and verifying a sample plan appears in vault via `mcp__obsidian__obsidian_get_file_contents`
+
+## SKILL.md Content Spec
+
+```markdown
+# Obsidian Sync
+
+Sync repo plans/ and docs/ to the Obsidian vault (one-way, repo → vault).
+
+## Steps
+
+1. Glob all `plans/**/*.md` from repo root
+2. For each file: Read content → mcp__obsidian__obsidian_put_content(path, content)
+3. Glob all `docs/**/*.md`, exclude paths matching `docs/wireframe/`
+4. For each file: Read content → mcp__obsidian__obsidian_put_content(path, content)
+5. Print: `✓ synced N files to Obsidian vault`
+
+## Exclusions
+- `docs/wireframe/**`
+- Any file > 500KB (skip with warning)
+
+## Notes
+- Vault path is relative — use the same relative path as in repo
+- Idempotent: re-running overwrites with latest repo content (vault is never source of truth)
+```
+
+## Success Criteria
+
+- [ ] `.claude/skills/obsidian-sync/SKILL.md` exists
+- [ ] `/ck:obsidian-sync` invocation syncs at least one plan file to vault
+- [ ] Vault file content matches repo file content after sync
+- [ ] Re-running produces no errors
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| MCP put_content path format differs from repo paths | Test with one file first; adjust path prefix if needed |
+| Large phase files hit MCP limits | Skill spec includes 500 KB skip guard |

--- a/plans/260525-1500-obsidian-vault-integration/phase-03-moc-files.md
+++ b/plans/260525-1500-obsidian-vault-integration/phase-03-moc-files.md
@@ -1,0 +1,111 @@
+---
+phase: 3
+title: "MOC Files"
+status: completed
+priority: P2
+effort: "30m"
+dependencies: [1]
+---
+
+# Phase 3: MOC Files
+
+## Overview
+
+Seed two Obsidian-only Map of Content files into `MOC/` — a Kanban board and a Dataview dashboard. These are written to the vault directly (not mirrored from repo) and are never synced back.
+
+## Requirements
+
+- Functional:
+  - `MOC/kanban.md` — Kanban plugin board with columns mapped to `status:` values
+  - `MOC/dashboard.md` — Dataview queries for plans table + journal index
+- Non-functional: files must be valid Obsidian Kanban / Dataview syntax; self-updating via plugin queries
+
+## Architecture
+
+### MOC/kanban.md
+
+Uses the Obsidian **Kanban** plugin format. Cards are seeded manually from current plan statuses; after initial seed, the board is managed by dragging cards in Obsidian.
+
+```markdown
+---
+kanban-plugin: basic
+---
+
+## Pending
+
+- [ ] [[plans/20260521-0700-typeburn-update-check-cli/plan|update-check-cli]]
+- [ ] [[plans/260518-2348-v1.1.0-theme-packs-and-hygiene/plan|v1.1.0-theme-packs]]
+- [ ] [[plans/260519-0142-code-mode-custom-text/plan|code-mode-custom-text]]
+- [ ] [[plans/260525-1500-obsidian-vault-integration/plan|obsidian-vault-integration]]
+
+## In Progress
+
+## Completed
+
+- [ ] [[plans/20260522-0900-typeburn-defect-fixes/plan|defect-fixes-v2.1]]
+- [ ] [[plans/20260520-1700-typeburn-pro-cli-v2/plan|pro-cli-v2]]
+...
+
+## Blocked
+```
+
+### MOC/dashboard.md
+
+Uses **Dataview** plugin. Queries run live over vault files — always reflects current sync state.
+
+````markdown
+# Typeburn — Project Dashboard
+
+## Active Plans
+
+```dataview
+TABLE status, priority, effort, tags
+FROM "plans"
+WHERE file.name = "plan" AND status != "completed"
+SORT priority ASC
+```
+
+## All Plans
+
+```dataview
+TABLE status, priority, effort
+FROM "plans"
+WHERE file.name = "plan"
+SORT file.mtime DESC
+```
+
+## Recent Journals
+
+```dataview
+LIST
+FROM "docs/journals"
+SORT file.name DESC
+LIMIT 10
+```
+````
+
+## Related Code Files
+
+- Create (in vault, via MCP): `MOC/kanban.md`, `MOC/dashboard.md`
+
+## Implementation Steps
+
+1. Read current plan statuses from repo (`plans/*/plan.md` frontmatter `status:` field)
+2. Build `MOC/kanban.md` content — seed cards into correct columns from step 1
+3. Write `MOC/kanban.md` to vault via `mcp__obsidian__obsidian_put_content`
+4. Write `MOC/dashboard.md` to vault via `mcp__obsidian__obsidian_put_content`
+5. Verify both files readable via `mcp__obsidian__obsidian_get_file_contents`
+
+## Success Criteria
+
+- [ ] `MOC/kanban.md` exists in vault with correct Kanban plugin frontmatter
+- [ ] `MOC/dashboard.md` exists in vault with valid Dataview query blocks
+- [ ] All current pending plans appear in Kanban "Pending" column
+- [ ] All completed plans appear in Kanban "Completed" column
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Kanban plugin not installed | Document prerequisite; board degrades gracefully to plain markdown |
+| Dataview query FROM path wrong | Test with `dataview` LIST query first; adjust path prefix if vault structure differs |

--- a/plans/260525-1500-obsidian-vault-integration/phase-04-hook-optional.md
+++ b/plans/260525-1500-obsidian-vault-integration/phase-04-hook-optional.md
@@ -1,0 +1,75 @@
+---
+phase: 4
+title: "Hook — Auto-sync on Write/Edit"
+status: pending
+priority: P3
+effort: "30m"
+dependencies: [2]
+---
+
+# Phase 4: Hook — Auto-sync on Write/Edit
+
+## Overview
+
+Optional PostToolUse hook that auto-triggers `/ck:obsidian-sync` (or a targeted single-file sync) whenever Claude Code writes or edits a file under `plans/` or `docs/`. Eliminates the need to manually invoke the sync skill after every plan/journal update.
+
+## Requirements
+
+- Functional: after any `Write` or `Edit` tool call on `plans/**/*.md` or `docs/**/*.md`, push that file to the vault
+- Non-functional: fast (single-file push, not full resync); non-blocking (hook failure must not break the primary write)
+
+## Architecture
+
+Claude Code hooks live in `.claude/settings.json` under `hooks.PostToolUse`. The hook fires a shell command that calls a Python or shell script to push the changed file via MCP.
+
+```json
+"hooks": {
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit|MultiEdit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".claude/scripts/obsidian-sync-file.sh \"$TOOL_INPUT_FILE_PATH\""
+        }
+      ]
+    }
+  ]
+}
+```
+
+`obsidian-sync-file.sh` logic:
+1. Check if `$1` matches `plans/**/*.md` or `docs/**/*.md` (skip everything else)
+2. If match: call the MCP obsidian put_content via Claude Code's MCP bridge — or write a small Python script using the obsidian REST API if the MCP server exposes HTTP
+3. Exit 0 always (hook failure must not surface as an error)
+
+**Alternative (simpler):** Instead of a shell script, configure the hook to run the `/ck:obsidian-sync` skill as a follow-up prompt. This is heavier (full resync) but zero new code.
+
+## Related Code Files
+
+- Modify: `.claude/settings.json` — add PostToolUse hook entry
+- Create: `.claude/scripts/obsidian-sync-file.sh`
+
+## Implementation Steps
+
+1. Decide hook strategy (single-file push vs full resync):
+   - Single-file: build `obsidian-sync-file.sh` that uses the Obsidian Local REST API plugin (`http://localhost:27123`)
+   - Full resync: configure hook to invoke `/ck:obsidian-sync` skill (no new script, but slower)
+2. Add hook entry to `.claude/settings.json`
+3. Test: edit a plan file via Claude Code → verify vault copy updates within seconds
+4. Verify hook failure (Obsidian not running) exits 0 and doesn't interrupt Claude Code
+
+## Success Criteria
+
+- [ ] Edit to `plans/*/plan.md` triggers vault update automatically
+- [ ] Edit to `docs/journals/*.md` triggers vault update automatically
+- [ ] Hook failure (vault unreachable) does not error or block Claude Code
+- [ ] Non-plan/docs files are not synced
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Obsidian Local REST API not installed | Fallback to full `/ck:obsidian-sync` on-demand; hook is explicitly optional (P3) |
+| Hook adds latency to every Write | Single-file push is fast (<200ms); full resync hook should be background (`&`) |
+| `.claude/settings.json` hook format changes | Test after any Claude Code update |

--- a/plans/260525-1500-obsidian-vault-integration/plan.md
+++ b/plans/260525-1500-obsidian-vault-integration/plan.md
@@ -1,0 +1,43 @@
+---
+title: "Obsidian vault integration for project management"
+description: "One-way sync of plans/ and docs/ into a separate Obsidian vault via MCP. Replaces Jira/Trello/Notion/Linear with local markdown-native project tracking."
+status: in_progress
+priority: P2
+branch: "main"
+tags: [obsidian, tooling, project-management, mcp]
+blockedBy: []
+blocks: []
+created: "2026-05-25T08:00:59.965Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Obsidian vault integration for project management
+
+## Overview
+
+Repo is already markdown-native with YAML frontmatter (`status`, `priority`, `effort`, `tags`, `blockedBy`, `blocks`) in all `plans/*/plan.md` files. This plan wires Obsidian as a visual project-management layer over that existing structure — no new data formats, no external services.
+
+**Architecture:** Separate Obsidian vault at `~/Obsidian/Typeburn/`. One-way sync: repo → vault via MCP obsidian tools. Repo is the single source of truth. Vault is a read/view layer with Obsidian-specific MOC files (kanban board, Dataview dashboard).
+
+**Scope:** `.claude/skills/obsidian-sync/` skill + MOC seed files. No repo code changes. No Go code.
+
+## Phases
+
+| Phase | Name | Effort | Status |
+|-------|------|--------|--------|
+| 1 | [Vault Bootstrap](./phase-01-vault-bootstrap.md) | 30m | Completed |
+| 2 | [Obsidian Sync Skill](./phase-02-obsidian-sync-skill.md) | 1h | Completed |
+| 3 | [MOC Files](./phase-03-moc-files.md) | 30m | Completed |
+| 4 | [Hook — Auto-sync on Write/Edit](./phase-04-hook-optional.md) | 30m | Pending (P3, deferred) |
+
+## Key Decisions (from brainstorm)
+
+- **Vault = separate** (`~/Obsidian/Typeburn/`) — not repo root. Obsidian config never touches git.
+- **Sync = one-way** (repo → vault). Bidirectional sync risks conflicts; deferred unless explicitly requested.
+- **Trigger = on-demand** (`/ck:obsidian-sync`) first. Auto-hook added in Phase 4 if desired.
+- **Kanban columns** map to existing `status:` values: `pending` | `in_progress` | `completed` | `blocked`.
+
+## Dependencies
+
+None — no cross-plan blockers.


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/obsidian-sync/SKILL.md` — on-demand skill that globs `plans/**/*.md` + `docs/**/*.md` and pushes each file to `Projects/Typeburn/` in the Obsidian vault via MCP
- Vault bootstrap complete: `MOC/README.md`, `MOC/kanban.md` (Kanban plugin), `MOC/dashboard.md` (Dataview queries) seeded
- Initial sync done: 12 plan files, 7 docs, 12 journals pushed to vault
- Phases 1-3 of `plans/260525-1500-obsidian-vault-integration` marked completed; Phase 4 (auto-hook) deferred as P3