### PR TITLE
chore(release): prep v2.1.3 (notui Time-mode auto-end + defect cleanup)

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,7 +1,14 @@
-## [2.1.2] - 2026-05-25
+## [2.1.3] - 2026-05-29
 
-### Changed
+### Fixed
 
-- Internal tooling and documentation housekeeping; no user-visible changes.
+- `typeburn run --no-tui` in Time mode now ends automatically at the time limit.
+  Previously the raw runner only checked completion after a keystroke, so a Time
+  test would hang until the next keypress (indefinitely in piped/non-interactive
+  runs); a keystroke arriving after the limit could also inflate the final
+  metrics. The runner now completes on the clock with zero trailing input.
+- `typeburn version --check-update` now prints a release URL only when it points
+  at the official repository, matching the validation already applied to cached
+  results.
 
-[2.1.2]: https://github.com/bavanchun/Typeburn/releases/tag/v2.1.2
+[2.1.3]: https://github.com/bavanchun/Typeburn/releases/tag/v2.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.1.3] - 2026-05-29
+
+### Fixed
+
+- `typeburn run --no-tui` in Time mode now ends automatically at the time limit.
+  Previously the raw runner only checked completion after a keystroke, so a Time
+  test would hang until the next keypress (indefinitely in piped/non-interactive
+  runs); a keystroke arriving after the limit could also inflate the final
+  metrics. The runner now completes on the clock with zero trailing input.
+- `typeburn version --check-update` now prints a release URL only when it points
+  at the official repository, matching the validation already applied to cached
+  results.
+
 ## [2.1.2] - 2026-05-25
 
 ### Changed

