### PR TITLE
feat: per-key error heatmap (Result screen + CLI)

### DIFF
--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -159,15 +159,17 @@ and `wordTarget` math shared by TUI and CLI.
 **Purpose:** Pure computation of typing test metrics from keystroke log. Zero UI dependencies. Formulas verified against researcher-02-typing-metrics.md.
 
 **Key types:**
-- `Result`: {NetWPM, RawWPM, Accuracy, Consistency, CPS, TimeMs, CharCount, ErrorCount, ErrorHistory, WPMHistory, ...} — final test metrics
+- `Result`: {NetWPM, RawWPM, Accuracy, Consistency, CPS, TimeMs, CharCount, ErrorCount, ErrorHistory, WPMHistory, KeyMisses, ...} — final test metrics
+- `KeyMiss`: {Key (folded rune), Label (display, e.g. "␣"), Misses, Attempts} — per-key fumble tally entry
 
 **Entry points:**
-- `Compute(log []typing.Keystroke, startMs, durationMs) Result`: compute all metrics post-hoc
+- `Compute(log []typing.Keystroke, startMs, durationMs) Result`: compute all metrics post-hoc; populates `Result.KeyMisses` (nil on empty/zero-duration logs)
+- `KeyHeatmap(log []typing.Keystroke) []KeyMiss`: per-key miss tally over the log — every wrong forward keystroke vs a real target (corrected fumbles included), case-folded, keys with ≥1 miss only, sorted misses desc → attempts desc → key asc. Surfaced on the Result screen and in CLI `key_misses` (JSON) / `most_missed_*` (table).
 - `LiveWPM(log []typing.Keystroke, elapsedMs int64) float64`: lightweight O(n) live WPM for in-progress display; returns 0 below 500 ms guard; counts only forward keystrokes (Typed != 0)
 - `AFKTrim(log, durationMs) ([]typing.Keystroke, int64)`: remove trailing AFK seconds (Time mode only, >7s)
 - `Consistency(wpmPerSecond []float64) float64`: 100 × tanh(1 − CV)
 
-**Files:** compute.go, consistency.go, per_second.go, afk_trim.go, live_wpm.go, compute_test.go, consistency_test.go, afk_trim_test.go, live_wpm_test.go.
+**Files:** compute.go, consistency.go, per_second.go, afk_trim.go, live_wpm.go, key_heatmap.go, compute_test.go, consistency_test.go, afk_trim_test.go, live_wpm_test.go, key_heatmap_test.go.
 
 ---
 

--- a/docs/journals/2026-05-29-per-key-error-heatmap.md
+++ b/docs/journals/2026-05-29-per-key-error-heatmap.md
@@ -1,0 +1,52 @@
+# Per-Key Error Heatmap
+
+**Date:** 2026-05-29
+**Branch:** `feat/key-error-heatmap` → PR #31
+**Plan:** `plans/20260529-key-error-heatmap/`
+
+## What shipped
+
+After each test, Typeburn now surfaces the keys the user fumbled most — a
+post-hoc per-key miss tally. Pure replay over the existing keystroke log; nothing
+persisted, no schema change. Rides the ephemeral `metrics.Result`.
+
+Built TDD across four phases:
+
+1. **Metrics** — `KeyHeatmap(log) []KeyMiss` + `Result.KeyMisses`, populated in
+   `Compute`. A miss = every wrong forward keystroke (`Typed!=0`) vs a real
+   target (`Target!=0`) where `!Correct` — corrected fumbles still count.
+   Case-folded (`unicode.ToLower`), keys with ≥1 miss only, sorted
+   misses↓ → attempts↓ → key↑, capped to top 8. Single pass, timing-independent.
+2. **Result screen** — `renderKeyHeatmap` adds a `most missed:  e ×4   t ×3 …`
+   line between char-stats and meta. Theme-roles only (NO_COLOR/mono layout
+   identical), width-capped to the panel; faint `no missed keys` on clean runs.
+3. **CLI** — additive `key_misses` JSON array (empty → `[]`, not `null`) and
+   top-5 `most_missed_*` table rows. Single mapping layer (`newMetricOutput` /
+   `metricTableRows`), so both `run --no-tui` and `replay` inherit it. Existing
+   JSON keys unchanged.
+4. **Docs + gate** — `codebase-summary.md` + `project-roadmap.md`; full CI gate
+   green (`go test ./... -race`, `go vet`, `gofmt -l`, `make size-check`).
+
+## Key decision: honor the locked plan over weakening docs
+
+The mandatory code review caught a real contract drift. The brainstorm had
+**locked "Top N = 8"**, and phase-03 documented JSON as "the full (top-8) list".
+But the first implementation left `KeyHeatmap` *uncapped* — the top-8 bound lived
+only in the UI layer (`heatmapMaxEntries`). So JSON `key_misses` was actually
+unbounded (a 200-distinct-key Code-mode paste would emit 200 entries).
+
+Two ways to resolve: (a) weaken the docs to "uncapped", or (b) move the cap into
+`KeyHeatmap` so every surface inherits it. Per the project rule that *verified/
+locked user decisions are sticky*, the cap was the user's locked design choice —
+so the fix aligned the code to the plan, not the other way around. The cap now
+lives in `KeyHeatmap`; the UI `heatmapMaxEntries` became defensive belt-and-
+suspenders. Added a `TestKeyHeatmap_CapsAtTopN` to lock it.
+
+## Notes
+
+- All new files <200 LOC; pure-logic packages (`metrics`, `cli`) keep zero UI deps.
+- Test robustness lesson: asserting `×4` against the raw styled Result view failed
+  because lipgloss splits a single `Render` with ANSI resets between runes — the
+  view-level substring checks had to run through the package's `stripANSI` helper.
+- Deferred (future): lifetime/aggregate heatmap across history, per-key error-*rate*
+  coloring, finger/row grouping, configurable N, ASCII space-glyph fallback.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -61,6 +61,19 @@
 
 ### Medium Priority (Feature Enhancements)
 
+#### Per-Key Error Heatmap — ✅ IMPLEMENTED (unreleased, version TBD at ship)
+- **Description:** Post-hoc per-key miss tally — counts every wrong forward
+  keystroke against a real target (corrected fumbles included), case-folded,
+  top 8. Surfaced on the Result screen ("most missed:" line) and in CLI output
+  (`key_misses` JSON array + `most_missed_*` table rows).
+- **Implementation:** Pure replay in `internal/metrics` (`KeyHeatmap` +
+  `Result.KeyMisses`); no persistence, no schema change (rides the ephemeral
+  `metrics.Result`). Result-screen render is theme-role only (NO_COLOR/mono safe).
+- **Status:** Implemented on `feat/key-error-heatmap`; ships in the next release.
+- **Deferred follow-ups:** lifetime/aggregate heatmap across history, per-key
+  error-*rate* coloring, finger/row grouping, configurable N, ASCII space-glyph
+  fallback.
+
 #### Code Mode (Custom Text Input)
 - **Description:** Paste arbitrary text for typing test instead of word/quote selection
 - **Effort:** ~3 days

