### PR TITLE
docs: sync roadmap, plan statuses, and CLAUDE.md to shipped state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,4 +72,4 @@ Every change — code, docs, config, release prep — follows:
 
 ## Documentation
 
-`docs/` is the source of truth: `codebase-summary.md` (per-package detail), `system-architecture.md`, `project-roadmap.md` (M2 new-best-precision is the tracked fast-follow), `code-standards.md`, `project-overview-pdr.md`. Update them when behavior or structure changes. Plans live in `plans/`; session journals in `docs/journals/`.
+`docs/` is the source of truth: `codebase-summary.md` (per-package detail), `system-architecture.md`, `project-roadmap.md` (shipped release history + deferred backlog), `code-standards.md`, `project-overview-pdr.md`. Update them when behavior or structure changes. Plans live in `plans/`; session journals in `docs/journals/`.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -221,7 +221,7 @@
 - **Artifact:** Binary in ./bin/typeburn
 - **Distribution:** GitHub Releases (source + pre-built linux/darwin binaries)
 - **Installation:** `go install Typeburn@latest` (via go.mod/go.sum versioning)
-- **Minimum Go:** 1.26+
+- **Minimum Go:** 1.25+
 - **Minimum terminal:** 60 cols × 20 rows (ANSI 256-color or truecolor recommended)
 
 ### Support Policy

--- a/plans/20260521-0700-typeburn-update-check-cli/plan.md
+++ b/plans/20260521-0700-typeburn-update-check-cli/plan.md
@@ -9,7 +9,7 @@ description: >-
   Locked: opt-in default-OFF, all three install methods printed verbatim,
   pre-releases filtered, dev-build skip, no self-upgrade. Ships in v2.1.0
   (separate from v2.0.0 in flight via PR #18).
-status: pending
+status: completed
 priority: P2
 branch: "feat/update-check-v2.1"
 tags: [feature, cli, network, release]

--- a/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/plan.md
+++ b/plans/260518-2348-v1.1.0-theme-packs-and-hygiene/plan.md
@@ -3,7 +3,7 @@ title: v1.1.0 — Theme Packs + Hygiene
 description: >-
   6 theme packs + bundled hygiene fixes; parallel phases, per-phase commits,
   protected-main PR flow
-status: pending
+status: completed
 priority: P2
 branch: feat/v1.1.0-theme-packs-hygiene
 tags:

--- a/plans/260519-0142-code-mode-custom-text/plan.md
+++ b/plans/260519-0142-code-mode-custom-text/plan.md
@@ -4,7 +4,7 @@ description: >-
   ModeCode: type CLI-supplied text/code with full-literal whitespace; new
   codetext loader + isolated code renderer; TDD per phase, protected-main PR
   flow
-status: pending
+status: completed
 priority: P2
 branch: feat/v1.2.0-code-mode
 tags:

--- a/plans/260525-1500-obsidian-vault-integration/plan.md
+++ b/plans/260525-1500-obsidian-vault-integration/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Obsidian vault integration for project management"
 description: "One-way sync of plans/ and docs/ into a separate Obsidian vault via MCP. Replaces Jira/Trello/Notion/Linear with local markdown-native project tracking."
-status: in_progress
+status: completed
 priority: P2
 branch: "main"
 tags: [obsidian, tooling, project-management, mcp]


### PR DESCRIPTION
## Summary
Documentation drift cleanup — syncs shipped state across 6 files:
- CLAUDE.md: corrects stale M2 reference (fixed in v1.0.1, not a fast-follow)
- project-roadmap.md: Go 1.26+ → 1.25+ (aligns with go.mod post-v1.5.0)
- 4 plan statuses: theme-packs, code-mode, update-check, obsidian-vault (marked completed)

**Impact:** Docs-only, no code or test changes.