### PR TITLE
docs: add journal entries for obsidian integration and v2.1.2 brainstorm

### DIFF
--- a/docs/journals/20260525-obsidian-vault-integration.md
+++ b/docs/journals/20260525-obsidian-vault-integration.md
@@ -1,0 +1,38 @@
+# Obsidian Vault Integration Complete
+
+**Date:** 2026-05-25
+**Severity:** Low
+**Component:** Project Management Tooling
+**Status:** Resolved
+
+## What Happened
+
+Completed three-phase Obsidian vault integration: vault bootstrap, sync skill implementation, and MOC file creation. Typeburn repo markdown (plans, docs, journals) now pushes to user's personal vault at `Projects/Typeburn/` subfolder.
+
+## Key Decisions
+
+- **Vault location:** Chose user's main personal vault + `Projects/Typeburn/` subfolder (discovered at runtime, not assumed). No dedicated vault overhead.
+- **Sync direction:** One-way repo → vault. MOC files (kanban.md, dashboard.md) are vault-only, never overwritten.
+- **Skill scope:** `/ck:obsidian-sync` globs `plans/**/*.md` + `docs/**/*.md` from repo root, excludes `docs/wireframe/**` and files >500 KB, uses `mcp__obsidian__obsidian_put_content` via MCP.
+
+## Technical Details
+
+- **Phase 1:** Vault bootstrap + smoke test (`MOC/README.md`)
+- **Phase 2:** Sync skill (`obsidian-sync/SKILL.md`). Code review caught: exclusion rules not inline (fixed), `filepath` definition ambiguous (fixed).
+- **Phase 3:** MOC files:
+  - `kanban.md` — Kanban plugin format, seeded with 12 plans by `status:` frontmatter
+  - `dashboard.md` — Dataview queries: active plans table + all plans sorted by mtime + journal index
+- **Initial sync:** 31 files pushed (12 plans, 7 docs, 12 journals)
+
+## Lessons Learned
+
+1. **Runtime discovery over assumptions:** Vault location was not hard-coded; discovered user's actual structure at runtime.
+2. **One-way sync clarity:** Clear vault prefix + MOC-only convention prevents sync conflicts.
+3. **Code review value:** Reviewer caught documentation gaps in skill steps before merging.
+
+## Next Steps
+
+- **Phase 4 (P3 future):** PostToolUse auto-sync hook for hands-off updates
+- Monitor vault for MOC manual edits; consider if they should feed back to repo
+
+**PR:** #26 merged to main, CI green.

--- a/docs/journals/20260525-v2.1.2-release-and-obsidian-brainstorm.md
+++ b/docs/journals/20260525-v2.1.2-release-and-obsidian-brainstorm.md
@@ -1,0 +1,34 @@
+# v2.1.2 Release + Obsidian Project-Management Architecture
+
+**Date**: 2026-05-25 10:30
+**Severity**: Low (release) + Medium (architecture)
+**Component**: Release engineering, project management
+**Status**: Resolved (release); Planning (Obsidian sync)
+
+## What Happened
+
+**v2.1.2 released.** CHANGELOG back-filled: v2.1.0 entry dated 2026-02-10, v2.1.1 defect-fix summary added (6 fixes from May 22 session), v2.1.2 entry added. `.github/release-notes.md` updated with curated notes. Dry-run tag `v0.0.0-rc.test` verified 7 assets (6 archives + checksums), deleted cleanly, then `v2.1.2` annotated on commit `8f232881` and pushed. `release.yml` green; roadmap updated.
+
+**Obsidian project-management brainstorm concluded.** User wants to replace Jira/Trello/Notion/Linear with local Obsidian vault for tracking plans, journals, roadmap, and kanban. Feasibility: high. Rationale: repo is already markdown-native; all `plans/*/plan.md` files have YAML frontmatter (`status`, `priority`, `effort`, `blockedBy`, `blocks`). Chosen architecture: separate vault at `~/Obsidian/Typeburn/`, one-way sync (repo → vault) via MCP obsidian tools, triggered on-demand via future `/ck:obsidian-sync` skill. Plugins needed: Dataview + Kanban + Templater. MOC files: `kanban.md` (filtered by status), `dashboard.md` (key metrics). Next: `/ck:plan` to produce implementation plan for sync skill + vault seeding.
+
+## Technical Details
+
+**Release engineering**: Zero glitches. 7/7 assets confirmed in dry-run before delete-and-retag. Linear history maintained; squash-merge flow respected. Changelog entry format matches prior releases (date, summary line, link to defect-audit journal).
+
+**Obsidian architecture rationale**: Frontmatter-based dataview queries eliminate sync complexity — no custom DBs, no transformation logic. `status` field drives kanban columns (backlog/in-progress/review/done). `blockedBy`/`blocks` enable dependency graph. Vault stays read-only from Obsidian's perspective; all mutations in repo, synced to Obsidian on pull/PR-merge workflow triggers. One-way avoids accidental Obsidian edits that bypass git.
+
+## Lessons Learned
+
+1. **CHANGELOG discipline matters** — back-filling at release time catches missing entries; should be written as each phase lands.
+2. **Obsidian for static knowledge is excellent** — plugins (Dataview, Kanban) turn YAML frontmatter into queryable dashboards without SQL/BI tooling overhead.
+3. **Sync direction matters** — read-only vault from Obsidian side forces discipline: git is source of truth.
+
+## Next Steps
+
+- **Spin up implementation plan** — `/ck:plan` to design obsidian-sync skill, vault template, and GitHub Actions trigger.
+- **Plugins**: Install Dataview, Kanban, Templater in Obsidian.
+- **MOC structure**: Create `dashboard.md` (Dataview table of open plans) and `kanban.md` (Kanban board by status).
+- **Sync trigger**: GitHub Actions hook on push-to-main to call MCP obsidian tools.
+- **Timeline**: Phase 1 (skill + template), Phase 2 (Actions integration), Phase 3 (vault handoff).
+
+Plan will live in `plans/20260525-HHSS-obsidian-project-management/` once spun up.


### PR DESCRIPTION
## Summary
- Add journal entry for Obsidian vault integration session (2026-05-25)
- Add journal entry for v2.1.2 release and Obsidian brainstorm session (2026-05-25)

## Test plan
- [ ] Docs-only change, no code affected