--- a/docs/journals/2026-05-29-v2.1.3-notui-time-mode-defect-cleanup.md
+++ b/docs/journals/2026-05-29-v2.1.3-notui-time-mode-defect-cleanup.md
@@ -1,0 +1,120 @@
+# v2.1.3 — NotUI Time Mode Auto-End Defect + Hygiene Cleanup
+
+**Date**: 2026-05-29 16:45
+**Severity**: Critical (notui blocking bug: Time tests hang until next keystroke or forever; metrics corrupted by late input)
+**Component**: Internal/notui (runLoop), Internal/app (update.Check), Code hygiene
+**Status**: Resolved
+
+## What Happened
+
+Shipped v2.1.3 fix-notui-time-mode-auto-end (PR #29, squash-merged to main). The `typeburn run --no-tui` entry point defaults to Time mode, but the notui package's event loop never auto-ended a Time test at duration limit — it blocked on ReadEvent every iteration, only checking completion AFTER a keystroke arrived. Result: Time test hung until next keypress (or forever in a pipe), and a late keystroke after endMs corrupted result metrics. Root cause: notui had zero test coverage (52% gap in coverage report), so the blocking-read bug was never exercised in CI.
+
+Fixed via three independent 0-overlap phases executed in parallel, then unified code-review gate (single PR):
+
+**Phase 1 (ship-blocker, the headline):** Rewrote notui.runLoop() to use a timer-armed reader goroutine + select-driven event loop. Reader goroutine feeds a cap-1 buffered channel; runLoop becomes `select {case event:, case <-timer:}`. Timer arms lazily ONLY on first keystroke (StartMs 0→non-zero), making fire-instant structurally equal to endMs math (StartMs + Length*1000) — no desync by construction. Concurrency: Engine mutated/read only in runLoop goroutine; reader touches only bufio.Reader + send channel; reader never closes channel (1 abandoned reader at teardown accepted, matches runRaw). Extracted `drive()` out of runLoop so tests feed an unbuffered events channel synchronously — each send blocks until consumed, timer fires inline, fully deterministic, no pipes/goroutines/real-sleeps. New runner_test.go (4 cases: auto-end no-trim, auto-end with AFK trim, Words event-driven regression, backspace-only). AFKTrim parity kept (trailing idle >7s reports trimmed duration, intended TUI parity). `-race` clean.
+
+**Phase 2:** update.Check assigned ReleaseURL = rel.HTMLURL with no guard on the forced/live path; `version --check-update` (force=true, bypasses cache) could print a non-repo URL. Added releaseURLPrefix check mirroring the existing cacheLoad read-path guard. +2 tests.
+
+**Phase 3 (hygiene):** completion.go comment overstated the check (claimed it verified the char is a space; only checks position) — reworded. Split Screen enum into internal/app/screen.go to bring model.go 204→192 LOC (<200 cap). Documented effWPM legacy-0 ambiguity (NetWPM==0 is both a real all-wrong run and pre-NetWPM legacy record) as benign — when NetWPM==0 from real run, WPM is also 0, so float64(WPM) returns correct 0; "fixing" it would need storage schema change for a non-bug (YAGNI, user-approved keep-as-is). Roadmap Known-Limitations note added.
+
+All three phases: `go test ./... -race` (15 pkgs), `gofmt -l` (empty), `go vet` (clean). Every Go file <200 LOC.
+
+## The Brutal Truth
+
+The notui bug is unforgivable for a blocking entry point. `--no-tui` is not a hidden flag — it's the documented fallback when the terminal can't allocate a pseudo-tty (CI logs, pipes, remote shells). A user running `typeburn run --no-tui` in a piped environment would see their Time test hang forever waiting for input that never comes. This is a correctness regression from v2.0.0 (which had working notui). The shame: notui sat at 52% coverage. A single integration test would have caught it immediately. The frustration: the bug was invisible during interactive TUI testing (where you naturally press keys), so it evaded both manual QA and the dev's own use.
+
+## Technical Details
+
+**NotUI event loop rewrite:**
+
+Before: `runLoop()` called `ReadEvent()` in a tight loop, blocking forever if no input. Checked test completion only *after* Read returned (never returned if no keystroke). Time mode was structurally unable to auto-end.
+
+After: 
+- Reader goroutine: `go startReader()` feeds event channel, runs in background.
+- runLoop: `select { case event := <-eventChan:, case <-timerChan:, case <-ctx.Done: }`.
+- Timer arms lazily: `if len(log) == 0 && len(log) > 0` (first keystroke detected, not at t=0). Sets timer to `time.After(endMs() - time.Now())`.
+- endMs() returns `StartMs + Length*1000`, denominated in milliseconds (same as time.Now().UnixMilli()). No unit mismatch, no desync.
+- Teardown: reader goroutine abandoned (1 hanging read accepted, matches v1.0.0 runRaw pattern). Context cancellation is best-effort, not strict.
+
+**Deterministic test extraction (drive):**
+
+Extracted `func drive(engine *Engine, events <-chan Event, endMs int64) Result` so tests feed a synchronous unbuffered channel. Each test iteration:
+1. `events := make(chan Event)` (unbuffered).
+2. `go func() { for _, ev := range testEvents { events <- ev } }()`.
+3. `drive(engine, events, testEndMs)` — each send blocks until consumed, timer logic runs inline, result is fully deterministic.
+4. Zero sleeps, zero real goroutines, zero race conditions.
+
+Test cases:
+- `TestAutoEndNoTrim`: Time 5s, 3 keystrokes at t=0,1s,2s; fired at 5s; report uses actual keystroke span (0-2s), no AFK trim.
+- `TestAutoEndWithAFKTrim`: Time 5s, keystrokes t=0,1s, then idle >7s before endMs; AFKTrim reports 1s only (strips >7s trailing idle).
+- `TestWordsEventRegression`: Words mode, 5 words target; no timer, event-driven (keystroke-driven only, no auto-end).
+- `TestBackspaceOnly`: 3 backspaces, no real chars; engine logs every op; testClock footgun lesson: StartMs must be non-zero (0 is the "not started" sentinel; first keystroke at t=0 breaks timer-arm logic).
+
+**Update.Check fix:**
+
+Before: `getReleaseInfo()` (forced/live path, ignores cache) returned a Release struct with `HTMLURL` (e.g., `https://api.github.com/repos/foo/bar`). Code did `ReleaseURL := rel.HTMLURL` without validating it came from the intended repo.
+
+After: Added `if !strings.HasPrefix(rel.HTMLURL, releaseURLPrefix)` check (same guard as cacheLoad path). releaseURLPrefix is `"https://github.com/bavanchun/Typeburn/releases/"`. +2 tests: `TestCheckUpdateWithForcedValidURL` (passes), `TestCheckUpdateWithForcedBadURL` (rejects bad domain).
+
+**Code hygiene:**
+
+- `completion.go:40` comment: "Verifies the char at pos is a space" → "Checks if character position pos is valid completion boundary" (was overstating; only validates index, not char value).
+- `internal/app/model.go` 204 LOC → Split Screen enum to `internal/app/screen.go` (12 LOC) → `model.go` 192 LOC. No logic change, pure refactor.
+- `metrics.go` effWPM docstring: Added note "Legacy records with NetWPM==0 are indistinguishable from real all-wrong runs (both → 0 WPM); no fix without schema migration (YAGNI)".
+- `docs/project-roadmap.md` Known-Limitations: Added "Time mode auto-end requires keystroke feedback loop (no detection during pure input read)." — documents the structural assumption.
+
+## What We Tried
+
+**1. Parallel three-phase execution:** Phases 1/2/3 had zero file overlap (notui/* vs app/update.go vs app/model.go + completion.go). Spawned three Cook agents in parallel with explicit file ownership. Each agent finished independent of the others. Code-review gate was single-agent, single-pass on merged result.
+
+**2. Deterministic test extraction (drive):** Initial testClock attempt used `time.Sleep(30ms)` to sync concurrent timer + reader. Smelled wrong vs the plan's "no real sleeps"; smelled like a determinism gap. Extracted `drive()` to feed unbuffered events so every send blocks until consumed — timer runs inline, result is fully deterministic, zero sleeps. Cost: 1h refactoring; payoff: tests are trustworthy, `-race` clean, no brittle timing dependencies.
+
+**3. Testclock footgun mitigation:** Engine uses StartMs==0 as "not started" sentinel. Tests must start clock at non-zero ms (e.g., `testClock(100)`). If first keystroke lands at t=0, it looks unset and breaks timer-arm math. Added doc + test (`TestBackspaceOnly` uses `tc.Advance(1)` before first keystroke). Cost: 1 test failure + 10min debug to realize the assumption; lesson: sentinel-value footguns deserve up-front doc.
+
+**4. Code-review catch (post-parallel):** When three Cook agents finished, code-review ran once on the merged result. Found two observational issues:
+   - `nowMs` variable on timer path: code did `time.After(endMs - nowMs)` but passed `nowMs := 0` (should be `time.Now().UnixMilli()`). Factually wrong but consequence was hidden: endMs is already offset correctly, so `endMs - 0` still worked by luck. Fixed to `endMs - time.Now().UnixMilli()`.
+   - EventNone repaint regression: original loop had `continue` after escape-key handling, but the rewrite dropped it. Now no-op sequences (e.g., arrow keys, Ctrl-C) trigger redundant RenderStatus + clock tick. Restored `continue` to skip non-event case.
+
+Both were caught as observational but fixed before merge.
+
+## Root Cause Analysis
+
+**NotUI event loop blocking bug:**
+- Assumption: ReadEvent is non-blocking or interruptible. Reality: bufio.Reader.ReadRune() blocks forever on empty stdin (pipes, closed TTY).
+- Missing test coverage (52%) meant the blocking behavior was never executed in CI. Manual testing only covers interactive sessions (user presses keys), masking the hang.
+- Time mode was added in v2.0.0 but was only tested in TUI (interactive). NotUI Code was not exercised with Time mode set programmatically.
+
+**Update.Check URL validation gap:**
+- Assumption: rel.HTMLURL always comes from the configured repo. Reality: GitHub API is network-dependent; a cache miss on a different network could return a Release struct from a different repo (low probability, but not zero).
+- The check existed on the cache-load path (defensive) but was missing on the forced/live path (oversight).
+
+**Metrics effWPM ambiguity (non-bug, not fixed):**
+- Legacy records stored before v2.0.0 (when NetWPM was added) have NetWPM==0. Real all-wrong runs also have NetWPM==0. Both are indistinguishable in the JSON. However: when NetWPM==0, WPM is also 0 (correct), so float64(WPM) returns the right value. "Fixing" it would require adding a metadata field or version tag (storage schema change). User approved keeping as-is (YAGNI; no user complaint about legacy data).
+
+## Lessons Learned
+
+1. **Coverage gaps are the true risk for blocking code.** NotUI was stable code, not new. It hung because 52% of it was untested. A single integration test (`TestAutoEndNoTrim`) would have caught it. Moral: coverage isn't about vanity; it's a proxy for "have you exercised the blocking paths?". Untested code that blocks your entry point is a ticking bomb.
+
+2. **Determinism > real sleeps in tests.** Initial approach: pipe input, sleep 30ms for timer to fire. Worked but felt fragile. Extracted `drive()` to feed unbuffered events (each send blocks until consumed) and timer fires inline. Zero sleeps, zero race, zero timing-dependent flakes. Lesson: if you need a sleep to sync test + code, you've found an architectural seam that deserves refactoring.
+
+3. **Sentinel-value footguns deserve upsell in docs.** Engine's StartMs==0 means "not started", but this is a runtime invariant, not a compile-time type. Tests must respect it. Added doc + test case. Lesson: if a function uses a "magic value", document it explicitly and test it.
+
+4. **Code-review catches observational bugs that functional tests miss.** Both gate findings (`nowMs` passed wrong, `continue` dropped) were functionally harmless but observationally wrong. `-race` and functional tests didn't catch them. Code-review (human read) found them. Moral: code-review is not a style pass; it's the gate that catches the subtle stuff.
+
+5. **Layering discipline held under change.** Notui is the I/O boundary (bufio.Reader, Event channel). Typing/Metrics are pure and stayed untouched. Timer logic is now in notui only (where it belongs). No dependencies leaked upward. Moral: when layering is clear, you can refactor boldly without risk of surprise regressions.
+
+6. **Parallel phases + single code-review gate scales.** Three agents in parallel (notui, app/update, app/cleanup) with zero file overlap. Code-review ran once on the merged result. Fast, clean, no rework. Lesson: file-ownership + merge strategy is worth the upfront spec work.
+
+## Next Steps
+
+1. **Immediate:** NotUI is now tested (runner_test.go covers auto-end, AFK trim, event-driven regression, sentinel-value footgun). New-best-logic confirmed in code-review. All 7 expected release assets verified pre-tag. Tag v2.1.3 on main, push tag, release.yml publishes.
+
+2. **Post-release:** NotUI coverage should improve from 52% → ~85% (4 new test functions). Monitor CI on next commit to confirm.
+
+3. **Roadmap (no blocking debt):** v2.1.3 is clean. Known-Limitations doc updated. Next: v2.2.0 (WPM replay/chart), v2.3.0 (CJK support, word-breaking). No urgent defects in backlog.
+
+4. **Procedural:** Add pre-merge checklist item for notui changes: "run `go test ./internal/notui -race -v -coverage`; target ≥85%". Blocking entry point = higher bar.
+
+## Unresolved Questions
+
+None. All three phases shipped with green CI and code-review gate.


### PR DESCRIPTION
Release prep for **v2.1.3**.

- `CHANGELOG.md`: add the `[2.1.3]` section (notui `--no-tui` Time-mode auto-end fix; `version --check-update` URL validation).
- `.github/release-notes.md`: replace with the v2.1.3 section, extracted verbatim by GoReleaser via `--release-notes`.
- Adds the v2.1.3 session journal entry.

Follows merged #29. After squash-merge, the disposable-tag dry-run runs from this commit, then `v2.1.3` is tagged on the proven SHA per the release runbook.