### PR TITLE
chore(release): prep v2.4.0 (update-UX polish)

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,15 +1,13 @@
-## [2.3.0] - 2026-05-30
+## [2.4.0] - 2026-05-30
 
-### Added
+### Changed
 
-- `typeburn update` self-update command. Downloads the matching release archive,
-  verifies it against the published SHA-256 `checksums.txt` over HTTPS, extracts
-  the binary, and atomically replaces the running executable in place (Linux,
-  macOS, Windows). `--check` reports availability without installing; `--yes`
-  skips the confirmation prompt. Package-manager builds (Homebrew, `go install`)
-  are refused with the matching upgrade command and a distinct exit code;
-  non-interactive streams refuse unless `--yes` is given. Integrity is
-  checksum-only (unsigned binaries) — the same trust model as the install
-  script.
+- The in-app "update available" hint on the result screen now points at
+  `typeburn update` (the self-updater) instead of the check-only
+  `typeburn version --check-update`.
+- `typeburn update` now prints `downloading` / `verifying` / `installing`
+  progress lines during the swap instead of blocking silently, and surfaces the
+  release-notes URL (`Release notes: <url>`) before installing — matching the
+  output of `typeburn version --check-update`.
 
-[2.3.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.3.0
+[2.4.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-05-30
+
 ### Changed
 
 - The in-app "update available" hint on the result screen now points at


### PR DESCRIPTION
Release prep for **v2.4.0** — the update-UX polish merged in #36.

## Changes
- `CHANGELOG.md`: `[Unreleased]` → `[2.4.0] - 2026-05-30` (the three update-UX entries).
- `.github/release-notes.md`: rewritten with the verbatim v2.4.0 body GoReleaser publishes.

## Shipped in v2.4.0 (from #36)
- In-app result-screen hint points at `typeburn update` (was the check-only `version --check-update`).
- `typeburn update` shows `downloading/verifying/installing` progress instead of a silent block.
- `Release notes: <url>` surfaced in `update` and `update --check`.

## Release procedure (after squash-merge)
Disposable `v0.0.0-rc.test` dry-run on the merged SHA → verify 7 assets + prerelease-excluded + tap untouched → delete dry-run → annotate `v2.4.0` on the proven SHA → push tag (separate push).

No code changes — docs/release-notes only.