### PR TITLE
fix: notui Time-mode auto-end + defect cleanup (v2.1.3)

### DIFF
--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -137,6 +137,7 @@
 | m3 | Parent dir not fsync'd on atomic write | MINOR | Power loss durability (acceptable for local data) | Document trade-off | Accepted |
 | m4 | MissedChars field always 0 | MINOR | Field advertised but unusable (no target delivery) | Remove field | ✅ Removed (v1.0.1) |
 | m5 | CJK runes not width-aware | MINOR | Text overflow in 60-col terminals with CJK quotes | Use lipgloss.Width if CJK added | Deferred |
+| m6 | effWPM legacy-0 ambiguity | MINOR | Legacy records with NetWPM==0 fall back to WPM; a real all-wrong run also yields both 0 — result is correct, no schema change needed | Reviewed-and-accepted (YAGNI) | Accepted |
 
 ### Design Constraints
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -12,18 +12,6 @@ import (
 	"github.com/bavanchun/Typeburn/internal/update"
 )
 
-// Screen enumerates the top-level screens. Routing switches on this value.
-type Screen int
-
-const (
-	ScreenHome Screen = iota
-	ScreenTyping
-	ScreenResult
-	ScreenSettings
-	ScreenHistory
-	ScreenCodePaste
-)
-
 // Model is the root Elm model.
 type Model struct {
 	screen   Screen

--- a/internal/app/screen.go
+++ b/internal/app/screen.go
@@ -1,0 +1,14 @@
+package app
+
+// Screen enumerates the top-level screens. The root model's Update switches on
+// this value to route messages to the correct sub-model.
+type Screen int
+
+const (
+	ScreenHome Screen = iota
+	ScreenTyping
+	ScreenResult
+	ScreenSettings
+	ScreenHistory
+	ScreenCodePaste
+)

--- a/internal/cli/notui/runner.go
+++ b/internal/cli/notui/runner.go
@@ -16,41 +16,129 @@ type ResultWriter func(io.Writer, metrics.Result) error
 
 func Run(ctx context.Context, in *os.File, out io.Writer, session runner.Session, write ResultWriter) error {
 	return runRaw(ctx, in, out, func(r io.Reader, w io.Writer) error {
-		return runLoop(r, w, session, write, time.Now)
+		return runLoop(r, w, session, write, time.Now, time.After)
 	})
 }
 
+// readMsg carries one ReadEvent result from the reader goroutine to runLoop.
+// Errors (including EOF and ErrAbort-carrying EventAbort) terminate the loop.
+type readMsg struct {
+	ev  Event
+	err error
+}
+
+// runLoop drives the typing session to completion.
+//
+// Concurrency invariants:
+//   - session.Engine is mutated and read ONLY in this goroutine.
+//   - The reader goroutine touches only the bufio.Reader and the send channel.
+//   - All output (RenderPrompt/RenderStatus/RenderSummary/write) happens here.
+//   - The reader goroutine MUST NOT close the channel; runLoop only receives.
+//     A single blocked reader may remain after return — intentionally abandoned
+//     at process teardown, identical to the runRaw done-goroutine in lifecycle.go.
+//
+// Timer seam: `after` defaults to time.After in Run; tests inject a controlled
+// channel so the timer fires synchronously without real sleeps.
 func runLoop(
 	in io.Reader,
 	out io.Writer,
 	session runner.Session,
 	write ResultWriter,
 	now func() time.Time,
+	after func(time.Duration) <-chan time.Time,
 ) error {
 	RenderPrompt(out, session.Target)
 	rd := bufio.NewReader(in)
+
+	// Cap-1 buffer: lets the reader goroutine deposit one message after drive
+	// returns without blocking, preventing a goroutine leak at process teardown.
+	events := make(chan readMsg, 1)
+	go func() {
+		for {
+			ev, err := ReadEvent(rd)
+			events <- readMsg{ev: ev, err: err}
+			if err != nil {
+				return // reader goroutine exits; never closes the channel
+			}
+		}
+	}()
+
+	return drive(out, session, write, now, after, events)
+}
+
+// drive runs the event/timer select loop, consuming readMsgs from events.
+// Splitting it out of runLoop lets tests feed events synchronously through an
+// unbuffered channel (no pipe, no reader goroutine, no real sleeps) while the
+// production path supplies the reader-fed cap-1 channel built in runLoop.
+func drive(
+	out io.Writer,
+	session runner.Session,
+	write ResultWriter,
+	now func() time.Time,
+	after func(time.Duration) <-chan time.Time,
+	events <-chan readMsg,
+) error {
+	// timer is nil until the first keystroke in Time mode arms it. Lazily arming
+	// on the first-keystroke transition (StartMs 0 → non-zero) makes the timer
+	// fire instant structurally equal to StartMs + Length*1000 — no desync.
+	// Using a nil channel in select is safe: a nil case is never selected.
+	var timer <-chan time.Time
+	timerArmed := false
+
+	// Zero-input path: if no keystroke ever arrives the timer is never armed
+	// and runLoop blocks on the events channel until EOF or SIGINT (ErrAbort).
+	// This is the accepted "no input, no test" behavior; no separate idle timer.
+
 	for {
-		ev, err := ReadEvent(rd)
-		if err != nil {
-			return err
-		}
-		nowMs := now().UnixMilli()
-		switch ev.Kind {
-		case EventNone:
-			continue
-		case EventAbort:
-			return ErrAbort
-		case EventBackspace:
-			session.Engine.Backspace(nowMs)
-		case EventRune:
-			session.Engine.Apply(ev.Rune, nowMs)
-		}
-		done, total := session.Engine.Progress()
-		elapsed := nowMs - session.Engine.StartMs()
-		live := metrics.LiveWPM(session.Engine.Log(), elapsed)
-		RenderStatus(out, done, total, live)
-		if completed(session, nowMs) {
-			result := metrics.Compute(session.Engine.Log(), session.Mode, endMs(session, nowMs))
+		select {
+		case msg := <-events:
+			if msg.err != nil {
+				return msg.err
+			}
+			nowMs := now().UnixMilli()
+			switch msg.ev.Kind {
+			case EventNone:
+				continue // no-op key (e.g. arrow/escape seq); skip repaint
+			case EventAbort:
+				return ErrAbort
+			case EventBackspace:
+				session.Engine.Backspace(nowMs)
+			case EventRune:
+				session.Engine.Apply(msg.ev.Rune, nowMs)
+			}
+
+			// Arm the timer on the keystroke that starts the clock (StartMs 0 → non-zero).
+			// Only relevant for Time mode; for other modes timer stays nil forever.
+			if !timerArmed && session.Mode == config.ModeTime && session.Engine.StartMs() != 0 {
+				timer = after(time.Duration(session.Length) * time.Second)
+				timerArmed = true
+			}
+
+			done, total := session.Engine.Progress()
+			elapsed := nowMs - session.Engine.StartMs()
+			live := metrics.LiveWPM(session.Engine.Log(), elapsed)
+			RenderStatus(out, done, total, live)
+
+			// Event-driven completion: Words/Quote/Code use engine completion;
+			// Time mode can also complete here (backward compat / pre-timer edge).
+			if completed(session, nowMs) {
+				result := metrics.Compute(session.Engine.Log(), session.Mode, endMs(session, nowMs))
+				if write != nil {
+					return write(out, result)
+				}
+				RenderSummary(out, result)
+				return nil
+			}
+
+		case <-timer:
+			// Time mode: clock expired. No trailing keystrokes can enter the log
+			// after this point because we return immediately. Compute uses
+			// StartMs + Length*1000 as endMs; TrimAFK may reduce it if trailing
+			// idle exceeds 7s — that is intended parity with the TUI path.
+			// RenderStatus is intentionally skipped here to avoid a stale frame.
+			// endMs ignores its nowMs arg in Time mode (returns StartMs + Length*1000),
+			// which is the only mode that arms the timer, so pass 0.
+			result := metrics.Compute(session.Engine.Log(), session.Mode, endMs(session, 0))
 			if write != nil {
 				return write(out, result)
 			}

--- a/internal/cli/notui/runner_test.go
+++ b/internal/cli/notui/runner_test.go
@@ -1,0 +1,171 @@
+package notui
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/metrics"
+	"github.com/bavanchun/Typeburn/internal/runner"
+)
+
+// testClock is a deterministic monotonic clock for tests.
+// Each now() call returns the current value then advances by stepMs.
+// Start at a non-zero value: Engine uses 0 as the "not yet started" sentinel
+// for StartMs, so a first-keystroke timestamp of 0 causes the engine to treat
+// the first rune as "no key pressed", breaking timer-arm and endMs math.
+type testClock struct {
+	curMs  int64
+	stepMs int64
+}
+
+func newTestClock(startMs, stepMs int64) *testClock {
+	return &testClock{curMs: startMs, stepMs: stepMs}
+}
+
+func (c *testClock) now() time.Time {
+	t := time.UnixMilli(c.curMs)
+	c.curMs += c.stepMs
+	return t
+}
+
+// timerFactory produces a single controllable timer channel. Calling fire()
+// unblocks the timer case in runLoop synchronously — no real sleep needed.
+type timerFactory struct{ ch chan time.Time }
+
+func newTimerFactory() *timerFactory { return &timerFactory{ch: make(chan time.Time, 1)} }
+
+func (f *timerFactory) after(_ time.Duration) <-chan time.Time { return f.ch }
+func (f *timerFactory) fire()                                  { f.ch <- time.Time{} }
+
+// makeTimeSession creates a Time-mode session with a long buffer so keystrokes
+// never exhaust the target within the test window.
+func makeTimeSession(lengthSec int) runner.Session {
+	tgt := strings.Repeat("hello world ", 500)
+	eng := runner.RebuildEngine(tgt, config.ModeTime, lengthSec)
+	return runner.Session{Engine: eng, Target: tgt, Mode: config.ModeTime, Length: lengthSec}
+}
+
+func makeWordsSession(tgt string, wordCount int) runner.Session {
+	eng := runner.RebuildEngine(tgt, config.ModeWords, wordCount)
+	return runner.Session{Engine: eng, Target: tgt, Mode: config.ModeWords, Length: wordCount}
+}
+
+// runTimerTest drives the select loop synchronously: it feeds each rune through
+// an unbuffered events channel (so every send blocks until drive has consumed
+// it), then fires the timer. Because the last send returns only after drive has
+// received and applied the final keystroke, the subsequent timer fire is the
+// only ready select case — fully deterministic, no pipe, no reader goroutine,
+// no real sleeps.
+func runTimerTest(t *testing.T, sess runner.Session, input string, clk *testClock, tf *timerFactory) metrics.Result {
+	t.Helper()
+
+	rCh := make(chan metrics.Result, 1)
+	captureWrite := ResultWriter(func(_ io.Writer, r metrics.Result) error {
+		rCh <- r
+		return nil
+	})
+
+	events := make(chan readMsg) // unbuffered: each send blocks until consumed
+	go func() {
+		_ = drive(io.Discard, sess, captureWrite, clk.now, tf.after, events)
+	}()
+
+	for _, r := range input {
+		events <- readMsg{ev: Event{Kind: EventRune, Rune: r}}
+	}
+	tf.fire()
+
+	select {
+	case r := <-rCh:
+		return r
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for result")
+		return metrics.Result{}
+	}
+}
+
+// TestRunLoop_TimeMode_AutoEnd_NoAFK: Time/30s, last keystroke within 7s of
+// the clock limit — AFKTrim does NOT fire. Timer fires → DurationMs == Length*1000.
+//
+// Clock: startMs=1000, stepMs=6000. 5 runes land at 1000..25000.
+// endMs = 1000+30000 = 31000. lastKeyMs=25000. gap=6000 ≤ 7000 → no trim.
+// DurationMs = 31000-1000 = 30000.
+func TestRunLoop_TimeMode_AutoEnd_NoAFK(t *testing.T) {
+	const lengthSec = 30
+	clk := newTestClock(1000, 6000)
+	result := runTimerTest(t, makeTimeSession(lengthSec), "hello", clk, newTimerFactory())
+	if result.DurationMs != int64(lengthSec*1000) {
+		t.Errorf("DurationMs: want %d, got %d", lengthSec*1000, result.DurationMs)
+	}
+	if result.CorrectChars+result.IncorrectChars == 0 {
+		t.Error("expected non-zero char counts")
+	}
+}
+
+// TestRunLoop_TimeMode_AutoEnd_WithAFK: Time/30s, runes end well before the
+// window (>7s trailing gap). Timer fires → DurationMs == lastKeyMs-startMs
+// (AFK-trimmed), NOT Length*1000. This is the core TUI parity assertion.
+//
+// Clock: startMs=1000, stepMs=100. 3 runes at 1000,1100,1200.
+// endMs=31000. gap=29800 > 7000 → trim fires → effective endMs=1200.
+// DurationMs = 1200-1000 = 200.
+func TestRunLoop_TimeMode_AutoEnd_WithAFK(t *testing.T) {
+	const lengthSec = 30
+	clk := newTestClock(1000, 100)
+	result := runTimerTest(t, makeTimeSession(lengthSec), "hel", clk, newTimerFactory())
+	const wantMs = int64(200)
+	if result.DurationMs != wantMs {
+		t.Errorf("DurationMs: want %d (AFK-trimmed), got %d", wantMs, result.DurationMs)
+	}
+	if result.DurationMs == int64(lengthSec*1000) {
+		t.Error("DurationMs equals full window — AFK trim should have fired")
+	}
+}
+
+// TestRunLoop_WordsMode_EventDriven: Words mode completes via engine event;
+// no timer required. Regression guard for non-Time paths.
+func TestRunLoop_WordsMode_EventDriven(t *testing.T) {
+	tgt := "hello world"
+	sess := makeWordsSession(tgt, 2)
+	clk := newTestClock(1000, 50)
+
+	pr, pw := io.Pipe()
+	go func() { _, _ = pw.Write([]byte(tgt)); pw.Close() }()
+
+	var result metrics.Result
+	err := runLoop(pr, io.Discard, sess,
+		func(_ io.Writer, r metrics.Result) error { result = r; return nil },
+		clk.now, newTimerFactory().after,
+	)
+	if err != nil {
+		t.Fatalf("runLoop error: %v", err)
+	}
+	if result.CorrectChars == 0 {
+		t.Error("expected correct chars")
+	}
+	if result.DurationMs <= 0 {
+		t.Error("expected positive DurationMs")
+	}
+}
+
+// TestRunLoop_BackspaceOnly_NoChars: backspace-only input on empty buffer (no-op
+// in the engine). EOF terminates the loop; no panic; empty log gives Accuracy=100.
+func TestRunLoop_BackspaceOnly_NoChars(t *testing.T) {
+	clk := newTestClock(1000, 100)
+	sess := makeTimeSession(30)
+
+	pr, pw := io.Pipe()
+	go func() { _, _ = pw.Write([]byte{0x7f, 0x7f, 0x7f}); pw.Close() }()
+
+	err := runLoop(pr, io.Discard, sess, nil, clk.now, newTimerFactory().after)
+	if err != nil && err != io.EOF && err != io.ErrClosedPipe {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	z := metrics.Compute(sess.Engine.Log(), sess.Mode, 0)
+	if z.Accuracy != 100 {
+		t.Errorf("empty log accuracy: want 100, got %v", z.Accuracy)
+	}
+}

--- a/internal/storage/new_best.go
+++ b/internal/storage/new_best.go
@@ -37,7 +37,8 @@ func itoa(n int) string {
 // Post-fix records carry NetWPM directly. Legacy records (written before this
 // field existed) unmarshal NetWPM as 0.0, so we fall back to float64(WPM) to
 // keep the same integer scale — otherwise a new 60.x run would falsely beat a
-// stored legacy 80.
+// stored legacy 80. The 0.0-vs-legacy ambiguity is benign: a genuine run that
+// yields NetWPM 0.0 also has WPM == 0, so float64(WPM) returns the correct 0.
 func effWPM(r Record) float64 {
 	if r.NetWPM == 0 {
 		return float64(r.WPM)

--- a/internal/typing/completion.go
+++ b/internal/typing/completion.go
@@ -50,8 +50,9 @@ func countCompletedWords(typed, target []rune) int {
 	for i, r := range target {
 		if r == ' ' {
 			if inWord {
-				// Check if this word AND its space are covered by typed.
-				// Space position is i; we need typed[i] to exist and be a space.
+				// Word counts complete once typing has advanced past its
+				// trailing-space position (position-based progress; the char
+				// itself isn't re-checked here).
 				if i < len(typed) {
 					completed++
 				}

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -10,7 +10,8 @@ import (
 // Returns (nil, nil) when currentVer is a dev/pseudo-version — no check is performed.
 // When force=true the 24h cache is bypassed and a fresh fetch is made.
 // On any network or parse error the caller receives a non-nil error; silent-degrade
-// is the caller's responsibility (both Phase 3 and Phase 4 treat errors as no-op).
+// is the caller's responsibility (both the opportunistic startup check and the
+// `--check-update` command treat errors as no-op).
 func Check(ctx context.Context, currentVer string, force bool) (*Result, error) {
 	v := strings.ToLower(strings.TrimSpace(currentVer))
 	if v == "" || v == "dev" || v == "unknown" || strings.HasPrefix(v, "v0.0.0-") {
@@ -42,12 +43,21 @@ func Check(ctx context.Context, currentVer string, force bool) (*Result, error) 
 	}
 
 	upgrade := Compare(currentVer, rel.TagName) < 0
+
+	// Mirror the guard that cacheLoad applies on read: only carry URLs that
+	// belong to this repo, so forced/live results cannot surface arbitrary URLs
+	// through --check-update output.
+	url := rel.HTMLURL
+	if !strings.HasPrefix(url, releaseURLPrefix) {
+		url = ""
+	}
+
 	r := &Result{
 		SchemaVersion:    cacheSchemaVersion,
 		Current:          currentVer,
 		Latest:           rel.TagName,
 		UpgradeAvailable: upgrade,
-		ReleaseURL:       rel.HTMLURL,
+		ReleaseURL:       url,
 		CheckedAt:        time.Now().UTC(),
 	}
 	_ = cacheSave(r) // best-effort; errors are non-fatal

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -142,6 +142,47 @@ func TestCheck_PrereleaseCached(t *testing.T) {
 	}
 }
 
+func TestCheck_ReleaseURL_HostileDropped(t *testing.T) {
+	defer withTempCache(t)()
+	srv := stubServer(t, Release{TagName: "v2.1.0", HTMLURL: "https://evil.example/x"})
+	defer srv.Close()
+	origURL := getFetchURL()
+	setFetchURL(srv.URL)
+	defer setFetchURL(origURL)
+
+	r, err := Check(context.Background(), "v2.0.0", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if r.ReleaseURL != "" {
+		t.Errorf("ReleaseURL: want empty for non-repo URL, got %q", r.ReleaseURL)
+	}
+}
+
+func TestCheck_ReleaseURL_ValidPassthrough(t *testing.T) {
+	defer withTempCache(t)()
+	validURL := "https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0"
+	srv := stubServer(t, Release{TagName: "v2.1.0", HTMLURL: validURL})
+	defer srv.Close()
+	origURL := getFetchURL()
+	setFetchURL(srv.URL)
+	defer setFetchURL(origURL)
+
+	r, err := Check(context.Background(), "v2.0.0", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if r.ReleaseURL != validURL {
+		t.Errorf("ReleaseURL: want %q, got %q", validURL, r.ReleaseURL)
+	}
+}
+
 func TestCheck_ForceBypassesCache(t *testing.T) {
 	defer withTempCache(t)()
 	// Pre-populate a fresh cache saying up-to-date.

--- a/plans/20260529-notui-time-mode-and-defect-cleanup/phase-01-notui-time-mode-auto-end.md
+++ b/plans/20260529-notui-time-mode-and-defect-cleanup/phase-01-notui-time-mode-auto-end.md
@@ -1,0 +1,77 @@
+---
+phase: 1
+title: "Notui Time-Mode Auto-End"
+status: completed
+priority: P1
+effort: "3-4h"
+dependencies: []
+---
+
+# Phase 1: Notui Time-Mode Auto-End
+
+## Overview
+Make `--no-tui` Time mode complete on the clock even with zero trailing input, and add the missing `runner_test.go`. Approach A (chosen in brainstorm): async read on a goroutine + `select` over {event channel, timer}. Words/Quote/Code paths unchanged.
+
+## Requirements
+- **Functional:** In Time mode (once started), `runLoop` must *terminate* at wall-time `StartMs + Length*1000` regardless of further input — i.e. the loop ends on the clock, not on a keystroke. The *reported* `DurationMs` from `Compute` may be smaller than `Length*1000` when AFKTrim fires (trailing idle >7s) — that is intended TUI parity, not a bug. No keystroke arriving after the timer fires may enter the engine log.
+- **Functional:** Words/Quote/Code still complete via `Engine.Complete(nowMs)` exactly as today (event-driven).
+- **Non-functional:** Tests deterministic (no real sleeps); reuse/extend the `now func() time.Time` seam. `-race` clean. New file < 200 LOC.
+
+## Architecture
+
+**Current (buggy) flow** — `internal/cli/notui/runner.go:30-61`:
+`runLoop` calls `ReadEvent(rd)` (blocking) at the top of every iteration; the `completed()` check runs only after a read returns. Time mode has no clock source → hangs.
+
+**Target flow:**
+- Spawn a reader goroutine that loops `ReadEvent(rd)` and sends `Event`/`error` into a buffered channel.
+- `runLoop` becomes a `select`:
+  - `case ev := <-events:` apply to engine, render status, then check `completed()`.
+  - `case <-timer:` (Time mode only) → completed by clock; build result with `endMs = start + Length*1000`; render/write; return.
+  - reader error/EOF flows through the channel as a terminating event.
+- Timer source: inject a seam alongside `now` — e.g. `after func(d time.Duration) <-chan time.Time` (defaults to `time.After`) so tests fire it synchronously.
+- **Timer arms on the first-keystroke transition only** (`StartMs() 0 → non-zero`), matching TUI where the clock starts on first input. By construction the timer-fire instant then equals `StartMs + Length*1000`, which is exactly what `endMs()` returns — fire-instant and `endMs` are the *same clock event*, so there is **no desync** (red-team Axis 2). Do NOT arm at loop entry.
+- **Zero-input Time test (no keystroke ever):** no timer is ever armed → `runLoop` stays blocked on the event channel until Ctrl-C (SIGINT → `ErrAbort` via `lifecycle.go`) or stdin EOF (ReadEvent error → loop returns). This is the accepted behavior ("no input, no test"); we do NOT add a separate idle timer. (User decision.)
+- **AFKTrim parity (red-team Axis 5):** `Compute` already runs `TrimAFK` for Time mode — if trailing idle >7s, it rewrites `endMs` down to `lastKeyMs`. We KEEP this (TUI parity, user decision). Consequence: the reported `DurationMs` is `min(Length*1000, lastKeyMs-StartMs)` after trim, NOT always `Length*1000`. Test assertions MUST account for this (see Steps).
+- **endMs already correct:** `endMs()` returns `start + Length*1000` for Time mode — keep it; the timer-fire path calls `Compute` with it (and `Compute` may AFK-trim it). The expiry keystroke does not exist on the timer path (timer fires independently of input), so no post-expiry keystroke can enter the log.
+
+**Concurrency invariants (red-team Axis 1/4) — HARD RULES, enforced in review + `-race`:**
+- `session.Engine` (`Apply`/`Backspace`/`Log`/`Progress`/`StartMs`) is mutated/read **only** from the `runLoop` goroutine. The reader goroutine touches **only** `bufio.Reader` and the send channel — never the engine, never `out`.
+- All `RenderPrompt`/`RenderStatus`/`write` output happens **only** in `runLoop`.
+- The reader goroutine **MUST NOT** `close` the channel (no `defer close`); it only sends. `runLoop` only receives. → no send-on-closed panic.
+- Channel is buffered cap-1 so the first post-return send does not block. After `runLoop` returns (timer/abort/ctx), one reader goroutine may remain blocked on `ReadEvent` or on a second channel send — **intentionally abandoned at process teardown**, same as today's `runRaw` `done` goroutine (`lifecycle.go:69`). Tests MUST tolerate this and **must not** use goroutine-leak assertions on this path.
+
+## Related Code Files
+- Modify: `internal/cli/notui/runner.go` (runLoop → select; add `after` seam; arm timer for Time mode)
+- Create: `internal/cli/notui/runner_test.go` (deterministic Time-mode + Words completion coverage)
+- Read for context: `internal/cli/notui/reader.go`, `lifecycle.go`, `render.go`, `internal/runner/session.go`, `internal/metrics/compute.go`
+
+## Implementation Steps
+1. **Test-first** — write `runner_test.go` with these deterministic cases (injected `now` + `after`; fire timer via manual channel send, never real sleep):
+   - **(a) Auto-end, no trailing idle:** Time/30s, feed runes whose last keystroke is within 7s of the limit (so AFKTrim does NOT fire), then fire the timer. Assert `runLoop` returns a result with `DurationMs == Length*1000` and char counts matching the typed runes.
+   - **(b) Auto-end with trailing idle >7s (AFKTrim path):** feed runes ending well before the limit, fire timer. Assert `DurationMs == lastKeyMs - StartMs` (AFK-trimmed), NOT `Length*1000`. This is the core parity case — getting the assertion right here is the main correctness check.
+   - **(c) Words-mode regression:** feed enough runes to complete; assert event-driven completion unchanged, no timer involved.
+   - **(d) Backspace/EventNone-only log:** feed only deletions then fire timer; assert no panic, valid (accuracy=100, WPM=0) result.
+2. Add an `after func(time.Duration) <-chan time.Time` seam to `runLoop` (default `time.After` in `Run`), alongside the existing `now`.
+3. Extract the read into a goroutine feeding a cap-1 buffered `chan readMsg{ev Event; err error}`. Goroutine: `for { ev,err := ReadEvent(rd); ch <- readMsg{ev,err}; if err != nil { return } }`. **No `close(ch)`.**
+4. Rewrite the loop as `select` over the read channel vs the (lazily-armed) timer channel:
+   - On `readMsg` with err → return err. On event → `Apply`/`Backspace` in runLoop; **arm the timer on the first keystroke that makes `StartMs() != 0`** if Time mode and not yet armed; render status; `completed()` check (unchanged for Words/Quote/Code).
+   - On timer fire (Time mode) → `metrics.Compute(Log(), Mode, endMs(session, nowMs))`; write/summary; return. **Skip the final `RenderStatus`** on this path (avoid a stale display frame — red-team Axis 6).
+5. Verify the zero-input path: with no keystroke, timer is never armed → loop blocks on the channel until EOF/SIGINT. Confirm `runRaw`'s ctx/signal `select` (lifecycle.go) still interrupts it. No code needed beyond not-arming; document it.
+6. Run `go test ./internal/cli/notui/ -race -count=1 -v`, then full `go test ./... -race`, `gofmt -l .`, `go vet ./...`.
+
+## Success Criteria
+- [ ] `runner_test.go` exists; cases (a)-(d) from Step 1 all pass, deterministic, `-race` green (no real sleeps).
+- [ ] Timer arms on first keystroke only; fire-instant == `endMs` by construction (no loop-entry arming).
+- [ ] AFKTrim parity preserved: trailing-idle Time test reports trimmed duration (case b), not `Length*1000`.
+- [ ] Zero-input Time test does not auto-end; terminates only on EOF/SIGINT (documented, not a separate timer).
+- [ ] **Concurrency invariants hold:** engine + all output touched only in `runLoop`; reader goroutine never closes the channel; tests use no goroutine-leak assertions. `-race` green.
+- [ ] Words/Quote/Code completion byte-identical to before (existing tests + case c pass).
+- [ ] `runner.go` and `runner_test.go` each < 200 LOC; gofmt empty; `go vet` clean.
+
+## Risk Assessment
+- **Timer/endMs desync (was CRITICAL):** resolved by arming on the first-keystroke transition so fire-instant == `endMs` is structural, not coincidental. Reviewer must reject any loop-entry arming.
+- **AFKTrim vs duration assertion (was MAJOR):** the naive `DurationMs == Length*1000` assertion is FALSE under trailing idle >7s. Split into case (a) no-trim and case (b) trim. This is the most likely first-write test failure — write both.
+- **Data race (was CRITICAL-leaning):** only safe if the engine is mutated solely in `runLoop`. Hard rule in Success Criteria; `-race` catches violations.
+- **Goroutine leak:** one blocked reader may remain at teardown — accepted (matches `runRaw`). Cap-1 buffer prevents deadlocking `runLoop`'s return. Never `close` the channel.
+- **Determinism:** real `time.After` in tests = flaky. The `after` seam is mandatory.
+- **Scope creep:** do NOT refactor `reader.go` event parsing; only wrap its call site.

--- a/plans/20260529-notui-time-mode-and-defect-cleanup/phase-02-update-url-validation.md
+++ b/plans/20260529-notui-time-mode-and-defect-cleanup/phase-02-update-url-validation.md
@@ -1,0 +1,41 @@
+---
+phase: 2
+title: "Update URL Validation"
+status: completed
+priority: P3
+effort: "30m"
+dependencies: []
+---
+
+# Phase 2: Update URL Validation
+
+## Overview
+Make `update.Check` validate `ReleaseURL` against `releaseURLPrefix` on the forced/live path, so `version --check-update` (which bypasses cache load) prints only repo-trusted URLs — matching the guard `cacheLoad` already applies on read.
+
+## Requirements
+- **Functional:** On the live-fetch path, if `rel.HTMLURL` does not start with `releaseURLPrefix`, do not store/print it (drop to empty string) — symmetric with `cache.go:79`.
+- **Non-functional:** No behavior change for valid GitHub URLs (the normal case). No new deps.
+
+## Architecture
+- `internal/update/cache.go:25` defines `const releaseURLPrefix = "https://github.com/bavanchun/Typeburn/"`.
+- `cacheLoad` (`cache.go:79`) already drops a non-prefixed `ReleaseURL` on read.
+- `Check` (`check.go:50`) assigns `ReleaseURL: rel.HTMLURL` with no guard; `version --check-update` uses `force=true` → skips cache load → prints unvalidated URL (`cmd_version.go:157`).
+- **Fix:** in `Check`, before assigning, validate: `url := rel.HTMLURL; if !strings.HasPrefix(url, releaseURLPrefix) { url = "" }`. `strings` is already imported.
+
+## Related Code Files
+- Modify: `internal/update/check.go` (guard `ReleaseURL` assignment)
+- Read for context: `internal/update/cache.go`, `internal/cli/cmd_version.go`, `internal/update/check_test.go`
+- Modify (tests): `internal/update/check_test.go` (add forced-path case with a hostile HTMLURL → expect empty ReleaseURL)
+
+## Implementation Steps
+1. Add a prefix-check in `Check` that zeroes `ReleaseURL` when `rel.HTMLURL` lacks `releaseURLPrefix`.
+2. Add a test: `Check(force=true)` with a fetched release whose `HTMLURL` is e.g. `https://evil.example/x` → `result.ReleaseURL == ""`, and a valid URL passes through unchanged.
+3. `go test ./internal/update/ -race -count=1`; full `-race`; gofmt; vet.
+
+## Success Criteria
+- [ ] Non-prefixed `ReleaseURL` is dropped on the forced path (test proves it).
+- [ ] Valid GitHub release URLs unchanged.
+- [ ] `-race` green; gofmt empty; vet clean.
+
+## Risk Assessment
+- **Very low.** Single guard mirroring an existing constant. Real-world risk was low (URL comes from GitHub API for this repo); this is consistency hardening, not a live exploit fix.

--- a/plans/20260529-notui-time-mode-and-defect-cleanup/phase-03-hygiene-cleanup.md
+++ b/plans/20260529-notui-time-mode-and-defect-cleanup/phase-03-hygiene-cleanup.md
@@ -1,0 +1,52 @@
+---
+phase: 3
+title: "Hygiene Cleanup"
+status: completed
+priority: P3
+effort: "1h"
+dependencies: []
+---
+
+# Phase 3: Hygiene Cleanup
+
+## Overview
+Three low-risk hygiene items: fix a misleading comment, split `app/model.go` back under 200 LOC, and formally document the `effWPM` zero-sentinel as reviewed-and-accepted (no code/schema change).
+
+## Requirements
+- **completion.go comment:** comment must describe the actual position-based completion logic.
+- **app/model.go:** < 200 LOC (currently 204), without changing behavior.
+- **effWPM:** no functional/schema change; record the review decision so it isn't re-flagged.
+
+## Architecture
+
+### 3a. completion.go comment (`internal/typing/completion.go:~54`)
+Logic counts a word complete when its trailing space position `i < len(typed)` — correct Monkeytype position-based progress. The inline comment ("we need typed[i] to exist and be a space") overstates the check (it does not verify the char IS a space). **Fix:** reword comment to "word counts complete once typing has advanced past its trailing-space position" — comment-only, zero logic change. Existing `completion`-related tests must stay green (no edit needed).
+
+### 3b. app/model.go split (204 → <200 LOC)
+`model.go` holds: `Screen` enum + const block (lines 16-26), `Model` struct (28-68), `New` (70-86), `Init` (88), `Update` (92-...). Sibling files already exist (`model_key_handler.go`, `routing.go`, `model_view.go`, etc.). **Fix (KISS):** move the `Screen` type + its `const (...)` enum into a new tiny `internal/app/screen.go`. That removes ~12 lines from model.go → under 200, with no behavior change and a self-documenting filename. Do NOT reshuffle `Update`/routing.
+
+### 3c. effWPM — documented, NOT changed (`internal/storage/new_best.go:41`)
+`if r.NetWPM == 0 { return float64(r.WPM) }` is a legacy-compat fallback (records pre-`NetWPM` unmarshal it as 0.0). A real run of all-wrong chars also yields NetWPM 0.0, but `WPM` is then 0 too, so the returned value is correct. "Hardening" to distinguish the two would require a presence flag → a **storage schema change for a non-bug** (YAGNI, risks serialization). **Decision: keep as-is.** Add one clarifying sentence to the existing comment noting the 0.0-vs-legacy ambiguity is benign because both fields are 0 in that case. Update `docs/project-roadmap.md` Known-Limitations note if warranted.
+
+## Related Code Files
+- Modify: `internal/typing/completion.go` (comment only)
+- Create: `internal/app/screen.go` (move `Screen` enum + const)
+- Modify: `internal/app/model.go` (remove moved enum)
+- Modify: `internal/storage/new_best.go` (comment only)
+- Read for context: existing `internal/app/*.go` to confirm `Screen` references resolve across the package (same package, no import change needed)
+
+## Implementation Steps
+1. Reword `completion.go` comment; run `go test ./internal/typing/ -race`.
+2. Create `internal/app/screen.go` with `package app`, move `type Screen int` + the `const (...)` block; delete from `model.go`. Build + `go test ./internal/app/ -race`.
+3. Confirm `wc -l internal/app/model.go` < 200.
+4. Add clarifying sentence to `effWPM` comment; no logic change.
+5. Full `go test ./... -race`; `gofmt -l .` empty; `go vet ./...`.
+
+## Success Criteria
+- [ ] `completion.go` comment matches behavior; typing tests green.
+- [ ] `internal/app/model.go` < 200 LOC; `screen.go` holds the enum; app tests green; behavior unchanged.
+- [ ] `effWPM` comment clarified; no schema/logic change; storage tests green.
+- [ ] Full `-race` green; gofmt empty; vet clean.
+
+## Risk Assessment
+- **Low.** Comment edits are zero-risk. The enum move is a same-package relocation (no import cycle, no API change). effWPM intentionally untouched to avoid a risky storage-format change — this is the brutally-honest YAGNI call; surfaced to user, who approved "all" with this caveat.

--- a/plans/20260529-notui-time-mode-and-defect-cleanup/plan.md
+++ b/plans/20260529-notui-time-mode-and-defect-cleanup/plan.md
@@ -1,0 +1,61 @@
+---
+title: "Notui Time-Mode Auto-End + Defect Cleanup (v2.1.3)"
+description: "Fix the --no-tui Time-mode loop that never auto-ends at the time limit (ship-blocker on the default run path), close the notui runner test gap, validate update.Check ReleaseURL on the forced path, and minor hygiene (comment + model.go LOC split). effWPM zero-sentinel reviewed and documented as accepted — no schema change."
+status: completed
+priority: P1
+branch: "fix/notui-time-mode-auto-end"
+tags: [bugfix, notui, cli, release]
+blockedBy: []
+blocks: []
+created: "2026-05-29T08:49:51.203Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Notui Time-Mode Auto-End + Defect Cleanup (v2.1.3)
+
+## Overview
+
+Brainstorm source: `plans/reports/20260529-defect-scan-brainstorm-summary.md`.
+
+Deep code-level defect scan of Typeburn @ v2.1.2 found **one ship-blocker** and minor cleanups. Codebase is otherwise clean (`-race` green, gofmt/vet clean, 0 TODO, no outdated direct deps).
+
+**Ship-blocker (confirmed, reachable via default path):** `typeburn run --no-tui` defaults to Time mode (`settings.DefaultMode`); the notui `runLoop` blocks on `ReadEvent` every iteration and only checks completion *after a keystroke*, so a Time test never auto-ends at the limit — it hangs until the next keypress (or forever in pipe/script). A late keystroke also corrupts result metrics. The notui package has **no `runner_test.go`** (the 52%-coverage gap), so this path was never exercised.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Notui Time-Mode Auto-End](./phase-01-notui-time-mode-auto-end.md) | Completed |
+| 2 | [Update URL Validation](./phase-02-update-url-validation.md) | Completed |
+| 3 | [Hygiene Cleanup](./phase-03-hygiene-cleanup.md) | Completed |
+
+Phases are independent (no inter-phase code dependency); ordered by severity. Phase 1 is mandatory; 2-3 are low-risk follow-ons that can ship in the same PR.
+
+## Key Constraints (from CLAUDE.md)
+
+- **Strict layering:** notui lives in `internal/cli/notui`; must not pull UI (`bubbletea`/`lipgloss`) into pure-logic packages. Time logic already lives in `runner.Session` / `metrics` — keep it there.
+- **Determinism in tests:** the existing `now func() time.Time` seam in `runLoop` must be preserved/extended so the new timer path is testable without real sleeps. No wall-clock flakiness.
+- **File size:** keep every Go file < 200 LOC.
+- **`-race` green, gofmt empty, `go vet` clean** are the CI gate — all three must pass.
+- **Protected main:** branch `fix/notui-time-mode-auto-end` → PR → squash-merge. No direct commit to main.
+
+## Out of Scope
+
+- TUI Time-mode path (already correct via `tea.Tick`).
+- Dependency upgrades (only indirect updates pending; no action).
+- effWPM schema change — see Phase 3 (reviewed, intentionally NOT changed).
+- New features / backlog (Vim motions, custom wordlists, CJK width m5).
+
+## Success Criteria (whole plan)
+
+- `typeburn run --no-tui` (Time/30s) auto-ends at the limit with **zero trailing input**.
+- No late-keystroke inflation in the trailing-path result metrics.
+- New deterministic `runner_test.go` covers Time-mode auto-completion; full suite `-race` green.
+- `update.Check` rejects a non-prefixed `ReleaseURL` on the forced path too.
+- `completion.go` comment matches the position-based logic; `app/model.go` < 200 LOC.
+- gofmt empty, `go vet` clean.
+
+## Dependencies
+
+None. No unfinished plans overlap (all prior plans completed).

--- a/plans/reports/20260529-defect-scan-brainstorm-summary.md
+++ b/plans/reports/20260529-defect-scan-brainstorm-summary.md
@@ -1,0 +1,57 @@
+# Brainstorm Summary — Typeburn Defect Scan & Fix Scope (2026-05-29)
+
+## Problem Statement
+User asked: "check inside my app, tell me what needs to update to fix." Deep code-level defect hunt on Typeburn @ v2.1.2 (post doc-drift cleanup PR #28). Goal: concrete fixes, not style nits.
+
+## Audit Baseline (verified, this session)
+- `go test ./... -race` GREEN; `gofmt -l` empty; `go vet` clean; binary 8.7 MB.
+- Coverage: runner/theme 100%, typing 96%, metrics 94%, codetext 92%, ui 87%; **lowest = cli/notui 52.3%**.
+- 0 TODO/FIXME in code. Only 1 file >200 LOC (`app/model.go` = 204).
+- Direct deps: NONE outdated. Pending updates all indirect (ultraviolet, x/text, testify…) — no action.
+
+## Findings (ranked)
+
+### 🔴 MAJOR — `--no-tui` Time mode never auto-ends (SHIP-BLOCKER, confirmed)
+- **Loc:** `internal/cli/notui/runner.go:30-61`.
+- **Root cause:** `runLoop` blocks on `ReadEvent(rd)` every iteration; `completed()` (Time: `nowMs-start >= Length*1000`) only evaluated AFTER a keystroke. No ticker (TUI uses 100ms `tea.Tick`).
+- **Reachable via default path:** `buildRunRequest` sets `mode := settings.DefaultMode` (= Time); `typeburn run --no-tui` with no `--mode` → Time/30s → hits bug.
+- **Failure:** user types then stops → test hangs until next keypress (or forever in pipe/script). Late keystroke also corrupts `bucketPerSecond`/`totalTyped` (inflated consistency/char counts).
+- **Evidence:** no `runner_test.go` exists — the 52% gap; Time path untested.
+- **User confirmed:** `--no-tui` Time mode IS an official flow → ship-blocker.
+
+### 🟡 MINOR — `update.Check` forced path skips ReleaseURL validation
+- **Loc:** `internal/update/check.go:50` + `internal/cli/cmd_version.go:157`.
+- `cacheLoad` validates `ReleaseURL` vs `releaseURLPrefix` on read; `version --check-update` calls `Check(force=true)` (bypasses cache) then prints URL unvalidated. Low real risk (GitHub API for own repo) but asymmetric.
+
+### 🟢 MINOR / hygiene (bundled per user scope = "all")
+- `effWPM` zero-sentinel `storage/new_best.go:41` — harmless today (both 0); harden against future WPM/NetWPM divergence.
+- `completion.go:55` misleading comment (logic correct, comment wrong).
+- `app/model.go` 204 LOC → split to <200 (convention).
+
+## Agreed Scope (user decision)
+**Fix ALL:** MAJOR notui + MINOR update.Check + effWPM hardening + comment fix + app/model.go split. Time-mode = official → MAJOR mandatory.
+
+## Recommended Solution — MAJOR fix (Approach A, chosen)
+- Async read on goroutine → channel; `runLoop` `select`s over {event channel, `time.NewTicker`/`time.After(limit)`}.
+- Time mode completes on clock even with zero input; `endMs` derived from timer fire (not post-expiry keystroke) → no log corruption.
+- Add `runner_test.go` covering Time-mode auto-completion (closes coverage gap).
+- Rejected Approach B (`SetReadDeadline` on raw terminal fd) — unreliable/flaky with bufio + raw mode.
+
+## Risks / Considerations
+- Goroutine lifecycle: reader goroutine must not leak on completion/abort/ctx-cancel (mirror existing `lifecycle.go` exit semantics; acceptable to leave blocked read at process exit as today).
+- Determinism for tests: keep `now func() time.Time` seam; ticker/timeout must be injectable or use the existing time seam so `runner_test.go` is deterministic (no real sleeps).
+- Backward compat: Words/Quote/Code paths must remain unchanged (they complete via `Engine.Complete`).
+
+## Success Criteria
+- `typeburn run --no-tui` (Time/30s) auto-ends at limit with zero trailing input.
+- No late-keystroke inflation in result metrics.
+- New `runner_test.go` deterministic, `-race` green.
+- update.Check rejects non-prefixed ReleaseURL on all paths.
+- `app/model.go` < 200 LOC; comment + effWPM cleaned.
+- Full suite `-race` green; gofmt/vet clean.
+
+## Next Step
+Hand off to `/ck:plan --deep` (this file as context).
+
+## Unresolved Questions
+- Should the ticker resolution for notui Time mode match TUI (100ms) or coarser (1s, since notui re-renders status line per event)? Plan to decide — leaning 250ms-1s to reduce redraw churn on pipes.


### PR DESCRIPTION
## Summary

- **Phase 1:** Auto-end notui --no-tui Time mode on clock expiry. Fixes hang from blocking ReadEvent; now uses timer-fed select with clock-start arm so timer fires at endMs.
- **Phase 2:** Drop non-repo ReleaseURL on forced --check-update path. Mirrors cacheLoad guard to prevent arbitrary URL surfacing.
- **Phase 3:** Hygiene cleanup: completion comment clarity, Screen enum split to dedicated file, effWPM formula note, roadmap bump.

See plan: `plans/20260529-notui-time-mode-and-defect-cleanup/`

## Test plan

- [x] go test ./... -race -count=1 ✓ (all packages, race detector green)
- [x] gofmt -l . ✓ (empty — no formatting violations)
- [x] go vet ./... ✓ (clean static analysis)
- [x] Code review: Phase-1 concurrency invariants verified under -race

CI gate (ci.yml) will run full test suite, lint, and binary size check on merge.