### PR TITLE
Polish typeburn update UX: hint, progress, release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+### Changed
+
+- The in-app "update available" hint on the result screen now points at
+  `typeburn update` (the self-updater) instead of the check-only
+  `typeburn version --check-update`.
+- `typeburn update` now prints `downloading` / `verifying` / `installing`
+  progress lines during the swap instead of blocking silently, and surfaces the
+  release-notes URL (`Release notes: <url>`) before installing — matching the
+  output of `typeburn version --check-update`.
+
 ## [2.3.0] - 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ typeburn config set update_check on
 
 When enabled, every TUI launch runs a background check with an 800 ms timeout.
 If a newer stable release is found, the Result screen shows a muted footer hint:
-`↑ v2.1.0 available — run "typeburn version --check-update"`.
+`↑ v2.1.0 available — run "typeburn update"`.
 
 ### Self-update
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -13,6 +13,7 @@ bare `typeburn` opens the TUI, `typeburn --version` prints the banner, and
 | `typeburn history` | Print saved history as a table or JSON |
 | `typeburn config` | Read or update persisted settings |
 | `typeburn version` | Print version info as text or JSON |
+| `typeburn update` | Check for and install a newer release |
 | `typeburn replay` | Compute metrics from a schema-versioned keystroke log |
 
 ## Exit Codes
