### PR TITLE
chore(release): prep CHANGELOG and release notes for v2.3.0

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,12 +1,15 @@
-## [2.2.0] - 2026-05-29
+## [2.3.0] - 2026-05-30
 
 ### Added
 
-- Per-key error heatmap. The Result screen now shows a "most missed:" line
-  listing the keys fumbled most during the test (top 8, case-folded, with
-  corrected mistakes counted). The CLI surfaces the same data: `typeburn run`
-  and `typeburn replay` with `--json` gain a `key_misses` array, and the
-  metrics table gains `most_missed_*` rows. Computed post-hoc from the
-  keystroke log — no persistence and no history schema change.
+- `typeburn update` self-update command. Downloads the matching release archive,
+  verifies it against the published SHA-256 `checksums.txt` over HTTPS, extracts
+  the binary, and atomically replaces the running executable in place (Linux,
+  macOS, Windows). `--check` reports availability without installing; `--yes`
+  skips the confirmation prompt. Package-manager builds (Homebrew, `go install`)
+  are refused with the matching upgrade command and a distinct exit code;
+  non-interactive streams refuse unless `--yes` is given. Integrity is
+  checksum-only (unsigned binaries) — the same trust model as the install
+  script.
 
-[2.2.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.2.0
+[2.3.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-05-30
+
 ### Added
 
 - `typeburn update` self-update command. Downloads the matching release archive,

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -74,7 +74,7 @@
   error-*rate* coloring, finger/row grouping, configurable N, ASCII space-glyph
   fallback.
 
-#### Self-Update Command (`typeburn update`) — ✅ IMPLEMENTED (unreleased)
+#### Self-Update Command (`typeburn update`) — ✅ SHIPPED in v2.3.0 (2026-05-30)
 - **Description:** `typeburn update` downloads the matching release archive,
   verifies it against the published SHA-256 `checksums.txt` over HTTPS, extracts
   the binary, and atomically replaces the running executable (Linux/macOS via
@@ -88,7 +88,7 @@
 - **Trust model:** checksum-only (unsigned), identical to `install.sh` — detects
   corruption/truncation, not a compromised host. Homebrew/`go install` builds are
   refused with the matching upgrade command (`ExitManagedInstall`).
-- **Status:** Implemented; ships in the next release.
+- **Status:** Shipped in v2.3.0 (squash-merged via #33).
 - **Deferred follow-ups:** code signing (cosign/Sigstore), delta updates,
   rollback-to-previous, `--version <tag>` pinned downgrade.
 


### PR DESCRIPTION
Release prep for **v2.3.0** (the first release carrying `typeburn update`).

- CHANGELOG.md: promote `[Unreleased]` → `[2.3.0] - 2026-05-30`, open a fresh `[Unreleased]`.
- .github/release-notes.md: replace with the v2.3.0 section (verbatim body GoReleaser publishes via `--release-notes`).
- docs/project-roadmap.md: flip Self-Update entry to ✅ SHIPPED in v2.3.0.

No code changes. GoReleaser stays pinned at v2.15.4. Tag is cut on main only after this merges, per the runbook.