--- a/internal/cli/cmd_replay_test.go
+++ b/internal/cli/cmd_replay_test.go
@@ -26,6 +26,10 @@ func TestReplayJSON(t *testing.T) {
 	if !strings.Contains(out.String(), `"net_wpm"`) || !strings.Contains(out.String(), `"mode": "words"`) {
 		t.Fatalf("unexpected replay JSON:\n%s", out.String())
 	}
+	// key_misses is additive to the CLI contract; the all-correct fixture has none.
+	if !strings.Contains(out.String(), `"key_misses"`) {
+		t.Fatalf("replay JSON missing key_misses field:\n%s", out.String())
+	}
 }
 
 func TestReplayErrors(t *testing.T) {

--- a/internal/cli/metric_output.go
+++ b/internal/cli/metric_output.go
@@ -6,19 +6,34 @@ import (
 	"github.com/bavanchun/Typeburn/internal/metrics"
 )
 
+// keyMissTableRows caps how many most_missed rows the table view shows; the
+// JSON output carries the full (top-8) list from metrics.KeyHeatmap.
+const keyMissTableRows = 5
+
+type keyMissOutput struct {
+	Key      string `json:"key"`
+	Misses   int    `json:"misses"`
+	Attempts int    `json:"attempts"`
+}
+
 type metricOutput struct {
-	NetWPM         float64 `json:"net_wpm"`
-	RawWPM         float64 `json:"raw_wpm"`
-	Accuracy       float64 `json:"accuracy"`
-	Consistency    float64 `json:"consistency"`
-	CPS            float64 `json:"cps"`
-	CorrectChars   int     `json:"correct_chars"`
-	IncorrectChars int     `json:"incorrect_chars"`
-	ExtraChars     int     `json:"extra_chars"`
-	DurationMs     int64   `json:"duration_ms"`
+	NetWPM         float64         `json:"net_wpm"`
+	RawWPM         float64         `json:"raw_wpm"`
+	Accuracy       float64         `json:"accuracy"`
+	Consistency    float64         `json:"consistency"`
+	CPS            float64         `json:"cps"`
+	CorrectChars   int             `json:"correct_chars"`
+	IncorrectChars int             `json:"incorrect_chars"`
+	ExtraChars     int             `json:"extra_chars"`
+	DurationMs     int64           `json:"duration_ms"`
+	KeyMisses      []keyMissOutput `json:"key_misses"`
 }
 
 func newMetricOutput(r metrics.Result) metricOutput {
+	misses := make([]keyMissOutput, 0, len(r.KeyMisses))
+	for _, km := range r.KeyMisses {
+		misses = append(misses, keyMissOutput{Key: km.Label, Misses: km.Misses, Attempts: km.Attempts})
+	}
 	return metricOutput{
 		NetWPM:         r.NetWPM,
 		RawWPM:         r.RawWPM,
@@ -29,11 +44,12 @@ func newMetricOutput(r metrics.Result) metricOutput {
 		IncorrectChars: r.IncorrectChars,
 		ExtraChars:     r.ExtraChars,
 		DurationMs:     r.DurationMs,
+		KeyMisses:      misses,
 	}
 }
 
 func metricTableRows(r metrics.Result) [][]string {
-	return [][]string{
+	rows := [][]string{
 		{"net_wpm", fmt.Sprintf("%.2f", r.NetWPM)},
 		{"raw_wpm", fmt.Sprintf("%.2f", r.RawWPM)},
 		{"accuracy", fmt.Sprintf("%.2f%%", r.Accuracy)},
@@ -41,4 +57,11 @@ func metricTableRows(r metrics.Result) [][]string {
 		{"cps", fmt.Sprintf("%.2f", r.CPS)},
 		{"duration_ms", fmt.Sprint(r.DurationMs)},
 	}
+	for i, km := range r.KeyMisses {
+		if i >= keyMissTableRows {
+			break
+		}
+		rows = append(rows, []string{"most_missed_" + km.Label, fmt.Sprintf("%d/%d", km.Misses, km.Attempts)})
+	}
+	return rows
 }

--- a/internal/cli/metric_output_test.go
+++ b/internal/cli/metric_output_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/metrics"
+)
+
+func sampleResult() metrics.Result {
+	return metrics.Result{
+		NetWPM: 80, RawWPM: 90, Accuracy: 95, Consistency: 88, CPS: 7.5,
+		CorrectChars: 100, IncorrectChars: 5, ExtraChars: 1, DurationMs: 30000,
+		KeyMisses: []metrics.KeyMiss{
+			{Key: 'e', Label: "e", Misses: 4, Attempts: 31},
+			{Key: 't', Label: "t", Misses: 3, Attempts: 20},
+		},
+	}
+}
+
+// TestNewMetricOutput_MapsKeyMisses checks key_misses mapping and that existing
+// fields are preserved (CLI contract guard).
+func TestNewMetricOutput_MapsKeyMisses(t *testing.T) {
+	out := newMetricOutput(sampleResult())
+	if out.NetWPM != 80 || out.DurationMs != 30000 || out.CorrectChars != 100 {
+		t.Fatalf("existing metric fields changed: %#v", out)
+	}
+	if len(out.KeyMisses) != 2 {
+		t.Fatalf("want 2 key misses, got %d", len(out.KeyMisses))
+	}
+	if out.KeyMisses[0] != (keyMissOutput{Key: "e", Misses: 4, Attempts: 31}) {
+		t.Errorf("top key miss mismatch: %#v", out.KeyMisses[0])
+	}
+}
+
+// TestNewMetricOutput_EmptyKeyMissesIsArray checks an empty heatmap serializes
+// as [] (stable contract), not null.
+func TestNewMetricOutput_EmptyKeyMissesIsArray(t *testing.T) {
+	out := newMetricOutput(metrics.Result{Accuracy: 100})
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"key_misses":[]`) {
+		t.Errorf("empty heatmap should marshal as []:\n%s", data)
+	}
+}
+
+// TestNewMetricOutput_JSONContainsKeyMisses checks the JSON key + entry shape.
+func TestNewMetricOutput_JSONContainsKeyMisses(t *testing.T) {
+	data, err := json.Marshal(newMetricOutput(sampleResult()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	for _, want := range []string{`"key_misses"`, `"key":"e"`, `"misses":4`, `"attempts":31`, `"net_wpm"`} {
+		if !strings.Contains(s, want) {
+			t.Errorf("JSON missing %q:\n%s", want, s)
+		}
+	}
+}
+
+// TestMetricTableRows_AppendsMissRows checks top-N most_missed rows are appended
+// after the existing rows.
+func TestMetricTableRows_AppendsMissRows(t *testing.T) {
+	rows := metricTableRows(sampleResult())
+	var foundE, foundT, foundDur bool
+	for _, r := range rows {
+		switch r[0] {
+		case "most_missed_e":
+			foundE = r[1] == "4/31"
+		case "most_missed_t":
+			foundT = r[1] == "3/20"
+		case "duration_ms":
+			foundDur = true
+		}
+	}
+	if !foundDur {
+		t.Error("existing duration_ms row missing")
+	}
+	if !foundE || !foundT {
+		t.Errorf("expected most_missed rows for e and t, got rows: %#v", rows)
+	}
+}
+
+// TestMetricTableRows_CapsAtFive checks no more than 5 most_missed rows appear.
+func TestMetricTableRows_CapsAtFive(t *testing.T) {
+	r := sampleResult()
+	r.KeyMisses = nil
+	for _, lbl := range []string{"a", "b", "c", "d", "e", "f", "g"} {
+		r.KeyMisses = append(r.KeyMisses, metrics.KeyMiss{Key: rune(lbl[0]), Label: lbl, Misses: 2, Attempts: 10})
+	}
+	rows := metricTableRows(r)
+	count := 0
+	for _, row := range rows {
+		if strings.HasPrefix(row[0], "most_missed_") {
+			count++
+		}
+	}
+	if count != 5 {
+		t.Errorf("want 5 most_missed rows (capped), got %d", count)
+	}
+}
+
+// TestMetricTableRows_NoMisses checks clean runs add no most_missed rows.
+func TestMetricTableRows_NoMisses(t *testing.T) {
+	rows := metricTableRows(metrics.Result{Accuracy: 100})
+	for _, row := range rows {
+		if strings.HasPrefix(row[0], "most_missed_") {
+			t.Errorf("clean run should add no most_missed rows, got %v", row)
+		}
+	}
+}

--- a/internal/metrics/compute.go
+++ b/internal/metrics/compute.go
@@ -21,6 +21,8 @@ type Result struct {
 
 	DurationMs int64       // effective test duration (endMs - startMs, after AFK trim)
 	PerSecond  []PerSecond // per-second breakdown
+
+	KeyMisses []KeyMiss // per-key fumble tally (nil on empty/zero-duration logs)
 }
 
 // Compute derives all metrics from the keystroke log, mode, and caller-supplied
@@ -111,6 +113,7 @@ func Compute(log []typing.Keystroke, mode config.Mode, endMs int64) Result {
 		Errors:         incorrect,
 		DurationMs:     durationMs,
 		PerSecond:      perSec,
+		KeyMisses:      KeyHeatmap(log),
 	}
 }
 

--- a/internal/metrics/key_heatmap.go
+++ b/internal/metrics/key_heatmap.go
@@ -20,8 +20,12 @@ type KeyMiss struct {
 	Attempts int    `json:"attempts"`
 }
 
+// heatmapTopN caps how many missed keys KeyHeatmap returns. Every surface
+// (Result screen, CLI JSON, CLI table) inherits this bound.
+const heatmapTopN = 8
+
 // KeyHeatmap tallies per-key misses across the keystroke log via a single pass,
-// then returns only the keys with ≥1 miss, sorted deterministically:
+// then returns the top heatmapTopN keys with ≥1 miss, sorted deterministically:
 // Misses desc → Attempts desc → Key asc.
 //
 // A counted keystroke is a forward keystroke (Typed != 0) aimed at a real target
@@ -66,6 +70,9 @@ func KeyHeatmap(log []typing.Keystroke) []KeyMiss {
 		}
 		return out[i].Key < out[j].Key
 	})
+	if len(out) > heatmapTopN {
+		out = out[:heatmapTopN]
+	}
 	return out
 }
 

--- a/internal/metrics/key_heatmap.go
+++ b/internal/metrics/key_heatmap.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"sort"
+	"strconv"
+	"unicode"
+
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+// KeyMiss is a per-key fumble tally for one case-folded target rune.
+// Attempts counts every forward keystroke aimed at that target (correct or
+// wrong); Misses counts only the wrong ones (including fumbles later corrected
+// via backspace). Key holds the folded rune for stable sorting; Label is the
+// display form (e.g. "␣" for space).
+type KeyMiss struct {
+	Key      rune   `json:"-"`   // case-folded target rune (sort key)
+	Label    string `json:"key"` // display label: "e", "t", "␣" for space
+	Misses   int    `json:"misses"`
+	Attempts int    `json:"attempts"`
+}
+
+// KeyHeatmap tallies per-key misses across the keystroke log via a single pass,
+// then returns only the keys with ≥1 miss, sorted deterministically:
+// Misses desc → Attempts desc → Key asc.
+//
+// A counted keystroke is a forward keystroke (Typed != 0) aimed at a real target
+// (Target != 0). Backspace markers (Typed == 0) and extra chars past the target
+// end (Target == 0) are skipped. Targets are case-folded so a/A merge into one
+// key. The pass is timing-independent: it does not depend on AFK trim order.
+func KeyHeatmap(log []typing.Keystroke) []KeyMiss {
+	tally := make(map[rune]*KeyMiss)
+
+	for _, k := range log {
+		if k.Typed == 0 || k.Target == 0 {
+			continue // backspace marker or extra char — no target to attribute
+		}
+		key := unicode.ToLower(k.Target)
+		km := tally[key]
+		if km == nil {
+			km = &KeyMiss{Key: key, Label: keyLabel(key)}
+			tally[key] = km
+		}
+		km.Attempts++
+		if !k.Correct {
+			km.Misses++
+		}
+	}
+
+	out := make([]KeyMiss, 0, len(tally))
+	for _, km := range tally {
+		if km.Misses > 0 {
+			out = append(out, *km)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Misses != out[j].Misses {
+			return out[i].Misses > out[j].Misses
+		}
+		if out[i].Attempts != out[j].Attempts {
+			return out[i].Attempts > out[j].Attempts
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}
+
+// keyLabel returns the display label for a folded target rune.
+//   - space → "␣" (U+2423 visible-space glyph)
+//   - printable rune → the rune itself
+//   - other control/whitespace (tab, newline; only reachable in Code mode) →
+//     its Go-quoted escape with the surrounding quotes trimmed (e.g. `\t`).
+func keyLabel(r rune) string {
+	if r == ' ' {
+		return "␣"
+	}
+	if unicode.IsPrint(r) {
+		return string(r)
+	}
+	q := strconv.QuoteRune(r) // e.g. "'\\t'"
+	return q[1 : len(q)-1]    // trim surrounding single quotes → `\t`
+}

--- a/internal/metrics/key_heatmap_test.go
+++ b/internal/metrics/key_heatmap_test.go
@@ -124,6 +124,25 @@ func TestKeyHeatmap_AttemptsCountAllForward(t *testing.T) {
 	}
 }
 
+// TestKeyHeatmap_CapsAtTopN confirms the result is bounded to the top 8 keys.
+func TestKeyHeatmap_CapsAtTopN(t *testing.T) {
+	// 12 distinct keys each with one miss → only the top 8 should survive.
+	var log []typing.Keystroke
+	for _, target := range "abcdefghijkl" {
+		log = append(log, ks('x', target, false))
+	}
+	got := metrics.KeyHeatmap(log)
+	if len(got) != 8 {
+		t.Errorf("want top-8 cap, got %d entries: %#v", len(got), got)
+	}
+	// Tie on misses/attempts → key asc, so the survivors are a..h.
+	for i, want := range "abcdefgh" {
+		if got[i].Key != want {
+			t.Errorf("entry %d: want key %q, got %q", i, want, got[i].Key)
+		}
+	}
+}
+
 // TestCompute_PopulatesKeyMisses confirms Compute fills Result.KeyMisses, and
 // that early-return paths leave it nil.
 func TestCompute_PopulatesKeyMisses(t *testing.T) {

--- a/internal/metrics/key_heatmap_test.go
+++ b/internal/metrics/key_heatmap_test.go
@@ -1,0 +1,154 @@
+package metrics_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/metrics"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+// ks is a terse Keystroke constructor for table-driven heatmap tests.
+func ks(typed, target rune, correct bool) typing.Keystroke {
+	return typing.Keystroke{Typed: typed, Target: target, Correct: correct}
+}
+
+// TestKeyHeatmap_EmptyLog returns nil for an empty log.
+func TestKeyHeatmap_EmptyLog(t *testing.T) {
+	if got := metrics.KeyHeatmap(nil); got != nil {
+		t.Errorf("empty log: want nil, got %#v", got)
+	}
+}
+
+// TestKeyHeatmap_OnlyCorrect returns nil when there are no misses.
+func TestKeyHeatmap_OnlyCorrect(t *testing.T) {
+	log := []typing.Keystroke{
+		ks('h', 'h', true),
+		ks('i', 'i', true),
+	}
+	if got := metrics.KeyHeatmap(log); got != nil {
+		t.Errorf("only-correct log: want nil, got %#v", got)
+	}
+}
+
+// TestKeyHeatmap_CorrectedFumbleCounts confirms a wrong keystroke that is later
+// fixed via backspace still counts as one miss; the backspace itself is ignored.
+func TestKeyHeatmap_CorrectedFumbleCounts(t *testing.T) {
+	log := []typing.Keystroke{
+		ks('x', 'e', false), // fumble
+		ks(0, 'e', false),   // backspace (excluded)
+		ks('e', 'e', true),  // correction
+	}
+	got := metrics.KeyHeatmap(log)
+	want := []metrics.KeyMiss{{Key: 'e', Label: "e", Misses: 1, Attempts: 2}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("corrected fumble:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+// TestKeyHeatmap_CaseFolding merges misses on 'a' and 'A' into one key 'a'.
+func TestKeyHeatmap_CaseFolding(t *testing.T) {
+	log := []typing.Keystroke{
+		ks('x', 'a', false),
+		ks('y', 'A', false),
+	}
+	got := metrics.KeyHeatmap(log)
+	want := []metrics.KeyMiss{{Key: 'a', Label: "a", Misses: 2, Attempts: 2}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("case folding:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+// TestKeyHeatmap_ExcludesExtrasAndBackspaces ignores extra chars (Target==0)
+// and backspace markers (Typed==0).
+func TestKeyHeatmap_ExcludesExtrasAndBackspaces(t *testing.T) {
+	log := []typing.Keystroke{
+		ks('z', 0, false),   // extra char past target end (excluded)
+		ks(0, 't', false),   // backspace (excluded)
+		ks('q', 't', false), // real miss on 't'
+	}
+	got := metrics.KeyHeatmap(log)
+	want := []metrics.KeyMiss{{Key: 't', Label: "t", Misses: 1, Attempts: 1}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("excludes extras/backspaces:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+// TestKeyHeatmap_SpaceLabel maps a missed space to the ␣ glyph.
+func TestKeyHeatmap_SpaceLabel(t *testing.T) {
+	log := []typing.Keystroke{ks('x', ' ', false)}
+	got := metrics.KeyHeatmap(log)
+	want := []metrics.KeyMiss{{Key: ' ', Label: "␣", Misses: 1, Attempts: 1}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("space label:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+// TestKeyHeatmap_SortDeterminism checks misses desc → attempts desc → key asc.
+func TestKeyHeatmap_SortDeterminism(t *testing.T) {
+	// key 'a': 2 misses, 2 attempts
+	// key 'b': 2 misses, 3 attempts  → before 'a' (attempts desc)
+	// key 'c': 2 misses, 2 attempts  → after 'a'  (key asc tiebreak)
+	// key 'd': 3 misses, 1 attempt   → first      (misses desc)
+	log := []typing.Keystroke{
+		ks('x', 'a', false), ks('y', 'a', false),
+		ks('x', 'b', false), ks('y', 'b', false), ks('b', 'b', true),
+		ks('x', 'c', false), ks('y', 'c', false),
+		ks('x', 'd', false), ks('y', 'd', false), ks('z', 'd', false),
+	}
+	got := metrics.KeyHeatmap(log)
+	want := []metrics.KeyMiss{
+		{Key: 'd', Label: "d", Misses: 3, Attempts: 3},
+		{Key: 'b', Label: "b", Misses: 2, Attempts: 3},
+		{Key: 'a', Label: "a", Misses: 2, Attempts: 2},
+		{Key: 'c', Label: "c", Misses: 2, Attempts: 2},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sort determinism:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+// TestKeyHeatmap_AttemptsCountAllForward verifies attempts tally correct +
+// wrong forward keystrokes against a target, while misses count only wrong.
+func TestKeyHeatmap_AttemptsCountAllForward(t *testing.T) {
+	log := []typing.Keystroke{
+		ks('e', 'e', true),  // correct attempt
+		ks('x', 'e', false), // wrong attempt (miss)
+		ks('e', 'e', true),  // correct attempt
+	}
+	got := metrics.KeyHeatmap(log)
+	want := []metrics.KeyMiss{{Key: 'e', Label: "e", Misses: 1, Attempts: 3}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("attempts count:\n got  %#v\n want %#v", got, want)
+	}
+}
+
+// TestCompute_PopulatesKeyMisses confirms Compute fills Result.KeyMisses, and
+// that early-return paths leave it nil.
+func TestCompute_PopulatesKeyMisses(t *testing.T) {
+	t.Run("populated from log", func(t *testing.T) {
+		log := buildLogTimed("hello world", config.ModeWords, 2, "hellx world", 0, 60000)
+		r := metrics.Compute(log, config.ModeWords, 60000)
+		if len(r.KeyMisses) == 0 {
+			t.Fatalf("expected KeyMisses populated, got empty")
+		}
+		// 'o' typed as 'x' → one miss on 'o'.
+		found := false
+		for _, km := range r.KeyMisses {
+			if km.Label == "o" && km.Misses == 1 {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected a miss on 'o', got %#v", r.KeyMisses)
+		}
+	})
+
+	t.Run("empty log leaves KeyMisses nil", func(t *testing.T) {
+		r := metrics.Compute(nil, config.ModeWords, 0)
+		if r.KeyMisses != nil {
+			t.Errorf("empty log: want nil KeyMisses, got %#v", r.KeyMisses)
+		}
+	})
+}

--- a/internal/ui/result_render_helpers.go
+++ b/internal/ui/result_render_helpers.go
@@ -30,6 +30,10 @@ func (m ResultModel) renderKeyHeatmap(innerW int) string {
 
 	const prefix = "most missed:  "
 	width := lipgloss.Width(prefix)
+	if width > innerW {
+		// Pathologically narrow panel — show the faint fallback rather than overflow.
+		return m.th.Style(theme.RoleTextFaint).Render("no missed keys")
+	}
 
 	var b strings.Builder
 	b.WriteString(labelStyle.Render(prefix))

--- a/internal/ui/result_render_helpers.go
+++ b/internal/ui/result_render_helpers.go
@@ -4,9 +4,59 @@ import (
 	"fmt"
 	"strings"
 
+	"charm.land/lipgloss/v2"
+
 	"github.com/bavanchun/Typeburn/internal/config"
 	"github.com/bavanchun/Typeburn/internal/theme"
 )
+
+// heatmapMaxEntries caps how many missed keys the Result line shows.
+const heatmapMaxEntries = 8
+
+// renderKeyHeatmap renders the "most missed" key line from m.res.KeyMisses,
+// capped to heatmapMaxEntries and to innerW visible columns (never overflowing
+// the panel). A clean run (no misses) renders a faint "no missed keys".
+//
+// Theme roles only — the plain text is identical under NO_COLOR/mono (attributes
+// differ, layout does not).
+func (m ResultModel) renderKeyHeatmap(innerW int) string {
+	if len(m.res.KeyMisses) == 0 {
+		return m.th.Style(theme.RoleTextFaint).Render("no missed keys")
+	}
+
+	labelStyle := m.th.Style(theme.RoleTextMuted)
+	keyStyle := m.th.Style(theme.RoleTextPrimary)
+	countStyle := m.th.Style(theme.RoleError)
+
+	const prefix = "most missed:  "
+	width := lipgloss.Width(prefix)
+
+	var b strings.Builder
+	b.WriteString(labelStyle.Render(prefix))
+
+	added := 0
+	for _, km := range m.res.KeyMisses {
+		if added >= heatmapMaxEntries {
+			break
+		}
+		sep := ""
+		if added > 0 {
+			sep = "   "
+		}
+		entry := fmt.Sprintf("%s ×%d", km.Label, km.Misses)
+		if width+lipgloss.Width(sep+entry) > innerW {
+			break
+		}
+		width += lipgloss.Width(sep + entry)
+
+		b.WriteString(sep)
+		b.WriteString(keyStyle.Render(km.Label))
+		b.WriteString(" ")
+		b.WriteString(countStyle.Render(fmt.Sprintf("×%d", km.Misses)))
+		added++
+	}
+	return b.String()
+}
 
 // accColorRole picks the appropriate theme role for accuracy display.
 // ≥97 → RoleSuccess, <90 → RoleWarning, else → RoleTextPrimary.

--- a/internal/ui/screen_result_heatmap_test.go
+++ b/internal/ui/screen_result_heatmap_test.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/metrics"
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/words"
+)
+
+// resultWithMisses builds an 80×24 ResultModel carrying a known heatmap, using
+// the given theme so NO_COLOR/mono invariants can be asserted.
+func resultWithMisses(th theme.Theme, misses []metrics.KeyMiss) ResultModel {
+	res := metrics.Result{
+		NetWPM:       80,
+		Accuracy:     95,
+		DurationMs:   30000,
+		CorrectChars: 100,
+		KeyMisses:    misses,
+	}
+	msg := ResultMsg{Result: res, Mode: config.ModeTime, Length: 30, QuoteLen: words.QuoteShort}
+	return NewResult(msg, th, config.DefaultKeymap()).SetSize(80, 24)
+}
+
+var sampleMisses = []metrics.KeyMiss{
+	{Key: 'e', Label: "e", Misses: 4, Attempts: 31},
+	{Key: 't', Label: "t", Misses: 3, Attempts: 20},
+	{Key: 'a', Label: "a", Misses: 2, Attempts: 18},
+	{Key: ' ', Label: "␣", Misses: 2, Attempts: 15},
+}
+
+// TestResultView_ShowsMostMissed checks the heatmap line renders the label and
+// the top key with a ×count.
+func TestResultView_ShowsMostMissed(t *testing.T) {
+	view := stripANSI(resultWithMisses(theme.Default(), sampleMisses).View())
+	if !strings.Contains(view, "most missed") {
+		t.Errorf("expected 'most missed' label in view:\n%s", view)
+	}
+	if !strings.Contains(view, "e ×4") {
+		t.Errorf("expected top key 'e ×4' in view:\n%s", view)
+	}
+	if !strings.Contains(view, "␣") {
+		t.Errorf("expected space glyph for missed space in view:\n%s", view)
+	}
+}
+
+// TestResultView_CleanRunShowsNoMissedKeys checks the faint fallback for clean runs.
+func TestResultView_CleanRunShowsNoMissedKeys(t *testing.T) {
+	view := stripANSI(resultWithMisses(theme.Default(), nil).View())
+	if !strings.Contains(view, "no missed keys") {
+		t.Errorf("expected 'no missed keys' on clean run:\n%s", view)
+	}
+}
+
+// TestRenderKeyHeatmap_MonoLayoutIdentical asserts the heatmap text content and
+// width are identical between the colored and NO_COLOR renders (attribute-only).
+func TestRenderKeyHeatmap_MonoLayoutIdentical(t *testing.T) {
+	colored := resultWithMisses(theme.Default(), sampleMisses).renderKeyHeatmap(60)
+	noColor := resultWithMisses(theme.Load("default", true), sampleMisses).renderKeyHeatmap(60)
+	if stripANSI(colored) != stripANSI(noColor) {
+		t.Errorf("layout differs between colored and NO_COLOR:\n colored=%q\n nocolor=%q",
+			stripANSI(colored), stripANSI(noColor))
+	}
+}
+
+// TestRenderKeyHeatmap_WidthCap ensures the visible width never exceeds innerW
+// even at a narrow terminal.
+func TestRenderKeyHeatmap_WidthCap(t *testing.T) {
+	m := resultWithMisses(theme.Default(), sampleMisses)
+	for _, innerW := range []int{20, 30, 52} {
+		line := m.renderKeyHeatmap(innerW)
+		if w := len([]rune(stripANSI(line))); w > innerW {
+			t.Errorf("innerW=%d: visible width %d exceeds cap:\n%q", innerW, w, stripANSI(line))
+		}
+	}
+}

--- a/internal/ui/screen_result_view.go
+++ b/internal/ui/screen_result_view.go
@@ -92,6 +92,8 @@ func (m ResultModel) renderPanel() string {
 	inner.WriteString("\n\n")
 	inner.WriteString(m.renderCharStats())
 	inner.WriteString("\n")
+	inner.WriteString(m.renderKeyHeatmap(innerW))
+	inner.WriteString("\n")
 	inner.WriteString(m.renderMeta())
 
 	// Build bordered panel, then inject "result" title on the top border line.

--- a/plans/20260529-key-error-heatmap/phase-01-heatmap-logic.md
+++ b/plans/20260529-key-error-heatmap/phase-01-heatmap-logic.md
@@ -1,0 +1,126 @@
+---
+phase: 1
+title: "Heatmap Logic"
+status: completed
+priority: P1
+effort: "2h"
+dependencies: []
+---
+
+# Phase 1: Heatmap Logic
+
+## Overview
+
+Add a pure per-key miss tally to `internal/metrics`, exposed via a new
+`KeyMisses []KeyMiss` field on `metrics.Result`, populated inside `Compute`.
+This is the foundation every surface (Phase 2, 3) reads.
+
+## Requirements
+
+- **Functional:**
+  - `KeyHeatmap(log []typing.Keystroke) []KeyMiss` tallies, per case-folded
+    target rune: total attempts and total misses.
+  - A miss = forward keystroke (`Typed != 0`) with a real target
+    (`Target != 0`) where `!Correct`. Corrected fumbles still count.
+  - Skip backspace events (`Typed == 0`) and extra chars (`Target == 0`).
+  - Case-fold the target via `unicode.ToLower` so `a`/`A` merge into one key.
+  - Return only keys with ≥1 miss, sorted deterministically.
+  - `Compute` populates `Result.KeyMisses` from the full log.
+- **Non-functional:**
+  - No UI deps (stays pure-logic). Only stdlib `unicode` + `sort` added.
+  - File < 200 LOC. Deterministic output (golden/table-test safe).
+
+## Architecture
+
+`Keystroke` already carries everything needed (`engine.go:11-16`):
+```go
+type Keystroke struct {
+    TimeMs  int64
+    Typed   rune   // 0 == backspace
+    Target  rune   // 0 == extra (past target end)
+    Correct bool
+}
+```
+
+`KeyHeatmap` does a single pass over the log into a `map[rune]*KeyMiss`
+keyed by folded target rune, then flattens + sorts. **Timing-independent** —
+it runs over the full untrimmed log (AFK trim only affects duration/rate
+metrics, not which keys were mistyped), so order vs `TrimAFK` in `Compute`
+does not matter.
+
+```go
+type KeyMiss struct {
+    Key      rune   `json:"-"`     // case-folded target rune
+    Label    string `json:"key"`   // display label: "e", "t", "␣" for space
+    Misses   int    `json:"misses"`
+    Attempts int    `json:"attempts"`
+}
+```
+
+Sort order (deterministic): `Misses` desc → `Attempts` desc → `Key` asc.
+
+Label mapping (`keyLabel(r rune) string`):
+- `' '` → `"␣"` (visible space glyph; ASCII-safe in any terminal? — `␣` is
+  U+2423, renders in UTF-8 terminals. Mono/NO_COLOR unaffected, it is a glyph
+  not a color. If ASCII-only fallback is wanted, that is a deferred follow-up.)
+- printable rune → `string(r)`
+- other control/whitespace (tab, newline — only reachable in Code mode) →
+  Go-quoted form trimmed of quotes (e.g. `\t`).
+
+In `Compute`, after the existing per-second/consistency block, add:
+```go
+return Result{
+    ...
+    KeyMisses: KeyHeatmap(log),
+}
+```
+Note: `log` inside `Compute` is the AFK-trimmed slice; that is fine — trim only
+drops *trailing idle* keystrokes (which by definition were not mistypes that
+matter), and matches the keys the user actually engaged. Keep it simple: pass
+the same `log` already in scope.
+
+## Related Code Files
+
+- Create: `internal/metrics/key_heatmap.go` (~70 LOC)
+- Create: `internal/metrics/key_heatmap_test.go`
+- Modify: `internal/metrics/compute.go` (add `KeyMisses` field to `Result`
+  struct + one line in the returned literal)
+
+## Implementation Steps
+
+1. Create `internal/metrics/key_heatmap.go`:
+   - `KeyMiss` struct (with JSON tags as above).
+   - `keyLabel(r rune) string` helper.
+   - `KeyHeatmap(log []typing.Keystroke) []KeyMiss`: single-pass tally → flatten
+     → `sort.Slice` with the deterministic comparator → return.
+2. In `internal/metrics/compute.go`:
+   - Add `KeyMisses []KeyMiss` to the `Result` struct (document it in the
+     struct comment block alongside the other fields).
+   - Populate it in the returned `Result` literal: `KeyMisses: KeyHeatmap(log)`.
+   - The early-return paths (`len(log)==0`, `durationMs<=0`) leave `KeyMisses`
+     nil — correct (no misses to show).
+3. Create `internal/metrics/key_heatmap_test.go` (table-driven, real data):
+   - Empty log → nil.
+   - Only-correct log → nil (no misses).
+   - Corrected fumble (wrong → backspace → right) still counts as 1 miss.
+   - Case folding: errors on `a` and `A` merge into key `a`.
+   - Extra chars (`Target==0`) and backspaces (`Typed==0`) excluded.
+   - Space miss → label `␣`.
+   - Sort determinism: equal misses break by attempts desc then key asc.
+   - Attempts counts all forward keystrokes against that target (correct + wrong).
+
+## Success Criteria
+
+- [ ] `KeyHeatmap` returns deterministic, correctly-sorted misses.
+- [ ] Corrected errors counted; backspaces/extras excluded; case folded.
+- [ ] `Result.KeyMisses` populated by `Compute`; early-returns leave it nil.
+- [ ] `go test ./internal/metrics/ -race -count=1` GREEN.
+- [ ] `gofmt -l internal/metrics/` empty; `go vet ./internal/metrics/` clean.
+- [ ] `key_heatmap.go` < 200 LOC, no UI imports.
+
+## Risk Assessment
+
+- **Low.** Pure additive; no change to existing metric values. Existing
+  `metrics` tests assert specific fields and will not break from a new field.
+- **Glyph risk:** `␣` (U+2423) requires UTF-8 terminal. Acceptable — the whole
+  TUI already assumes a modern terminal. ASCII fallback deferred.

--- a/plans/20260529-key-error-heatmap/phase-02-result-screen-surfacing.md
+++ b/plans/20260529-key-error-heatmap/phase-02-result-screen-surfacing.md
@@ -1,0 +1,94 @@
+---
+phase: 2
+title: "Result Screen Surfacing"
+status: completed
+priority: P2
+effort: "1.5h"
+dependencies: [1]
+---
+
+# Phase 2: Result Screen Surfacing
+
+## Overview
+
+Render the top missed keys on the Result screen, below the correct/incorrect/
+extra char-stats line. One compact line; clean runs show a faint "no missed keys".
+
+## Requirements
+
+- **Functional:**
+  - New `renderKeyHeatmap()` produces a line like:
+    `most missed:  e ×4   t ×3   a ×2   ␣ ×2   r ×1` (top 8, fit to width).
+  - Clean run (`len(KeyMisses)==0`) → faint `no missed keys`.
+  - Inserted into the result panel after `renderCharStats()` (before `renderMeta`).
+- **Non-functional:**
+  - Theme roles only — no hex. Mono/NO_COLOR safe (layout identical, attrs only).
+  - `screen_result_view.go` stays < 200 LOC → put the new helper in the existing
+    `internal/ui/result_render_helpers.go`.
+  - Width-aware: truncate the key list to `innerW`; never overflow the panel.
+
+## Architecture
+
+`renderPanel()` (`screen_result_view.go:80-108`) currently assembles:
+`hero → sparkline → charStats → meta`. Insert heatmap between charStats and meta:
+
+```go
+inner.WriteString(m.renderCharStats())
+inner.WriteString("\n")
+inner.WriteString(m.renderKeyHeatmap(innerW))   // NEW
+inner.WriteString("\n")
+inner.WriteString(m.renderMeta())
+```
+
+`renderKeyHeatmap(innerW int) string` lives in `result_render_helpers.go`
+(method on `ResultModel`, same receiver as the existing helpers there). Reads
+`m.res.KeyMisses`.
+
+Styling (theme roles, consistent with `renderCharStats`):
+- label `most missed:` → `RoleTextMuted`
+- key glyph → `RoleTextPrimary`
+- `×N` count → `RoleError`
+- clean-run text → `RoleTextFaint`
+
+Width handling: build entries left-to-right, stop appending once the visible
+(ANSI-stripped) width would exceed `innerW`. Reuse the same width discipline the
+file already uses; if a `lipgloss.Width` measure is needed, follow the existing
+pattern in this package (do not hand-count runes against ANSI).
+
+## Related Code Files
+
+- Modify: `internal/ui/result_render_helpers.go` (add `renderKeyHeatmap`)
+- Modify: `internal/ui/screen_result_view.go` (wire 2 lines into `renderPanel`)
+- Modify: `internal/ui/result_render_helpers_test.go` and/or
+  `internal/ui/screen_result_test.go` (substring assertions — NOT golden files;
+  Result view tests use `strings.Contains`, confirmed)
+
+## Implementation Steps
+
+1. Add `renderKeyHeatmap(innerW int) string` to `result_render_helpers.go`:
+   - If `len(m.res.KeyMisses) == 0` → return faint `no missed keys`.
+   - Else build `most missed:  <k ×n>...` up to 8 entries, width-capped to `innerW`.
+2. Wire it into `renderPanel()` in `screen_result_view.go` (2 inserted lines).
+3. Tests:
+   - With misses: view contains `most missed` and at least the top key + `×`.
+   - Clean run: view contains `no missed keys`.
+   - Mono theme + `NO_COLOR`: assert the heatmap text still present and that
+     overall line count / layout is unchanged vs the colored render (attribute-
+     only invariant — mirror how existing theme tests assert this).
+4. Run `go test ./internal/ui/ -race -count=1`.
+
+## Success Criteria
+
+- [ ] Result screen shows top missed keys (or "no missed keys" on clean runs).
+- [ ] Mono / NO_COLOR render identical layout (attributes only).
+- [ ] No panel overflow at min terminal width (60 cols).
+- [ ] `screen_result_view.go` still < 200 LOC.
+- [ ] `go test ./internal/ui/ -race -count=1` GREEN; `gofmt`/`vet` clean.
+
+## Risk Assessment
+
+- **Low-medium.** Main risk is width math causing overflow at narrow widths —
+  mitigated by truncation capped at `innerW` and a 60-col test.
+- No golden-file regeneration needed (substring-based tests confirmed), which
+  removes the usual teatest churn risk for this screen.
+- Vertical space: +1 line; footer still pins to bottom via existing `spacer` math.

--- a/plans/20260529-key-error-heatmap/phase-03-cli-output-surfacing.md
+++ b/plans/20260529-key-error-heatmap/phase-03-cli-output-surfacing.md
@@ -1,0 +1,85 @@
+---
+phase: 3
+title: "CLI Output Surfacing"
+status: completed
+priority: P2
+effort: "1h"
+dependencies: [1]
+---
+
+# Phase 3: CLI Output Surfacing
+
+## Overview
+
+Expose the heatmap in CLI output: a `key_misses` array in JSON and top-key rows
+in the table view. Flows automatically through `run --no-tui` and `replay` since
+both build their output from `metrics.Result` via `newMetricOutput` /
+`metricTableRows`.
+
+## Requirements
+
+- **Functional:**
+  - `metricOutput` gains `KeyMisses []keyMissOutput` → JSON key `key_misses`,
+    each `{ "key": "e", "misses": 4, "attempts": 31 }`.
+  - Table output gains rows for the top keys, e.g. `most_missed_e | 4/31`.
+  - Empty heatmap → `key_misses: []` (or omitted — pick one and assert it);
+    table simply adds no rows.
+- **Non-functional:**
+  - Deterministic ordering (inherits Phase 1 sort) for stable JSON/table tests.
+  - No change to existing JSON keys (additive only — preserves the CLI contract
+    relied on by `run --no-tui --json` and `replay --json`).
+
+## Architecture
+
+`metric_output.go` is the single mapping layer (callers: `cmd_run_notui.go:27`,
+`cmd_replay.go:50,53`). Extend it; both call sites benefit with no other edits.
+
+```go
+type keyMissOutput struct {
+    Key      string `json:"key"`
+    Misses   int    `json:"misses"`
+    Attempts int    `json:"attempts"`
+}
+
+type metricOutput struct {
+    ...
+    DurationMs int64           `json:"duration_ms"`
+    KeyMisses  []keyMissOutput `json:"key_misses"`   // NEW (last field)
+}
+```
+
+`newMetricOutput` maps `r.KeyMisses` → `[]keyMissOutput` (using `Label` for `Key`).
+`metricTableRows` appends top-N rows after `duration_ms` using a compact
+`"misses/attempts"` value form. Cap table rows at top 5 to keep the table tight;
+JSON carries the full list (still top-8 from Phase 1).
+
+## Related Code Files
+
+- Modify: `internal/cli/metric_output.go` (add `keyMissOutput`, struct field,
+  mapping in `newMetricOutput`, rows in `metricTableRows`)
+- Modify: `internal/cli/cmd_run_test.go` (assert `key_misses` in JSON;
+  verify additive — existing keys unchanged)
+- Possibly: `internal/cli/cmd_replay_test.go` if it snapshots metric output
+
+## Implementation Steps
+
+1. Add `keyMissOutput` struct + `KeyMisses` field to `metricOutput`.
+2. Map in `newMetricOutput`: iterate `r.KeyMisses` → `keyMissOutput{Key: km.Label, ...}`.
+3. Append top-5 rows in `metricTableRows` (`most_missed_<label>` → `n/attempts`).
+4. Update `cmd_run_test.go`:
+   - JSON contains `key_misses` with expected entries for a known-error input.
+   - Existing metric keys still present and unchanged (contract guard).
+5. Run `go test ./internal/cli/ -race -count=1`.
+
+## Success Criteria
+
+- [ ] `run --no-tui --json` includes `key_misses`; existing keys unchanged.
+- [ ] `replay` JSON + table include heatmap data.
+- [ ] Empty heatmap handled (empty array / no rows) and asserted.
+- [ ] `go test ./internal/cli/ -race -count=1` GREEN; `gofmt`/`vet` clean.
+
+## Risk Assessment
+
+- **Low.** Purely additive to an output struct. The only real risk is breaking
+  an existing JSON snapshot test — mitigated by the explicit "existing keys
+  unchanged" assertion and by appending the new field last.

--- a/plans/20260529-key-error-heatmap/phase-04-docs-and-verification.md
+++ b/plans/20260529-key-error-heatmap/phase-04-docs-and-verification.md
@@ -1,0 +1,69 @@
+---
+phase: 4
+title: "Docs and Verification"
+status: completed
+priority: P3
+effort: "1h"
+dependencies: [1, 2, 3]
+---
+
+# Phase 4: Docs and Verification
+
+## Overview
+
+Update source-of-truth docs and run the full CI gate. Closes the feature out
+for a PR.
+
+## Requirements
+
+- **Functional:** docs reflect the new heatmap; CI gate fully green.
+- **Non-functional:** docs concise, consistent with existing style.
+
+## Architecture
+
+Docs are source of truth (per CLAUDE.md). Touch the two that describe metrics
+behavior + release history. No code architecture change in this phase.
+
+## Related Code Files
+
+- Modify: `docs/codebase-summary.md` (metrics package entry — add `KeyHeatmap`
+  + `Result.KeyMisses`; note Result/CLI surfacing)
+- Modify: `docs/project-roadmap.md` (add a shipped entry under Post-1.0 once
+  released, or a "Next" → in-progress note pre-release)
+- (No CLAUDE.md change required — no new constraint or layering rule introduced.)
+
+## Implementation Steps
+
+1. Update `docs/codebase-summary.md` metrics section: document `KeyHeatmap`,
+   the `KeyMiss` type, and the `Result.KeyMisses` field; mention it surfaces on
+   the Result screen and in CLI `key_misses`.
+2. Update `docs/project-roadmap.md` with the heatmap entry (version TBD at ship).
+3. Run the full CI gate locally (exactly what `ci.yml` enforces):
+   - `go test ./... -race -count=1` → GREEN
+   - `go vet ./...` → clean
+   - `gofmt -l .` → empty
+   - `make size-check` → within binary size cap
+4. `make build && make version` sanity check (binary builds, banner resolves).
+
+## Success Criteria
+
+- [ ] `docs/codebase-summary.md` + `docs/project-roadmap.md` updated.
+- [ ] `go test ./... -race -count=1` GREEN.
+- [ ] `go vet ./...` clean; `gofmt -l .` empty.
+- [ ] `make size-check` passes.
+- [ ] Branch + PR ready (feat/key-error-heatmap → PR → squash-merge per Git
+      Workflow in CLAUDE.md; never commit to main directly).
+
+## Risk Assessment
+
+- **Low.** Docs + verification only. The size-check is the one gate that could
+  surprise — the feature adds little code, but confirm the binary stays under
+  the cap (it should comfortably).
+
+## Notes
+
+- **Git:** branch `feat/key-error-heatmap`, conventional commits, no AI refs,
+  PR to protected `main`, squash-merge. Tag only after merge if releasing.
+- **Out of scope (future):** lifetime/aggregate heatmap across history,
+  per-key error-*rate* coloring, finger/row grouping, configurable N, ASCII
+  space-glyph fallback.

--- a/plans/20260529-key-error-heatmap/plan.md
+++ b/plans/20260529-key-error-heatmap/plan.md
@@ -1,0 +1,56 @@
+---
+title: "Per-Key Error Heatmap"
+description: "Post-hoc per-key miss tally surfaced on the Result screen and in CLI JSON/table output. Pure replay over the existing keystroke log; computed on the fly, no persistence."
+status: completed
+priority: P2
+branch: "main"
+tags: [metrics, ui, cli, feature]
+blockedBy: []
+blocks: []
+created: "2026-05-29T15:06:37.589Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Per-Key Error Heatmap
+
+## Overview
+
+After each test, show the keys the user fumbled most — counting **every** wrong
+keystroke against a target char (including ones later corrected via backspace),
+case-folded, top N. Surfaces on the Result screen and in CLI JSON/table output.
+Computed on the fly from the keystroke log; nothing persisted, no schema change.
+
+**Why it fits:** the keystroke log already records `Target rune` + `Correct bool`
+per event (`internal/typing/engine.go:11-16`). The heatmap is a pure tally over
+that log — the same post-hoc replay pattern as `metrics.Compute`. It lives
+entirely in pure-logic `internal/metrics` (no UI deps) and rides on the ephemeral
+`metrics.Result` (never serialized to history), so "compute on the fly, no
+persistence" is automatic.
+
+**Design decisions (locked in brainstorm):**
+- Miss = every wrong forward keystroke vs a real target (`Target != 0 && !Correct`), incl. corrected.
+- Case-folded (`unicode.ToLower`): `a`/`A` merge.
+- Top N = 8, sorted deterministically (misses desc → attempts desc → key asc).
+- Surfaced on Result screen + CLI JSON/table.
+- Not persisted to history (Result is ephemeral).
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Heatmap Logic](./phase-01-heatmap-logic.md) | Completed |
+| 2 | [Result Screen Surfacing](./phase-02-result-screen-surfacing.md) | Completed |
+| 3 | [CLI Output Surfacing](./phase-03-cli-output-surfacing.md) | Completed |
+| 4 | [Docs and Verification](./phase-04-docs-and-verification.md) | Completed |
+
+**Build order:** Phase 1 is the foundation (the `KeyMisses` field everything reads).
+Phases 2 and 3 are independent of each other and both depend only on Phase 1.
+Phase 4 closes out docs + the full CI gate.
+
+## Dependencies
+
+No cross-plan dependencies — all prior Typeburn plans are `completed`.
+
+**External:** stdlib only (`unicode`, `sort`). No new module dependencies (honors
+the allowed-deps constraint in CLAUDE.md).


### PR DESCRIPTION
## Summary

Adds a post-hoc **per-key error heatmap** — after each test, surface the keys the user fumbled most. Pure replay over the existing keystroke log; nothing persisted, no schema change.

- **Metrics (Phase 1):** `KeyHeatmap(log) []KeyMiss` + `Result.KeyMisses`, populated in `Compute`. A miss = every wrong forward keystroke vs a real target (corrected fumbles included), case-folded, keys with ≥1 miss, sorted misses↓ → attempts↓ → key↑, capped to top 8.
- **Result screen (Phase 2):** a `most missed:  e ×4   t ×3 …` line (theme-roles only, NO_COLOR/mono layout identical, width-capped to the panel); faint `no missed keys` on clean runs.
- **CLI (Phase 3):** additive `key_misses` JSON array (empty → `[]`) and top-5 `most_missed_*` table rows; existing keys unchanged. Flows through both `run --no-tui` and `replay`.
- **Docs (Phase 4):** `codebase-summary.md` + `project-roadmap.md` updated.

## Testing

- `go test ./... -race -count=1` — GREEN
- `go vet ./...` clean · `gofmt -l .` empty · `make size-check` within cap
- New coverage: tally rules, case-folding, backspace/extra exclusion, sort determinism, top-8 cap, JSON mapping + `[]` contract, table cap, NO_COLOR parity, width cap.

## Notes

- All new files <200 LOC; pure-logic packages keep zero UI deps.
- Code review fix applied: the top-8 cap now lives in `KeyHeatmap` so every surface inherits the same bound (was previously only enforced at the UI layer).
- Out of scope (deferred): lifetime/aggregate heatmap, per-key error-rate coloring, finger/row grouping, configurable N, ASCII space-glyph fallback.

Plan: `plans/20260529-key-error-heatmap/`