@@ -139,6 +140,44 @@ JSON schema (`--check-update --json`):
   }
 }
 ```
+
+## Update
+
+```sh
+typeburn update --check
+typeburn update [--yes]
+```
+
+Flags:
+
+| Flag | Purpose |
+|---|---|
+| `--check` | Detect if upgrade available and print release notes (no download/install) |
+| `--yes` | Skip confirmation prompt; use in scripts |
+
+`--check` always hits the network (no cache). Output when no upgrade available:
+```
+you are on the latest version (v2.0.0).
+```
+
+Output when upgrade available:
+```
+typeburn v2.1.0 is available (you have v2.0.0).
+Release notes: https://github.com/bavanchun/Typeburn/releases/tag/v2.1.0
+Run 'typeburn update' to upgrade.
+```
+
+Interactive install (default) prompts for confirmation, then prints progress lines:
+```
+updating v2.0.0 → v2.1.0 ...
+  downloading...
+  verifying...
+  installing...
+updated v2.0.0 → v2.1.0. restart typeburn to use the new version.
+```
+
+Non-interactive installs (e.g. in CI) require `--yes` or exit 1.
+Managed installs (Homebrew) refuse with error; use the appropriate package manager.
 
 ## Replay
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -23,7 +23,7 @@
 **Test seams:** `getFetchURL()`/`setFetchURL()` and `getCacheFilePath()`/`setCacheFilePath()` — mutex-guarded accessors around the HTTP endpoint and temp-dir overrides used in tests.
 
 **Self-update pipeline (`typeburn update`):**
-- `Apply(ctx, currentVer, tag, execPath, goos, goarch) (Outcome, error)`: the single entry point. Acquires an O_EXCL lock in the install dir, downloads + verifies the archive, extracts the binary, and atomically swaps it over `execPath`. `tag` MUST come from a live `Check(force=true)` Result, never the on-disk cache.
+- `Apply(ctx, currentVer, tag, execPath, goos, goarch, reportFn) (Outcome, error)`: the single entry point. Acquires an O_EXCL lock in the install dir, downloads + verifies the archive, extracts the binary, and atomically swaps it over `execPath`. `tag` MUST come from a live `Check(force=true)` Result, never the on-disk cache. `reportFn` (optional, pass nil to silence) is called with each `Stage` (downloading → verifying → installing) for progress reporting.
 - `Preflight(execPath, env) Plan`: classifies the install (self-managed / Homebrew / `go install`) and probes the install dir's writability, so the CLI can refuse managed installs and fail fast on a read-only dir.
 - Trust model: TLS + published SHA-256 checksums only — detects corruption/truncation, not a compromised host (binaries are unsigned; see SECURITY.md).
 - `download.go`: redirect-restricted client (follows only GitHub-owned asset hosts / same host), size caps (50 MiB archive, 64 KiB checksums), O_EXCL temp writes; `assetName`/`assetURL` mirror the GoReleaser naming.
@@ -31,12 +31,13 @@
 - `archive.go`: `.tar.gz`/`.zip` extraction accepting only the exact top-level regular-file member (path-traversal + symlink hardened, decompression-capped).
 - `selfpath.go`: `classifyInstall`, `goBinDir`, `canWrite`, `instructionFor`.
 - `lock.go`: O_EXCL `.typeburn-update.lock` serialization.
+- `progress.go`: `Stage` enum (downloading/verifying/installing) + `String()` for human labels; `report(fn, stage)` safely invokes optional progress callback.
 - `replace_unix.go` / `replace_windows.go`: atomic same-dir rename; the Windows path moves the running exe aside with rollback + crash recovery (`restoreInterruptedUpdate`).
 
 **Test seams:** `getFetchURL()`/`setFetchURL()` and `getCacheFilePath()`/`setCacheFilePath()` (check); `getDownloadBase()`/`setDownloadBase()` (self-update download).
 
 **Files (check):** `result.go`, `compare.go`, `prerelease.go`, `client.go`, `cache.go`, `check.go` (+ `_test.go`).
-**Files (self-update):** `download.go`, `verify.go`, `archive.go`, `selfpath.go`, `lock.go`, `preflight.go`, `apply.go`, `replace_unix.go`, `replace_windows.go` (+ `_test.go`).
+**Files (self-update):** `download.go`, `verify.go`, `archive.go`, `selfpath.go`, `lock.go`, `progress.go`, `preflight.go`, `apply.go`, `replace_unix.go`, `replace_windows.go` (+ `_test.go`).
 
 ---
 

--- a/docs/journals/2026-05-30-update-ux-polish.md
+++ b/docs/journals/2026-05-30-update-ux-polish.md
@@ -1,0 +1,72 @@
+# Update UX Polish: Discovery Path, Progress Feedback, Release Notes
+
+**Date**: 2026-05-30 15:45
+**Severity**: Medium (UX improvement, shipping with v2.3.0)
+**Component**: CLI / UI (Result Screen + Update Command)
+**Status**: Resolved (merged PR #36, commit 377fdbe)
+
+## What Happened
+
+Shipped three UX refinements to `typeburn update`: (1) fixed a stale footer hint on the result screen that misdirected users to the check-only `version --check-update` instead of the actual `update` command; (2) added live progress feedback during the ~9MB download/verify/swap cycle (was silently frozen); (3) surfaced release notes URL in both `update` and `update --check` output. All CI gates green; docs updated (CHANGELOG, README, codebase-summary, cli-reference).
+
+## The Brutal Truth
+
+The hint defect exposed a critical gap in the app's own discovery path. The `typeburn update` feature shipped in v2.3.0, but v2.2.0 users who saw the footer hint and typed `typeburn update` silently got the TUI instead — because Typeburn treats unknown root args as "launch the app" by design. The command existed, the hint existed, but they never connected. A user had to reverse-engineer the command from release notes. The real fix is one string, but the *feeling* is frustration that we shipped a feature nobody could discover from inside the app.
+
+## Technical Details
+
+**Phase 1 — Hint Fix:**
+- File: `internal/ui/screen_result_view.go` + `screen_result_test.go`
+- Change: repointed footer hint from `typeburn version --check-update` to `typeburn update`
+- Rationale: `version --check-update` reports available updates but doesn't actually update; `update` is the action command
+
+**Phase 2 — Progress Feedback:**
+- New file: `internal/update/progress.go` with `Stage` enum (downloading, verifying, installing)
+- Nil-safe `report(stage)` helper to emit stage labels
+- Threaded trailing `func(Stage)` callback param through `Apply() → downloadVerified()` call chain
+- CLI prints stage lines like `  downloading...` in real-time; reporter kept strictly outside verify/replace logic to preserve checksum-only trust model
+- Signature change rippled to `applyFn` type, `setApplyFn`, `recordingApply` test stub, all call sites in apply_test and download_test
+- Trade-off: single callback param (KISS) over Options struct; enumerated all callers first to confirm ripple cost was acceptable
+
+**Phase 3 — Release Notes:**
+- Reused existing `Result.ReleaseURL` field (already populated from GitHub API)
+- New `printReleaseNotes(url)` helper that guards on non-empty URL
+- Applied in both `cmd_update.go` (pre-confirm) and `cmd_version.go` (check output)
+- Wording mirrors existing `version --check-update` pattern
+
+## What We Tried
+
+1. **Initial scope:** hint only. Realized silent download freeze was usability debt.
+2. **Progress design options:** (a) global progress writer (too loose), (b) Options struct (heavier), (c) trailing callback (settled here; minimal coupling, easy to test with nil-safe noop)
+3. **Release notes placement:** considered adding to TUI footer hint, rejected (width-capped, already crowded)
+4. **Test coverage:** added `TestReportStage` for progress emission; added regression assert for hint string in result view test
+
+## Root Cause Analysis
+
+**Discovery Gap:** Treating unknown root args as TUI launch (v1 alias behavior, intentional design) was correct for the REPL but created a silent trap for commands that didn't exist in an old binary. The hint was the bridge, but it pointed at the wrong target (`--check-update` is a status check, not an action). Root cause: hint was written before the command was built, never double-checked against shipped behavior.
+
+**Silent Download:** Progress was deprioritized during the initial `update` implementation (Phase 1–3 planning was complete, code review gates met). This is acceptable shipping debt for v2.3.0 (the command works), but users experience a frozen terminal and might ctrl-c thinking it's hung.
+
+**Release Notes Omission:** Result.ReleaseURL existed in the data but wasn't surfaced to the user. Low-hanging fruit that should have been in the original PR.
+
+## Lessons Learned
+
+1. **Discovery paths are themselves a feature.** Shipping a command doesn't ship the knowledge of it. In-app hints must be validated against the actual command signature, not just the intent. Treat hint strings like API contracts — if it says "run X", verify X exists and does what the hint claims.
+
+2. **Progress feedback prevents panic.** A 9MB download with no output feels broken even when it's working. Structured stage reporting (downloading → verifying → installing) costs one callback param but eliminates the "is it stuck?" anxiety. Worth it.
+
+3. **Callback over config struct when the chain is short.** The ripple to 4 call sites was manageable; a new field in a broad Options struct would have been harder to test and audit. Keep signature changes shallow when possible.
+
+4. **Trust model isolation is non-negotiable but invisible.** Keeping the progress reporter outside verify/replace logic means we're not introducing a code path that bypasses checksums. Easy to miss in review if you're not thinking about it; hard to fix after merge. Callout in code review saved us.
+
+## Next Steps
+
+- **Merged and shipped.** PR #36 squash-merged to main; commit 377fdbe in main.
+- **Follow-up (M1, optional):** `version --check-update` currently prints bare `Release notes:` on empty URL. Consider applying the same guard (`printReleaseNotes` pattern) for parity. Out of scope for this PR but noted for v2.4 backlog.
+- **Docs:** README updated with updated hint quote; codebase-summary and cli-reference synced; CHANGELOG entry for [Unreleased].
+- **Testing:** gofmt clean, go vet clean, go test -race PASS, size-check PASS. All Go files < 200 LOC.
+
+## Unresolved Questions
+
+- (a) Should `version --check-update` apply the same empty-URL guard as the new `printReleaseNotes` for full parity, or is the bare line acceptable for that command?
+- (b) Should a managed-install message (e.g., "installed via Homebrew, run `brew upgrade typeburn`") also surface release notes, or is the command hint enough?

--- a/internal/cli/cmd_update.go
+++ b/internal/cli/cmd_update.go
@@ -24,13 +24,13 @@ var (
 	applyFn   = update.Apply
 )
 
-func getApplyFn() func(context.Context, string, string, string, string, string) (update.Outcome, error) {
+func getApplyFn() func(context.Context, string, string, string, string, string, func(update.Stage)) (update.Outcome, error) {
 	applyFnMu.Lock()
 	defer applyFnMu.Unlock()
 	return applyFn
 }
 
-func setApplyFn(fn func(context.Context, string, string, string, string, string) (update.Outcome, error)) {
+func setApplyFn(fn func(context.Context, string, string, string, string, string, func(update.Stage)) (update.Outcome, error)) {
 	applyFnMu.Lock()
 	defer applyFnMu.Unlock()
 	applyFn = fn
@@ -106,6 +106,8 @@ func runUpdate(cmd *cobra.Command, yes, check bool) error {
 		return ioError("install directory %s is not writable; re-run with sufficient permissions or reinstall", plan.Dir)
 	}
 
+	printReleaseNotes(cmd.OutOrStdout(), result.ReleaseURL)
+
 	if !yes {
 		if !isInteractive(cmd.InOrStdin()) {
 			return usageError("refusing to prompt on a non-interactive stream; re-run with --yes")
@@ -120,12 +122,14 @@ func runUpdate(cmd *cobra.Command, yes, check bool) error {
 		}
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "updating %s → %s ...\n", ver, result.Latest)
-	out, err := getApplyFn()(cmd.Context(), ver, result.Latest, execPath, runtime.GOOS, runtime.GOARCH)
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "updating %s → %s ...\n", ver, result.Latest)
+	progress := func(s update.Stage) { fmt.Fprintf(out, "  %s...\n", s) }
+	outcome, err := getApplyFn()(cmd.Context(), ver, result.Latest, execPath, runtime.GOOS, runtime.GOARCH, progress)
 	if err != nil {
 		return ioError("update failed: %v", err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "updated %s → %s. restart typeburn to use the new version.\n", out.From, out.To)
+	fmt.Fprintf(out, "updated %s → %s. restart typeburn to use the new version.\n", outcome.From, outcome.To)
 	return nil
 }
 
@@ -139,11 +143,22 @@ func reportCheck(cmd *cobra.Command, ver string, result *update.Result, checkErr
 	case checkErr != nil:
 		fmt.Fprintf(cmd.ErrOrStderr(), "could not check for updates: %v\n", checkErr)
 	case result.UpgradeAvailable:
-		fmt.Fprintf(out, "typeburn %s is available (you have %s).\nRun 'typeburn update' to upgrade.\n", result.Latest, ver)
+		fmt.Fprintf(out, "typeburn %s is available (you have %s).\n", result.Latest, ver)
+		printReleaseNotes(out, result.ReleaseURL)
+		fmt.Fprintln(out, "Run 'typeburn update' to upgrade.")
 	default:
 		fmt.Fprintf(out, "you are on the latest version (%s).\n", ver)
 	}
 	return nil
+}
+
+// printReleaseNotes writes a "Release notes: <url>" line when url is non-empty,
+// matching the wording of `version --check-update`. url is already repo-guarded
+// upstream in update.Check, so no further validation is needed here.
+func printReleaseNotes(w io.Writer, url string) {
+	if url != "" {
+		fmt.Fprintf(w, "Release notes: %s\n", url)
+	}
 }
 
 func confirmUpdate(cmd *cobra.Command, cur, latest string) (bool, error) {

--- a/internal/cli/cmd_update_test.go
+++ b/internal/cli/cmd_update_test.go
@@ -25,10 +25,17 @@ func upgradeResult() *update.Result {
 	}
 }
 
-// recordingApply returns an applyFn stub and a pointer to its called-flag.
-func recordingApply(called *bool) func(context.Context, string, string, string, string, string) (update.Outcome, error) {
-	return func(_ context.Context, from, to, _, _, _ string) (update.Outcome, error) {
+// recordingApply returns an applyFn stub and a pointer to its called-flag. It
+// drives the progress reporter through every stage so callers can assert the
+// CLI prints the step lines.
+func recordingApply(called *bool) func(context.Context, string, string, string, string, string, func(update.Stage)) (update.Outcome, error) {
+	return func(_ context.Context, from, to, _, _, _ string, reportFn func(update.Stage)) (update.Outcome, error) {
 		*called = true
+		if reportFn != nil {
+			reportFn(update.StageDownloading)
+			reportFn(update.StageVerifying)
+			reportFn(update.StageInstalling)
+		}
 		return update.Outcome{From: from, To: to}, nil
 	}
 }
@@ -74,8 +81,27 @@ func TestUpdate_CheckReportsAvailability(t *testing.T) {
 	if !strings.Contains(out.String(), "v2.3.0") {
 		t.Errorf("expected latest version in output, got:\n%s", out.String())
 	}
+	if !strings.Contains(out.String(), "Release notes: https://github.com/bavanchun/Typeburn/releases/tag/v2.3.0") {
+		t.Errorf("expected release-notes URL, got:\n%s", out.String())
+	}
 	if called {
 		t.Error("--check must not install")
+	}
+}
+
+func TestUpdate_CheckOmitsReleaseNotesWhenEmpty(t *testing.T) {
+	orig := getCheckFn()
+	r := upgradeResult()
+	r.ReleaseURL = "" // guarded away upstream (non-repo URL) → no notes line
+	setCheckFn(stubCheck(r, nil))
+	defer setCheckFn(orig)
+
+	var out bytes.Buffer
+	if err := updateRoot(t, &out, &bytes.Buffer{}, &bytes.Buffer{}, "update", "--check"); err != nil {
+		t.Fatalf("update --check: %v", err)
+	}
+	if strings.Contains(out.String(), "Release notes:") {
+		t.Errorf("expected no release-notes line for empty URL, got:\n%s", out.String())
 	}
 }
 
@@ -181,6 +207,16 @@ func TestUpdate_YesSkipsPromptAndInstalls(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "updated") {
 		t.Errorf("expected 'updated' confirmation, got:\n%s", out.String())
+	}
+	// Each progress stage must surface to the user during the swap.
+	for _, stage := range []string{"downloading", "verifying", "installing"} {
+		if !strings.Contains(out.String(), stage) {
+			t.Errorf("expected %q progress line, got:\n%s", stage, out.String())
+		}
+	}
+	// Release notes URL must be shown before the install.
+	if !strings.Contains(out.String(), "Release notes: https://github.com/bavanchun/Typeburn/releases/tag/v2.3.0") {
+		t.Errorf("expected release-notes URL, got:\n%s", out.String())
 	}
 }
 

--- a/internal/ui/screen_result_test.go
+++ b/internal/ui/screen_result_test.go
@@ -348,7 +348,7 @@ func TestResultView_UpdateHint_Present(t *testing.T) {
 	if !strings.Contains(view, "v2.1.0") {
 		t.Errorf("expected version in hint, view:\n%s", view)
 	}
-	if !strings.Contains(view, "typeburn version --check-update") {
+	if !strings.Contains(view, "typeburn update") {
 		t.Errorf("expected command in hint, view:\n%s", view)
 	}
 }

--- a/internal/ui/screen_result_view.go
+++ b/internal/ui/screen_result_view.go
@@ -72,7 +72,7 @@ func (m ResultModel) renderUpdateHint() string {
 	if !validSemverFooter.MatchString(latest) {
 		return ""
 	}
-	hint := fmt.Sprintf("↑ %s available — run \"typeburn version --check-update\"", latest)
+	hint := fmt.Sprintf("↑ %s available — run \"typeburn update\"", latest)
 	return m.th.Style(theme.RoleTextMuted).Render(hint)
 }
 

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -21,7 +21,11 @@ type Outcome struct {
 //
 // Integrity rests on TLS + the published sha256 checksums — not signatures; this
 // detects corruption and truncation, not a compromised release host.
-func Apply(ctx context.Context, currentVer, tag, execPath, goos, goarch string) (Outcome, error) {
+//
+// reportFn, if non-nil, is called with each Stage as it begins (downloading →
+// verifying → installing) so a front-end can show progress; it is purely
+// observational and never affects control flow. Pass nil to stay silent.
+func Apply(ctx context.Context, currentVer, tag, execPath, goos, goarch string, reportFn func(Stage)) (Outcome, error) {
 	dir := filepath.Dir(execPath)
 
 	release, err := acquireUpdateLock(dir)
@@ -30,12 +34,13 @@ func Apply(ctx context.Context, currentVer, tag, execPath, goos, goarch string) 
 	}
 	defer release()
 
-	archivePath, err := downloadVerified(ctx, tag, goos, goarch, dir)
+	archivePath, err := downloadVerified(ctx, tag, goos, goarch, dir, reportFn)
 	if err != nil {
 		return Outcome{}, err
 	}
 	defer cleanup(archivePath)
 
+	report(reportFn, StageInstalling)
 	member := binaryMember(goos)
 	newBin, err := extractBinary(archivePath, member, dir)
 	if err != nil {

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -41,12 +41,24 @@ func TestApply_SwapsBinary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := Apply(context.Background(), "2.2.0", "v2.3.0", exec, "linux", "amd64")
+	var stages []Stage
+	out, err := Apply(context.Background(), "2.2.0", "v2.3.0", exec, "linux", "amd64",
+		func(s Stage) { stages = append(stages, s) })
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 	if out.From != "2.2.0" || out.To != "v2.3.0" {
 		t.Errorf("outcome = %+v, want 2.2.0 → v2.3.0", out)
+	}
+	// The reporter must see each stage, in order, on a successful update.
+	want := []Stage{StageDownloading, StageVerifying, StageInstalling}
+	if len(stages) != len(want) {
+		t.Fatalf("stages = %v, want %v", stages, want)
+	}
+	for i := range want {
+		if stages[i] != want[i] {
+			t.Errorf("stage[%d] = %s, want %s", i, stages[i], want[i])
+		}
 	}
 
 	got, _ := os.ReadFile(exec)
@@ -81,7 +93,7 @@ func TestApply_FailureLeavesOriginal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := Apply(context.Background(), "2.2.0", "v2.3.0", exec, "linux", "amd64"); err == nil {
+	if _, err := Apply(context.Background(), "2.2.0", "v2.3.0", exec, "linux", "amd64", nil); err == nil {
 		t.Error("expected failure on non-archive payload")
 	}
 	got, _ := os.ReadFile(exec)

--- a/internal/update/download.go
+++ b/internal/update/download.go
@@ -162,10 +162,11 @@ func downloadTo(ctx context.Context, client *http.Client, rawURL, dest string, s
 // downloaded asset always matches the release being installed — never the
 // caller's current version. On any failure no archive path is returned and
 // temporaries are removed.
-func downloadVerified(ctx context.Context, rawTag, goos, goarch, destDir string) (string, error) {
+func downloadVerified(ctx context.Context, rawTag, goos, goarch, destDir string, reportFn func(Stage)) (string, error) {
 	name := assetName(rawTag, goos, goarch)
 	client := newDownloadClient()
 
+	report(reportFn, StageDownloading)
 	sumPath := filepath.Join(destDir, "checksums.txt")
 	if err := downloadTo(ctx, client, assetURL(rawTag, "checksums.txt"), sumPath, checksumsSizeCap); err != nil {
 		return "", err
@@ -182,6 +183,8 @@ func downloadVerified(ctx context.Context, rawTag, goos, goarch, destDir string)
 	if err := downloadTo(ctx, client, assetURL(rawTag, name), archivePath, archiveSizeCap); err != nil {
 		return "", err
 	}
+
+	report(reportFn, StageVerifying)
 	if err := verifySHA256(archivePath, want); err != nil {
 		_ = os.Remove(archivePath)
 		return "", err

--- a/internal/update/download_test.go
+++ b/internal/update/download_test.go
@@ -50,7 +50,7 @@ func TestDownloadVerified_HappyPath(t *testing.T) {
 	defer setDownloadBase(old)
 
 	dir := t.TempDir()
-	got, err := downloadVerified(context.Background(), "v2.2.0", "linux", "amd64", dir)
+	got, err := downloadVerified(context.Background(), "v2.2.0", "linux", "amd64", dir, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestDownloadVerified_ChecksumMismatch(t *testing.T) {
 	defer setDownloadBase(old)
 
 	dir := t.TempDir()
-	got, err := downloadVerified(context.Background(), "v2.2.0", "linux", "amd64", dir)
+	got, err := downloadVerified(context.Background(), "v2.2.0", "linux", "amd64", dir, nil)
 	if err == nil {
 		t.Error("expected checksum mismatch error, got nil")
 	}

--- a/internal/update/progress.go
+++ b/internal/update/progress.go
@@ -1,0 +1,38 @@
+package update
+
+// Stage identifies a phase of an Apply run, reported to an optional progress
+// callback so a CLI front-end can show the user what is happening during the
+// otherwise-silent download/verify/swap. Reporting is observational only — it
+// never alters control flow or error handling.
+type Stage int
+
+const (
+	// StageDownloading is reported just before the release archive is fetched.
+	StageDownloading Stage = iota
+	// StageVerifying is reported just before the SHA-256 integrity check.
+	StageVerifying
+	// StageInstalling is reported just before the binary is extracted and swapped.
+	StageInstalling
+)
+
+// String returns the lowercase human label for a stage.
+func (s Stage) String() string {
+	switch s {
+	case StageDownloading:
+		return "downloading"
+	case StageVerifying:
+		return "verifying"
+	case StageInstalling:
+		return "installing"
+	default:
+		return "unknown"
+	}
+}
+
+// report invokes fn(s) only when fn is non-nil, so every call site can pass a
+// nil reporter to stay silent without a guard of its own.
+func report(fn func(Stage), s Stage) {
+	if fn != nil {
+		fn(s)
+	}
+}

--- a/plans/20260530-update-ux-polish/brainstorm-summary.md
+++ b/plans/20260530-update-ux-polish/brainstorm-summary.md
@@ -1,0 +1,83 @@
+# Brainstorm Summary — Update-UX Polish
+
+**Date:** 2026-05-30
+**Topic:** Improve the `typeburn update` self-update UX (post-v2.3.0)
+**Outcome:** Approved scope = #1 + #2 + #3. Next step = `/ck:plan --tdd`.
+
+## Problem Statement
+
+`typeburn update` shipped in v2.3.0 but its UX has gaps. The most damaging: the
+app's own in-app nudge points users to a check-only command, not the new
+self-updater — so users never discover the feature exists. Two further polish
+gaps (silent download, no "what changed") reduce trust during the swap.
+
+## Audit Findings (ranked)
+
+### 🔴 #1 — In-app hint points to the wrong command (DEFECT)
+- `internal/ui/screen_result_view.go:75`:
+  `↑ %s available — run "typeburn version --check-update"`
+- `version --check-update` is **detect-only** — a dead end that re-reports
+  availability without upgrading. Predates the `update` command.
+- **Fix:** point the hint at `typeburn update`.
+- **Blast radius:** the muted footer line on the Result screen; NO_COLOR/mono
+  layouts must stay identical; a teatest golden file almost certainly captures
+  this line → golden must be regenerated.
+
+### 🟠 #2 — No progress feedback during the swap
+- `runUpdate` (`cmd_update.go:123-124`) prints `updating X → Y ...` then blocks
+  silently inside `update.Apply` (download ~9 MB → SHA-256 verify → extract →
+  atomic swap). Terminal looks frozen; risk of mid-download `ctrl-c`.
+- **Fix options (decide in plan):**
+  - (a) Add a progress-reporter callback / `io.Writer` status param to `Apply`
+    (or a thin wrapper) so the CLI prints `downloading… / verifying… /
+    installing…` step lines. Stdlib-only, non-TUI, KISS-friendly.
+  - (b) Spinner via `bubbles/spinner` — heavier for a non-TUI command; not
+    preferred.
+- **Constraint:** `Apply` already takes 6 params; prefer a single reporter
+  rather than widening further, or a small wrapper in `internal/cli`.
+
+### 🟡 #3 — "What changed?" never surfaced
+- Update messages give a version but no changelog. Append the release URL
+  (`…/releases/tag/v<latest>`) to the available/updated messages so users can
+  read notes.
+- **Check:** does `update.Result` already carry an HTML/release URL, or must the
+  CLI compose it from the tag + repo prefix? (researcher/scout to confirm.)
+
+### 🟢 #4 — Deferred (YAGNI)
+- `--check` always exit-0 — intentional (mirrors `version --check-update`); skip.
+- In-TUI "press U to update" — scope creep for a typing app; skip.
+
+## Approved Scope
+
+Act on #1 + #2 + #3 together as one "update-UX polish" change. Skip #4.
+
+## Constraints (from CLAUDE.md)
+
+- Stdlib-only in `internal/update`; charm allowed in UI/CLI seams.
+- Every Go file <200 LOC.
+- NO_COLOR + mono themes: layout identical, attributes only.
+- Update trust model unchanged (checksum-only, unsigned) — do not touch.
+- Protected main: branch → PR → squash-merge.
+
+## Touchpoints
+
+- `internal/ui/screen_result_view.go` (#1) + its teatest golden.
+- `internal/cli/cmd_update.go` (#2, #3) + `cmd_update_test.go`.
+- `internal/update/apply.go` and/or a new reporter seam (#2) + tests.
+- `internal/update/result.go` / `check.go` (#3 — release URL source).
+- Docs: `CHANGELOG.md`, README/usage if update output changes.
+
+## Success Criteria
+
+- Result-screen hint reads `run "typeburn update"`; golden updated; NO_COLOR/mono
+  unchanged.
+- `typeburn update` emits visible step feedback during download/verify/install.
+- Update available/updated messages include the release URL.
+- `go test ./... -race`, `go vet`, `gofmt -l` all clean; size-check passes.
+
+## Open Questions
+
+1. #2 feedback: reporter-callback into `Apply` vs CLI-side wrapper — plan to pick
+   the lower-LOC option that keeps `internal/update` stdlib-only.
+2. #3: confirm whether `update.Result` exposes a release URL or it must be
+   composed from tag + repo prefix.

--- a/plans/20260530-update-ux-polish/phase-01-fix-in-app-update-hint.md
+++ b/plans/20260530-update-ux-polish/phase-01-fix-in-app-update-hint.md
@@ -1,0 +1,62 @@
+---
+phase: 1
+title: Fix in-app update hint
+status: completed
+priority: P1
+effort: 30m
+dependencies: []
+---
+
+# Phase 1: Fix in-app update hint
+
+## Overview
+
+The result-screen "update available" footer nudge points at the check-only
+`typeburn version --check-update`, which never upgrades. Repoint it at
+`typeburn update`. This is the highest-value fix — the stale string defeated
+feature discovery.
+
+## Requirements
+
+- Functional: when an opportunistic check finds a newer release, the result
+  screen's muted footer line tells the user to run `typeburn update`.
+- Non-functional: NO_COLOR + mono layouts identical (attributes only); semver
+  injection guard and width-capping behavior preserved.
+
+## Architecture
+
+- `internal/ui/screen_result_view.go:75` — `renderUpdateHint()` builds the hint
+  string. Only the literal command text changes; the surrounding `Latest` semver
+  guard (suppress non-semver) and `theme.RoleTextMuted` styling stay as-is.
+- New string is shorter than the old, so the existing width cap cannot newly
+  truncate — no layout regression.
+
+## Related Code Files
+
+- Modify: `internal/ui/screen_result_view.go` (line ~75, hint string)
+- Modify: `internal/ui/screen_result_test.go` (assertion at line ~351)
+
+## Implementation Steps (TDD)
+
+1. **Red:** in `screen_result_test.go`, change the assertion
+   `strings.Contains(view, "typeburn version --check-update")` to expect
+   `"typeburn update"`. Run the test → fails against current code.
+2. **Green:** in `screen_result_view.go`, change the hint format string from
+   `↑ %s available — run "typeburn version --check-update"` to
+   `↑ %s available — run "typeburn update"`.
+3. Run `go test ./internal/ui/ -run Result -count=1` → green.
+4. Confirm `TestRenderUpdateHint_InjectionGuard` still passes (non-semver
+   `Latest` still suppressed — unaffected by the string change).
+
+## Success Criteria
+
+- [ ] Result-screen hint reads `run "typeburn update"`.
+- [ ] `screen_result_test.go` assertion updated and green.
+- [ ] Injection-guard test still passes.
+- [ ] `go test ./internal/ui/ -race -count=1` green; `gofmt -l` clean.
+
+## Risk Assessment
+
+- Low. Single string + single assertion. Risk = a *second* test or golden also
+  pins the old string → grep `check-update` under `internal/ui/` before editing
+  (current scan shows only the one assertion; re-verify).

--- a/plans/20260530-update-ux-polish/phase-02-update-progress-feedback.md
+++ b/plans/20260530-update-ux-polish/phase-02-update-progress-feedback.md
@@ -1,0 +1,90 @@
+---
+phase: 2
+title: Update progress feedback
+status: completed
+priority: P2
+effort: 2h
+dependencies:
+  - 1
+---
+
+# Phase 2: Update progress feedback
+
+## Overview
+
+`typeburn update` prints `updating X → Y ...` then blocks silently inside
+`update.Apply` while it downloads ~9 MB, verifies SHA-256, extracts, and swaps —
+the terminal looks frozen. Add a nil-safe progress reporter so the CLI prints
+`downloading… / verifying… / installing…` step lines.
+
+## Requirements
+
+- Functional: during a real `update`, stdout shows distinct download, verify, and
+  install stage lines before the final `updated X → Y` line.
+- Non-functional: `internal/update` stays stdlib-only (no UI deps); reporter is a
+  plain `func(Stage)`; nil reporter = silent (preserves existing callers/tests).
+
+## Architecture
+
+- **Reporter type** (in `internal/update`, e.g. `apply.go` or a small
+  `progress.go`):
+  ```go
+  type Stage int
+  const ( StageDownloading Stage = iota; StageVerifying; StageInstalling )
+  func (s Stage) String() string // "downloading"/"verifying"/"installing"
+  ```
+- **Thread the reporter** as a final nil-safe param:
+  - `Apply(ctx, currentVer, tag, execPath, goos, goarch, report func(Stage))`
+  - `downloadVerified(ctx, rawTag, goos, goarch, destDir, report func(Stage))`
+  - Emit: `report(StageDownloading)` before the archive download, then
+    `report(StageVerifying)` before `verifySHA256`, then `report(StageInstalling)`
+    in `Apply` before `extractBinary`/`replaceBinary`. Guard every call:
+    `if report != nil { report(...) }`.
+- **Rejected:** bundling params into an `Options` struct — more churn across
+  callers/tests for no behavior gain; the single nil-safe param is KISS.
+- **CLI wiring** (`cmd_update.go`): replace the lone `updating X → Y ...` print
+  with a reporter that prints `<stage>...` step lines; keep the final
+  `updated X → Y. restart…` line. Plain `fmt.Fprintln` — no spinner (non-TUI).
+- **File-size watch:** `cmd_update.go` is 161 LOC; if wiring pushes it toward 200,
+  extract the reporter/printing into a helper file.
+
+## Related Code Files
+
+- Create: `internal/update/progress.go` (Stage type) — or inline in `apply.go`
+- Modify: `internal/update/apply.go`, `internal/update/download.go`
+- Modify: `internal/cli/cmd_update.go`
+- Modify: `internal/update/apply_test.go`, `internal/cli/cmd_update_test.go`
+- Update call sites: any existing `Apply(...)`/`downloadVerified(...)` callers +
+  the `applyFn` signature/var in `cmd_update.go` and its test override.
+
+## Implementation Steps (TDD)
+
+1. **Red (unit):** in `apply_test.go`, add a test that passes a recording
+   reporter to `Apply` (using existing httptest fixtures) and asserts the stage
+   sequence == `[downloading, verifying, installing]` on success. Fails to
+   compile/run (no param yet).
+2. **Green:** add `Stage`, thread the nil-safe `report` param through `Apply` and
+   `downloadVerified`, emit at the three boundaries. Update the `applyFn` type in
+   `cmd_update.go` + its `setApplyFn` test override to the new signature.
+3. **Red (CLI):** in `cmd_update_test.go`, assert stdout contains the step lines
+   (`downloading`, `verifying`, `installing`) on a successful stubbed update.
+4. **Green:** wire the CLI reporter to print `<stage>...`. Verify nil-reporter
+   path (any other caller / `--check`) unaffected.
+5. Run `go test ./internal/update/ ./internal/cli/ -race -count=1` → green.
+
+## Success Criteria
+
+- [ ] `Apply` calls the reporter `downloading → verifying → installing` on success.
+- [ ] Nil reporter = silent; pre-existing tests pass unchanged in behavior.
+- [ ] `typeburn update` stdout shows the three stage lines + final updated line.
+- [ ] No `internal/update` UI imports; all files <200 LOC.
+- [ ] `go test ./... -race`, `go vet`, `gofmt -l` clean.
+
+## Risk Assessment
+
+- Signature change ripples to `applyFn`/`setApplyFn` in `cmd_update.go` + tests —
+  enumerate all `Apply(`/`downloadVerified(` call sites first (grep) so none is
+  missed.
+- Reporter must be nil-safe to avoid panicking any caller that passes nil.
+- Keep stage emission OUTSIDE the verify/replace integrity logic — reporting must
+  not alter control flow or error paths.

--- a/plans/20260530-update-ux-polish/phase-03-surface-release-url-docs.md
+++ b/plans/20260530-update-ux-polish/phase-03-surface-release-url-docs.md
@@ -1,0 +1,81 @@
+---
+phase: 3
+title: Surface release URL + docs
+status: completed
+priority: P2
+effort: 1h
+dependencies:
+  - 2
+---
+
+# Phase 3: Surface release URL + docs
+
+## Overview
+
+Surface `Release notes: <url>` in `typeburn update` output so users see what
+changed, mirroring the exact wording `version --check-update` already uses.
+`Result.ReleaseURL` already exists and is repo-guarded — no new fetching. Then
+update docs and run the full CI gate.
+
+## Requirements
+
+- Functional: when an update is available, both `update` and `update --check`
+  print `Release notes: <ReleaseURL>` (only when non-empty).
+- Non-functional: wording matches `version --check-update` (`Release notes: %s`);
+  empty/guarded-away URL prints no broken line.
+
+## Architecture
+
+- **`cmd_update.go`:**
+  - `reportCheck` upgrade-available branch (`--check`): append
+    `Release notes: <result.ReleaseURL>` when non-empty (matches
+    `renderVersionCheckHuman`).
+  - Install path: print the release-notes line before the confirm prompt (so the
+    user can decide informed). Skip the line when `ReleaseURL == ""`.
+  - The managed-install message may also append the notes line (optional; keep if
+    it doesn't push the file past 200 LOC).
+- **In-app hint (Phase 1 file):** intentionally NOT changed — the footer is one
+  width-capped muted line; a URL would overflow. Release URL is CLI-only. Document
+  this decision.
+- **Wording source of truth:** `cmd_version.go:renderVersionCheckHuman` uses
+  `Release notes: %s` — reuse verbatim for consistency.
+
+## Related Code Files
+
+- Modify: `internal/cli/cmd_update.go`
+- Modify: `internal/cli/cmd_update_test.go`
+- Modify: `CHANGELOG.md` (`[Unreleased]` → add the three UX entries)
+- Modify: `README.md` / usage docs IF they quote `update` output (verify first)
+- Modify: `docs/codebase-summary.md` if update-UX behavior described there
+
+## Implementation Steps (TDD)
+
+1. **Red:** in `cmd_update_test.go`, assert that with a stubbed
+   `UpgradeAvailable` result carrying a `ReleaseURL`, both `update` (install path,
+   pre-confirm) and `update --check` stdout contain `Release notes: <url>`. Add a
+   case asserting NO `Release notes:` line when `ReleaseURL == ""`.
+2. **Green:** add the conditional `Release notes:` prints in `reportCheck` and the
+   install path of `runUpdate`.
+3. Run `go test ./internal/cli/ -race -count=1` → green.
+4. **Docs:** add `CHANGELOG.md` `[Unreleased]` entries for the hint fix, progress
+   feedback, and release-notes surfacing. Grep README/docs for quoted `update`
+   output and sync if present.
+5. **Full CI gate:** `go test ./... -race -count=1`, `go vet ./...`,
+   `gofmt -l .` (empty), `make size-check` (exit 0).
+
+## Success Criteria
+
+- [ ] `update` and `update --check` print `Release notes: <url>` when available.
+- [ ] No release-notes line when `ReleaseURL` is empty.
+- [ ] Wording matches `version --check-update`.
+- [ ] `CHANGELOG.md` `[Unreleased]` updated; docs synced if affected.
+- [ ] Full CI gate green; binary size-check passes.
+
+## Risk Assessment
+
+- Low. Additive output only; guarded on non-empty URL so no broken line.
+- `ReleaseURL` is already repo-prefix-guarded in `check.go` — no SSRF/arbitrary
+  URL risk introduced.
+- Confirm the asserted `Release notes:` lines don't collide with Phase 2's stage
+  lines in the same stdout buffer (order: notes line before confirm, stage lines
+  after confirm).

--- a/plans/20260530-update-ux-polish/plan.md
+++ b/plans/20260530-update-ux-polish/plan.md
@@ -1,0 +1,61 @@
+---
+title: Update-UX Polish (post-v2.3.0)
+description: ''
+status: completed
+priority: P2
+branch: feat/update-ux-polish
+tags: []
+blockedBy: []
+blocks: []
+created: '2026-05-29T19:45:40.961Z'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Update-UX Polish (post-v2.3.0)
+
+## Overview
+
+Three UX fixes for the `typeburn update` self-updater shipped in v2.3.0:
+
+1. **Defect** — the in-app result-screen hint points at the check-only
+   `typeburn version --check-update`, a dead end that never upgrades. Point it at
+   `typeburn update`. (This stale string is why the feature went undiscovered.)
+2. **Polish** — `typeburn update` blocks silently during the ~9 MB
+   download/verify/swap. Emit `downloading… / verifying… / installing…` step
+   lines via a nil-safe reporter threaded through `update.Apply`.
+3. **Polish** — surface `Release notes: <url>` in `update` output, mirroring the
+   wording `version --check-update` already uses (`Result.ReleaseURL` exists and
+   is repo-guarded — no new fetching).
+
+Design source: [brainstorm-summary.md](./brainstorm-summary.md).
+
+**TDD:** each phase writes/updates tests first (red), then implements to green.
+Existing update tests (httptest fixtures, string assertions) lock current
+behavior before the changes land.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Fix in-app update hint](./phase-01-fix-in-app-update-hint.md) | Completed |
+| 2 | [Update progress feedback](./phase-02-update-progress-feedback.md) | Completed |
+| 3 | [Surface release URL + docs](./phase-03-surface-release-url-docs.md) | Completed |
+
+## Key Constraints (from CLAUDE.md)
+
+- **Layering:** no UI deps in `internal/update`; reporter is a plain stdlib
+  `func(Stage)`. CLI step-printing stays in `internal/cli`.
+- **File size:** every Go file <200 LOC; `cmd_update.go` is at 161 — watch the cap
+  in Phase 2/3 (split a helper out if it would cross 200).
+- **Themes:** NO_COLOR + mono layouts identical; Phase 1's new hint is *shorter*
+  than the old string, so width-capping stays safe — assert mono unchanged.
+- **Trust model unchanged:** checksum-only, unsigned. Do not touch verify/replace.
+- **Protected main:** branch `feat/update-ux-polish` → PR → squash-merge.
+
+## Dependencies
+
+- **Builds on (completed):** `plans/20260529-typeburn-self-update-command` —
+  shipped `internal/update` Apply/download/verify + `cmd_update.go` (v2.3.0).
+  Foundation merged; no blocking relationship.
+- No open plans block or are blocked by this one (all prior plans completed).


### PR DESCRIPTION
## Summary

Three UX improvements to the self-updater shipped in v2.3.0:

1. **Fixed in-app result-screen hint** — now points at `typeburn update` instead of the read-only `typeburn version --check-update`, making the update feature discoverable in the UI.

2. **Added progress feedback** — nil-safe progress reporter (new `internal/update/progress.go` Stage type) threaded through `update.Apply` and `downloadVerified` so the CLI prints "downloading", "verifying", "installing" instead of blocking silently.

3. **Surfaced release notes URL** — both `typeburn update` and `typeburn update --check` now display `Release notes: <url>`, reusing the existing `Result.ReleaseURL`.

## Verification

- ✅ gofmt clean (no diffs)
- ✅ go vet clean (no warnings)
- ✅ go test ./... -race PASS (all tests)
- ✅ make size-check PASS (binary within limits)
- ✅ All Go files < 200 LOC
- ✅ Code review complete (no Critical/High issues)

## Merge Strategy

Squash-merge to main (per repo convention).