### PR TITLE
chore(release): prep v2.2.0 (per-key error heatmap)

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,14 +1,12 @@
-## [2.1.3] - 2026-05-29
+## [2.2.0] - 2026-05-29
 
-### Fixed
+### Added
 
-- `typeburn run --no-tui` in Time mode now ends automatically at the time limit.
-  Previously the raw runner only checked completion after a keystroke, so a Time
-  test would hang until the next keypress (indefinitely in piped/non-interactive
-  runs); a keystroke arriving after the limit could also inflate the final
-  metrics. The runner now completes on the clock with zero trailing input.
-- `typeburn version --check-update` now prints a release URL only when it points
-  at the official repository, matching the validation already applied to cached
-  results.
+- Per-key error heatmap. The Result screen now shows a "most missed:" line
+  listing the keys fumbled most during the test (top 8, case-folded, with
+  corrected mistakes counted). The CLI surfaces the same data: `typeburn run`
+  and `typeburn replay` with `--json` gain a `key_misses` array, and the
+  metrics table gains `most_missed_*` rows. Computed post-hoc from the
+  keystroke log — no persistence and no history schema change.
 
-[2.1.3]: https://github.com/bavanchun/Typeburn/releases/tag/v2.1.3
+[2.2.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-05-29
+
+### Added
+
+- Per-key error heatmap. The Result screen now shows a "most missed:" line
+  listing the keys fumbled most during the test (top 8, case-folded, with
+  corrected mistakes counted). The CLI surfaces the same data: `typeburn run`
+  and `typeburn replay` with `--json` gain a `key_misses` array, and the
+  metrics table gains `most_missed_*` rows. Computed post-hoc from the
+  keystroke log — no persistence and no history schema change.
+
 ## [2.1.3] - 2026-05-29
 
 ### Fixed

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -61,7 +61,7 @@
 
 ### Medium Priority (Feature Enhancements)
 
-#### Per-Key Error Heatmap — ✅ IMPLEMENTED (unreleased, version TBD at ship)
+#### Per-Key Error Heatmap — ✅ SHIPPED in v2.2.0 (2026-05-29)
 - **Description:** Post-hoc per-key miss tally — counts every wrong forward
   keystroke against a real target (corrected fumbles included), case-folded,
   top 8. Surfaced on the Result screen ("most missed:" line) and in CLI output
@@ -69,7 +69,7 @@
 - **Implementation:** Pure replay in `internal/metrics` (`KeyHeatmap` +
   `Result.KeyMisses`); no persistence, no schema change (rides the ephemeral
   `metrics.Result`). Result-screen render is theme-role only (NO_COLOR/mono safe).
-- **Status:** Implemented on `feat/key-error-heatmap`; ships in the next release.
+- **Status:** Shipped in v2.2.0 (squash-merged via #31).
 - **Deferred follow-ups:** lifetime/aggregate heatmap across history, per-key
   error-*rate* coloring, finger/row grouping, configurable N, ASCII space-glyph
   fallback.


### PR DESCRIPTION
Release prep for **v2.2.0** — ships the per-key error heatmap merged in #31.

## Changes
- `CHANGELOG.md`: new `## [2.2.0]` section under `### Added` (heatmap: Result-screen "most missed" line + CLI `key_misses` array / `most_missed_*` table rows).
- `.github/release-notes.md`: replaced with the curated v2.2.0 body (GoReleaser uses this verbatim; the changelog filter is deliberately exclude-all).
- `docs/project-roadmap.md`: heatmap status finalized `unreleased → SHIPPED in v2.2.0`.

## Version rationale
New additive user-facing feature, no breaking changes → semver **minor** (`v2.1.3 → v2.2.0`).

## Not in this PR
- The tag itself (`v2.2.0`) is cut on `main` only after squash-merge, per the runbook.
- Unrelated untracked journal (`documentation-drift-cleanup.md`) deliberately excluded.

Docs impact: minor (changelog/notes/roadmap only; no code).