### PR TITLE
Architecture performance hardening: mode layering, live-WPM hot path, best-bucket dedup

### DIFF
--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -36,10 +36,11 @@ monkeytype/
 ├── internal/
 │   ├── app/                  # root Elm model + routing
 │   ├── ui/                   # screen sub-models + components
+│   ├── mode/                 # shared mode enum + length policy
 │   ├── typing/               # pure keystroke engine
 │   ├── metrics/              # pure metric formulas
 │   ├── words/                # word/quote generator
-│   ├── config/               # settings + keybindings
+│   ├── config/               # settings + centralized keybindings
 │   ├── storage/              # persistence + new-best detection
 │   └── theme/                # color/attribute roles
 └── docs/                     # documentation
@@ -227,6 +228,7 @@ func (m HomeModel) View() tea.View {
 ### Pure Computation Guarantee
 
 - **No side effects:** metrics.Compute, typing.Engine.Replay, consistency calculations
+- **Layering:** typing/metrics/words/runner use `internal/mode`, not `internal/config`
 - **Testable standalone:** No dependency on Bubble Tea, storage, or UI
 - **Reusable:** Metrics package suitable for future CLI/server projects
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -111,6 +111,22 @@ and `wordTarget` math shared by TUI and CLI.
 
 ---
 
+### `internal/mode` — Shared Mode Definitions
+
+**Purpose:** Source-of-truth for typing mode identifiers and selectable length
+policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
+`config` without pulling in settings/keymap dependencies.
+
+**Key types:**
+- `Mode`: string enum {time, words, quote, code}
+
+**Entry points:**
+- `LengthsFor(mode)`: valid length options; quote/code return nil.
+
+**Files:** mode.go, mode_test.go.
+
+---
+
 ### `internal/app` — Root Elm Model & Routing
 
 **Purpose:** Bubble Tea root model. Routes global messages (StartTestMsg, ResultMsg, AbortMsg, NavHistoryMsg) to sub-models. Manages screen enum + shared state (theme, keymap, terminal size, quit prompt overlay).
@@ -163,9 +179,11 @@ and `wordTarget` math shared by TUI and CLI.
 - `Engine`: {target []rune, typed []rune, log []Keystroke, startMs, mode, wordTarget} — mutable state machine
 
 **Entry points:**
-- `New(target string, mode, wordTarget)`: create engine for a test
+- `New(target string, mode mode.Mode, wordTarget int)`: create engine for a test
 - `Apply(rune, nowMs)`: record keystroke; auto-sets startMs on first call
 - `Backspace(nowMs)`: record deletion marker (Typed=0)
+- `Typed()`: copy current typed buffer without replaying the log
+- `ForwardKeystrokes()`: count forward entries for live metrics without copying the log
 - `IsComplete() bool`: check if test goal met (Time/Words/Quote mode-dependent)
 - `Replay() (final typed/target runes, duration, errors)`: reconstruct final state for metrics
 
@@ -182,10 +200,11 @@ and `wordTarget` math shared by TUI and CLI.
 - `KeyMiss`: {Key (folded rune), Label (display, e.g. "␣"), Misses, Attempts} — per-key fumble tally entry
 
 **Entry points:**
-- `Compute(log []typing.Keystroke, startMs, durationMs) Result`: compute all metrics post-hoc; populates `Result.KeyMisses` (nil on empty/zero-duration logs)
+- `Compute(log []typing.Keystroke, mode mode.Mode, endMs int64) Result`: compute all metrics post-hoc; populates `Result.KeyMisses` (nil on empty/zero-duration logs)
 - `KeyHeatmap(log []typing.Keystroke) []KeyMiss`: per-key miss tally over the log — every wrong forward keystroke vs a real target (corrected fumbles included), case-folded, keys with ≥1 miss only, sorted misses desc → attempts desc → key asc. Surfaced on the Result screen and in CLI `key_misses` (JSON) / `most_missed_*` (table).
-- `LiveWPM(log []typing.Keystroke, elapsedMs int64) float64`: lightweight O(n) live WPM for in-progress display; returns 0 below 500 ms guard; counts only forward keystrokes (Typed != 0)
-- `AFKTrim(log, durationMs) ([]typing.Keystroke, int64)`: remove trailing AFK seconds (Time mode only, >7s)
+- `LiveWPM(log []typing.Keystroke, elapsedMs int64) float64`: log-based live WPM helper; returns 0 below 500 ms guard
+- `LiveWPMFromCount(forward, elapsedMs) float64`: O(1) live WPM helper used by the Typing screen tick path
+- `TrimAFK(log, mode, endMs) ([]typing.Keystroke, int64)`: remove trailing AFK seconds (Time mode only, >7s)
 - `Consistency(wpmPerSecond []float64) float64`: 100 × tanh(1 − CV)
 
 **Files:** compute.go, consistency.go, per_second.go, afk_trim.go, live_wpm.go, key_heatmap.go, compute_test.go, consistency_test.go, afk_trim_test.go, live_wpm_test.go, key_heatmap_test.go.
@@ -201,7 +220,7 @@ and `wordTarget` math shared by TUI and CLI.
 - `quotePack`: {short, medium, long, epic []string} — embedded quotes for each bucket
 
 **Entry points:**
-- `ForMode(mode, length)`: return target string (Time: ~words × 5 chars; Words: exact N words; Quote: random from bucket)
+- `ForMode(generator, mode, length, quoteLen)`: return target string (Time: time buffer; Words: exact N words; Quote: random from bucket)
 - `Word(n)`: return n-th word from wordlist (deterministic, seeded)
 - `Quote(len QuoteLen)`: return random quote from bucket (seeded)
 - `TimeBuffer(seconds)`: generate words for Time mode (~5 chars/word avg)
@@ -212,10 +231,12 @@ and `wordTarget` math shared by TUI and CLI.
 
 ### `internal/config` — Settings, Keymap, XDG Paths
 
-**Purpose:** User-facing configuration (theme, mode, length, cursor blink) + centralized keybindings + XDG directory resolution. Zero UI / storage dependencies.
+**Purpose:** User-facing configuration (theme, mode, length, cursor blink) +
+centralized keybindings + XDG directory resolution. Settings and XDG helpers
+stay storage-agnostic; keymap intentionally centralizes Bubble Tea key bindings.
 
 **Key types:**
-- `Mode`: enum {ModeTime, ModeWords, ModeQuote} — stored as string in JSON
+- `Mode`: alias of `mode.Mode` for persisted settings compatibility
 - `Settings`: {Theme, DefaultMode, DefaultLength, BlinkCursor} — loaded from disk or defaults
 - `Keymap`: keybinds per screen (Home/Typing/Result/Settings/History) — maps Bubble Tea key codes to actions
 - `QuoteLen`: enum for quote bucket selection
@@ -244,7 +265,10 @@ and `wordTarget` math shared by TUI and CLI.
 - `AppendHistory(r Record)`: append + cap to 200 newest + atomic write
 - `LoadSettings()`: read settings.json; return defaults on any error
 - `SaveSettings(s Settings)`: atomic write to XDG_CONFIG
-- `IsNewBest(r Record, history []Record)`: check if WPM is highest for that (mode, length) pair
+- `EffectiveWPM(r Record)`: precise NetWPM comparison with legacy WPM fallback
+- `BestBucketKey(mode, length)`: shared leaderboard bucket key
+- `BestWPMPerBucket(records)`: shared per-bucket bests for UI badges
+- `IsNewBest(history, r)`: check if WPM is highest for that (mode, length) pair
 
 **Data flow:**
 - Settings loaded at startup in `app.NewFromDisk()`
@@ -252,7 +276,8 @@ and `wordTarget` math shared by TUI and CLI.
 - Records appended via `AppendHistory()` immediately after test (from ResultMsg handler)
 - New-best flag computed in root model's `handleResultMsg()`
 
-**Files:** history_store.go, settings_store.go, new_best.go, atomic_write.go, history_record.go, history_store_test.go, settings_store_test.go.
+**Files:** history_store.go, settings_store.go, new_best.go, atomic_write.go,
+history_record.go, history_store_test.go, new_best_test.go, settings_store_test.go.
 
 ---
 

--- a/docs/journals/260604-1425-architecture-performance-hardening.md
+++ b/docs/journals/260604-1425-architecture-performance-hardening.md
@@ -1,0 +1,43 @@
+---
+title: Architecture Performance Hardening
+date: 2026-06-04
+type: journal
+---
+
+# Architecture Performance Hardening
+
+## Context
+
+Implemented plan `plans/260604-1354-architecture-performance-hardening/plan.md`
+after architecture/performance audit of Typeburn.
+
+## What Happened
+
+Added benchmark coverage for typing engine, metrics, TUI render, and storage
+new-best detection. Baseline showed full TUI render is the real allocation/time
+hotspot, while live metrics and storage were modest.
+
+Applied small hot-path fixes: `typing.Engine.Typed()` exposes current buffer as
+a copy, `ForwardKeystrokes()` lets the tick path compute live WPM without
+copying/replaying the log, and `metrics.LiveWPMFromCount()` keeps that formula
+pure.
+
+Split shared mode definitions into `internal/mode`. `config.Mode` remains an
+alias for compatibility, but production core packages now import `internal/mode`
+instead of `internal/config`.
+
+Centralized best-bucket comparison in `internal/storage` so persistence and UI
+history badges use the same effective-WPM policy.
+
+## Decisions
+
+- Keep `config.Keymap` in `internal/config`; repo rules say this Bubble Tea
+  key binding boundary is deliberate.
+- Do not rewrite the renderer. Benchmarks identify render cost, but the planned
+  scope was measurement plus low-risk allocation cleanup.
+- Keep history JSON schema unchanged.
+
+## Next
+
+If future performance work is needed, target render-windowing or style batching
+in code-mode rendering, using the new benchmarks as guardrails.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -218,6 +218,11 @@
   to disk; typing content width scales to ~82% of wide terminals (floored at
   80) with the block vertically centered.
 - ✅ **v1.5.0 (Distribution):** Go floor lowered to 1.25.0 (from 1.26.2); hardened POSIX `install.sh` with OS/arch detection, latest-tag resolution, sha256 verification, and atomic ~/.local/bin install (no sudo); new `scripts/test-install-sh.sh` offline regression harness (14 cases, localhost fixtures) integrated into CI as `installer` job; GoReleaser config hardened with determinism pins (project_name, builds.binary, archives.name_template) and `release.prerelease: auto`; new Homebrew cask channel (bavanchun/homebrew-tap-typeburn) with token isolation; 7-asset release integrity invariant preserved. Ship date: 2026-05-20.
+- ✅ **Architecture/performance hardening (2026-06-04):** Added benchmark
+  coverage for typing, metrics, storage new-best, and TUI render paths; split
+  shared mode definitions into `internal/mode`; removed hot-path log replay/copy
+  from Typing tick/view; centralized best-bucket helpers in storage so history
+  badges and persistence use the same comparison policy.
 - ✅ **v2.0.0 (Pro CLI):** cobra/fang subcommands (`run`, `history`,
   `version`, `config`, `replay`), JSON outputs, schema-versioned replay logs,
   and raw `run --no-tui`; v1 root aliases remain compatible. Ship date:

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -266,6 +266,6 @@
 
 ## Conclusion
 
-**Typeburn v2.1.2 is the current stable release.** The codebase is clean, tested, and well-documented. Post-1.0 work has been additive or corrective, with v2.0.0 adding a professional scriptable CLI, v2.1.0 adding opt-in update-check, and v2.1.1 resolving 6 audited defects.
+**Typeburn v2.4.0 is the current stable release.** The codebase is clean, tested, and well-documented. Post-1.0 work has been additive or corrective: v2.0.0 added a professional scriptable CLI, v2.1.x added opt-in update checks plus audited defect cleanup, v2.2.0 added per-key error heatmaps, v2.3.0 added the self-update command, and v2.4.0 polished the update discovery and progress UX.
 
 M1 (timer re-arm) and M2 (new-best precision) — the identified correctness bugs — were fixed in v1.0 (d6369de) and v1.0.1 respectively. v1.4.0 fixed a Settings live-apply bug (changes were persisted but not applied in-session) and improved the wide-terminal typing layout. Remaining backlog is additive or cosmetic.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -103,12 +103,21 @@ Each sub-model has `SetSize(w, h)` to handle WindowSizeMsg; root calls it on res
 
 ### Pure Packages (Zero Bubble Tea Imports)
 
+- **`internal/mode`:** Shared mode enum + selectable length policy. No UI/Bubble Tea.
 - **`internal/typing`:** Engine state machine + keystroke logging. No UI/Bubble Tea.
 - **`internal/metrics`:** WPM/accuracy/consistency computation. No UI/Bubble Tea.
 - **`internal/words`:** Word generator + quote pack. No UI/Bubble Tea.
-- **`internal/config`:** Settings types + keymap. No UI/Bubble Tea.
 - **`internal/storage`:** JSON persistence (atomic write, XDG paths). No UI/Bubble Tea.
 - **`internal/theme`:** Role-based color mapping. No UI/Bubble Tea.
+
+### Configuration Boundary
+
+- **`internal/config`:** Settings types, XDG paths, and centralized keymap.
+  `config.Mode` is a compatibility alias of `mode.Mode`; `config.LengthsFor`
+  delegates to `internal/mode`.
+- `config.Keymap` intentionally owns Bubble Tea key bindings so screen code has
+  one keybinding source. Core packages (`typing`, `metrics`, `words`, `runner`)
+  must not import `internal/config`.
 
 ### UI Package
 
@@ -163,14 +172,14 @@ type Record struct {
   RawWPM    float64
   Accuracy  float64
   Consistency float64
-  Mode      config.Mode
+  Mode      mode.Mode
   Length    int
   Time      time.Time
   // ... other fields
 }
 ```
 
-Persisted to history.json; compared in IsNewBest() logic.
+Persisted to history.json; compared via storage's exported best-bucket helpers.
 
 ### config.Settings
 
@@ -201,8 +210,8 @@ func tickCmd() tea.Cmd {
 
 In TypingModel.Update(tickMsg):
 - Calculate elapsed = now − startMs
-- Replay keystroke log to final state
-- Compute metrics.Compute(log, startMs, elapsed)
+- Compute live WPM from the engine's forward-keystroke count
+- Keep final metrics on the post-test path, not every tick
 - Render live WPM in header
 - Re-arm tick (returned from handleTick)
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -3,31 +3,22 @@
 // types to disk.
 package config
 
+import "github.com/bavanchun/Typeburn/internal/mode"
+
 // Mode identifies a test mode. Stored as a string for forward-compatible JSON.
-type Mode string
+type Mode = mode.Mode
 
 const (
-	ModeTime  Mode = "time"
-	ModeWords Mode = "words"
-	ModeQuote Mode = "quote"
-	// ModeCode types a user-supplied snippet verbatim (CLI --text). It has
-	// no numeric length and completes on an exact full-text match (like
-	// quote). Whitespace/newlines/tabs are literal.
-	ModeCode Mode = "code"
+	ModeTime  = mode.ModeTime
+	ModeWords = mode.ModeWords
+	ModeQuote = mode.ModeQuote
+	ModeCode  = mode.ModeCode
 )
 
 // LengthsFor returns the selectable length options for a mode. Quote mode has
 // no numeric length (the quote itself bounds the test) so it returns nil.
 func LengthsFor(m Mode) []int {
-	switch m {
-	case ModeWords:
-		return []int{10, 25, 50, 100}
-	case ModeQuote, ModeCode:
-		// No numeric length: the quote / supplied snippet bounds the test.
-		return nil
-	default: // ModeTime
-		return []int{15, 30, 60, 120}
-	}
+	return mode.LengthsFor(m)
 }
 
 // Settings is the persisted user configuration.

--- a/internal/metrics/afk_trim.go
+++ b/internal/metrics/afk_trim.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/mode"
 	"github.com/bavanchun/Typeburn/internal/typing"
 )
 
@@ -18,8 +18,8 @@ const afkThresholdMs int64 = 7000 // strictly greater than this triggers AFK tri
 //
 // Returns the (possibly unchanged) log and the effective endMs to use for
 // metric computation. The log itself is never modified; only endMs changes.
-func TrimAFK(log []typing.Keystroke, mode config.Mode, endMs int64) ([]typing.Keystroke, int64) {
-	if mode != config.ModeTime {
+func TrimAFK(log []typing.Keystroke, m mode.Mode, endMs int64) ([]typing.Keystroke, int64) {
+	if m != mode.ModeTime {
 		return log, endMs
 	}
 

--- a/internal/metrics/compute.go
+++ b/internal/metrics/compute.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/mode"
 	"github.com/bavanchun/Typeburn/internal/typing"
 )
 
@@ -39,7 +39,7 @@ type Result struct {
 //   - A char typed wrong then corrected via backspace counts as Correct → 100%.
 //   - An uncorrected error counts as Incorrect → penalises accuracy.
 //   - Zero chars typed → Accuracy = 100, all others = 0.
-func Compute(log []typing.Keystroke, mode config.Mode, endMs int64) Result {
+func Compute(log []typing.Keystroke, mode mode.Mode, endMs int64) Result {
 	if len(log) == 0 {
 		return Result{Accuracy: 100}
 	}

--- a/internal/metrics/live_wpm.go
+++ b/internal/metrics/live_wpm.go
@@ -15,5 +15,13 @@ func LiveWPM(log []typing.Keystroke, elapsedMs int64) float64 {
 			forward++
 		}
 	}
+	return LiveWPMFromCount(forward, elapsedMs)
+}
+
+// LiveWPMFromCount estimates current net WPM from a forward-keystroke count.
+func LiveWPMFromCount(forward int, elapsedMs int64) float64 {
+	if elapsedMs < 500 || forward <= 0 {
+		return 0
+	}
 	return float64(forward) / 5.0 / (float64(elapsedMs) / 60000.0)
 }

--- a/internal/metrics/live_wpm_test.go
+++ b/internal/metrics/live_wpm_test.go
@@ -47,3 +47,15 @@ func TestLiveWPM(t *testing.T) {
 		})
 	}
 }
+
+func TestLiveWPMFromCount(t *testing.T) {
+	if got := LiveWPMFromCount(25, 60000); got != 5 {
+		t.Fatalf("LiveWPMFromCount() = %v, want 5", got)
+	}
+	if got := LiveWPMFromCount(25, 499); got != 0 {
+		t.Fatalf("LiveWPMFromCount below guard = %v, want 0", got)
+	}
+	if got := LiveWPMFromCount(0, 60000); got != 0 {
+		t.Fatalf("LiveWPMFromCount zero count = %v, want 0", got)
+	}
+}

--- a/internal/metrics/metrics_benchmark_test.go
+++ b/internal/metrics/metrics_benchmark_test.go
@@ -1,0 +1,55 @@
+package metrics_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/metrics"
+	"github.com/bavanchun/Typeburn/internal/mode"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+func benchCodeTarget(n int) string {
+	var b strings.Builder
+	for b.Len() < n {
+		b.WriteString("func main() {\n\tprintln(\"typeburn\")\n}\n")
+	}
+	return b.String()[:n]
+}
+
+func benchLog(target string, m mode.Mode, wordTarget int) []typing.Keystroke {
+	e := typing.New(target, m, wordTarget)
+	for i, r := range target {
+		if i%97 == 0 {
+			e.Apply('x', int64(i+1))
+			e.Backspace(int64(i + 2))
+		}
+		e.Apply(r, int64(i+3))
+	}
+	return e.Log()
+}
+
+func BenchmarkMetricsComputeCode10k(b *testing.B) {
+	log := benchLog(benchCodeTarget(10000), mode.ModeCode, 0)
+	endMs := log[len(log)-1].TimeMs + 1000
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = metrics.Compute(log, mode.ModeCode, endMs)
+	}
+}
+
+func BenchmarkLiveWPMCode10k(b *testing.B) {
+	log := benchLog(benchCodeTarget(10000), mode.ModeCode, 0)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = metrics.LiveWPM(log, 120000)
+	}
+}
+
+func BenchmarkKeyHeatmapCode10k(b *testing.B) {
+	log := benchLog(benchCodeTarget(10000), mode.ModeCode, 0)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = metrics.KeyHeatmap(log)
+	}
+}

--- a/internal/mode/mode.go
+++ b/internal/mode/mode.go
@@ -1,0 +1,27 @@
+// Package mode defines typing-test modes and their selectable lengths.
+package mode
+
+// Mode identifies a test mode. Stored as a string for forward-compatible JSON.
+type Mode string
+
+const (
+	ModeTime  Mode = "time"
+	ModeWords Mode = "words"
+	ModeQuote Mode = "quote"
+	// ModeCode types a user-supplied snippet verbatim. It has no numeric length
+	// and completes on an exact full-text match.
+	ModeCode Mode = "code"
+)
+
+// LengthsFor returns the selectable length options for a mode. Quote and Code
+// modes have no numeric length selector, so they return nil.
+func LengthsFor(m Mode) []int {
+	switch m {
+	case ModeWords:
+		return []int{10, 25, 50, 100}
+	case ModeQuote, ModeCode:
+		return nil
+	default:
+		return []int{15, 30, 60, 120}
+	}
+}

--- a/internal/mode/mode_test.go
+++ b/internal/mode/mode_test.go
@@ -1,0 +1,55 @@
+package mode
+
+import (
+	"reflect"
+	"testing"
+)
+
+var knownModes = []Mode{ModeTime, ModeWords, ModeQuote, ModeCode}
+
+func TestModeStringValues(t *testing.T) {
+	tests := map[Mode]string{
+		ModeTime:  "time",
+		ModeWords: "words",
+		ModeQuote: "quote",
+		ModeCode:  "code",
+	}
+	for m, want := range tests {
+		if string(m) != want {
+			t.Fatalf("%v string = %q, want %q", m, string(m), want)
+		}
+	}
+}
+
+func TestLengthsFor(t *testing.T) {
+	tests := []struct {
+		mode Mode
+		want []int
+	}{
+		{ModeTime, []int{15, 30, 60, 120}},
+		{ModeWords, []int{10, 25, 50, 100}},
+		{ModeQuote, nil},
+		{ModeCode, nil},
+	}
+	for _, tt := range tests {
+		if got := LengthsFor(tt.mode); !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("LengthsFor(%q) = %v, want %v", tt.mode, got, tt.want)
+		}
+	}
+}
+
+func TestLengthsForHandlesEveryKnownMode(t *testing.T) {
+	for _, m := range knownModes {
+		lens := LengthsFor(m)
+		switch m {
+		case ModeQuote, ModeCode:
+			if lens != nil {
+				t.Fatalf("LengthsFor(%q): want nil, got %v", m, lens)
+			}
+		default:
+			if len(lens) == 0 {
+				t.Fatalf("LengthsFor(%q): want options, got %v", m, lens)
+			}
+		}
+	}
+}

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -2,7 +2,7 @@
 package runner
 
 import (
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/mode"
 	"github.com/bavanchun/Typeburn/internal/typing"
 	"github.com/bavanchun/Typeburn/internal/words"
 )
@@ -11,7 +11,7 @@ import (
 type Session struct {
 	Engine   *typing.Engine
 	Target   string
-	Mode     config.Mode
+	Mode     mode.Mode
 	Length   int
 	QuoteLen words.QuoteLen
 	CodeText string
@@ -19,13 +19,13 @@ type Session struct {
 
 // NewSession builds a fresh non-code typing session.
 // seed==0 uses the words package's time-based random seed.
-func NewSession(mode config.Mode, length int, ql words.QuoteLen, seed int64) Session {
+func NewSession(m mode.Mode, length int, ql words.QuoteLen, seed int64) Session {
 	g := words.NewGenerator(seed)
-	target := words.ForMode(g, mode, length, ql)
+	target := words.ForMode(g, m, length, ql)
 	return Session{
-		Engine:   RebuildEngine(target, mode, length),
+		Engine:   RebuildEngine(target, m, length),
 		Target:   target,
-		Mode:     mode,
+		Mode:     m,
 		Length:   length,
 		QuoteLen: ql,
 	}
@@ -34,20 +34,20 @@ func NewSession(mode config.Mode, length int, ql words.QuoteLen, seed int64) Ses
 // NewCodeSession builds a Code-mode session from an already-normalized snippet.
 func NewCodeSession(snippet string) Session {
 	return Session{
-		Engine:   RebuildEngine(snippet, config.ModeCode, 0),
+		Engine:   RebuildEngine(snippet, mode.ModeCode, 0),
 		Target:   snippet,
-		Mode:     config.ModeCode,
+		Mode:     mode.ModeCode,
 		CodeText: snippet,
 	}
 }
 
 // RebuildEngine returns a fresh engine for an existing target.
-func RebuildEngine(target string, mode config.Mode, length int) *typing.Engine {
-	return typing.New(target, mode, wordTarget(mode, length))
+func RebuildEngine(target string, m mode.Mode, length int) *typing.Engine {
+	return typing.New(target, m, wordTarget(m, length))
 }
 
-func wordTarget(mode config.Mode, length int) int {
-	if mode == config.ModeTime {
+func wordTarget(m mode.Mode, length int) int {
+	if m == mode.ModeTime {
 		return length * 1000
 	}
 	return length

--- a/internal/storage/history_benchmark_test.go
+++ b/internal/storage/history_benchmark_test.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+func benchRecord(i int) Record {
+	mode := "time"
+	length := 30
+	if i%2 == 0 {
+		mode = "words"
+		length = 50
+	}
+	return Record{
+		Time:        time.Unix(int64(i), 0).UTC(),
+		Mode:        mode,
+		Length:      length,
+		WPM:         60 + i%80,
+		NetWPM:      float64(60+i%80) + 0.25,
+		RawWPM:      float64(70 + i%90),
+		Accuracy:    95,
+		Consistency: 85,
+	}
+}
+
+func BenchmarkIsNewBestHistory200(b *testing.B) {
+	hist := make([]Record, 200)
+	for i := range hist {
+		hist[i] = benchRecord(i)
+	}
+	candidate := Record{Mode: "time", Length: 30, WPM: 150, NetWPM: 150.5}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = IsNewBest(hist, candidate)
+	}
+}

--- a/internal/storage/new_best.go
+++ b/internal/storage/new_best.go
@@ -1,10 +1,10 @@
 package storage
 
-// modeKey returns the comparison key for new-best scoping.
+// BestBucketKey returns the comparison key for new-best scoping.
 // For time and words modes the key includes the length parameter so that, e.g.,
 // a 60s best does not suppress a 30s best. Quote mode has no numeric length
 // (length is always 0) so the key is just "quote".
-func modeKey(mode string, length int) string {
+func BestBucketKey(mode string, length int) string {
 	switch mode {
 	case "time", "words":
 		// Include length so time/30 and time/60 are separate leaderboards.
@@ -33,17 +33,30 @@ func itoa(n int) string {
 	return string(buf[pos:])
 }
 
-// effWPM returns the effective WPM for new-best comparison as a float64.
+// EffectiveWPM returns the effective WPM for new-best comparison as a float64.
 // Post-fix records carry NetWPM directly. Legacy records (written before this
 // field existed) unmarshal NetWPM as 0.0, so we fall back to float64(WPM) to
 // keep the same integer scale — otherwise a new 60.x run would falsely beat a
 // stored legacy 80. The 0.0-vs-legacy ambiguity is benign: a genuine run that
 // yields NetWPM 0.0 also has WPM == 0, so float64(WPM) returns the correct 0.
-func effWPM(r Record) float64 {
+func EffectiveWPM(r Record) float64 {
 	if r.NetWPM == 0 {
 		return float64(r.WPM)
 	}
 	return r.NetWPM
+}
+
+// BestWPMPerBucket returns the highest effective WPM for each mode+length bucket.
+func BestWPMPerBucket(records []Record) map[string]float64 {
+	bests := make(map[string]float64)
+	for _, r := range records {
+		key := BestBucketKey(r.Mode, r.Length)
+		eff := EffectiveWPM(r)
+		if prev, ok := bests[key]; !ok || eff > prev {
+			bests[key] = eff
+		}
+	}
+	return bests
 }
 
 // IsNewBest reports whether r represents a new personal best for its mode+length
@@ -65,11 +78,11 @@ func IsNewBest(hist []Record, r Record) bool {
 	if r.Mode == "code" {
 		return false
 	}
-	key := modeKey(r.Mode, r.Length)
+	key := BestBucketKey(r.Mode, r.Length)
 	best := -1.0
 	for _, h := range hist {
-		if modeKey(h.Mode, h.Length) == key {
-			if eff := effWPM(h); eff > best {
+		if BestBucketKey(h.Mode, h.Length) == key {
+			if eff := EffectiveWPM(h); eff > best {
 				best = eff
 			}
 		}
@@ -78,5 +91,5 @@ func IsNewBest(hist []Record, r Record) bool {
 	if best < 0 {
 		return true
 	}
-	return effWPM(r) > best
+	return EffectiveWPM(r) > best
 }

--- a/internal/storage/new_best_test.go
+++ b/internal/storage/new_best_test.go
@@ -1,0 +1,57 @@
+package storage
+
+import "testing"
+
+func TestBestBucketKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		mode   string
+		length int
+		want   string
+	}{
+		{name: "time includes length", mode: "time", length: 30, want: "time/30"},
+		{name: "words includes length", mode: "words", length: 50, want: "words/50"},
+		{name: "quote ignores length", mode: "quote", length: 0, want: "quote"},
+		{name: "code ignores length", mode: "code", length: 0, want: "code"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BestBucketKey(tt.mode, tt.length); got != tt.want {
+				t.Fatalf("BestBucketKey(%q, %d) = %q, want %q", tt.mode, tt.length, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveWPM(t *testing.T) {
+	if got := EffectiveWPM(Record{WPM: 80}); got != 80 {
+		t.Fatalf("legacy EffectiveWPM = %v, want 80", got)
+	}
+	if got := EffectiveWPM(Record{WPM: 80, NetWPM: 80.42}); got != 80.42 {
+		t.Fatalf("net EffectiveWPM = %v, want 80.42", got)
+	}
+}
+
+func TestBestWPMPerBucket(t *testing.T) {
+	rows := []Record{
+		{Mode: "time", Length: 30, WPM: 70, NetWPM: 70.1},
+		{Mode: "time", Length: 30, WPM: 75, NetWPM: 75.2},
+		{Mode: "time", Length: 60, WPM: 90, NetWPM: 90.3},
+		{Mode: "words", Length: 50, WPM: 100},
+		{Mode: "quote", WPM: 65, NetWPM: 65.4},
+	}
+
+	bests := BestWPMPerBucket(rows)
+	want := map[string]float64{
+		"time/30":  75.2,
+		"time/60":  90.3,
+		"words/50": 100,
+		"quote":    65.4,
+	}
+	for key, expected := range want {
+		if got := bests[key]; got != expected {
+			t.Fatalf("bests[%q] = %v, want %v", key, got, expected)
+		}
+	}
+}

--- a/internal/typing/completion.go
+++ b/internal/typing/completion.go
@@ -1,7 +1,7 @@
 package typing
 
 import (
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/mode"
 )
 
 // Complete reports whether the test is finished according to the active mode.
@@ -17,13 +17,13 @@ import (
 //     '\n'/'\t' are ordinary target runes).
 func (e *Engine) Complete(nowMs int64) bool {
 	switch e.mode {
-	case config.ModeTime:
+	case mode.ModeTime:
 		return nowMs >= int64(e.wordTarget)
 
-	case config.ModeWords:
+	case mode.ModeWords:
 		return countCompletedWords(e.typed, e.target) >= e.wordTarget
 
-	case config.ModeQuote, config.ModeCode:
+	case mode.ModeQuote, mode.ModeCode:
 		return runesEqual(e.typed, e.target)
 
 	default:

--- a/internal/typing/engine.go
+++ b/internal/typing/engine.go
@@ -1,7 +1,7 @@
 package typing
 
 import (
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/mode"
 )
 
 // Keystroke records a single typed or deleted character event.
@@ -24,7 +24,7 @@ type Engine struct {
 	typed      []rune
 	log        []Keystroke
 	startMs    int64 // 0 until first Apply call
-	mode       config.Mode
+	mode       mode.Mode
 	wordTarget int // Words: N words to complete; Time: limit in ms; Quote: unused (0)
 }
 
@@ -32,7 +32,7 @@ type Engine struct {
 // For ModeWords, wordTarget is the number of words to type.
 // For ModeTime, wordTarget is the time limit in milliseconds.
 // For ModeQuote, wordTarget is ignored (0).
-func New(target string, mode config.Mode, wordTarget int) *Engine {
+func New(target string, mode mode.Mode, wordTarget int) *Engine {
 	return &Engine{
 		target:     []rune(target),
 		mode:       mode,
@@ -143,12 +143,30 @@ func (e *Engine) Log() []Keystroke {
 	return out
 }
 
+// Typed returns the current typed buffer after applying backspaces.
+func (e *Engine) Typed() []rune {
+	out := make([]rune, len(e.typed))
+	copy(out, e.typed)
+	return out
+}
+
+// ForwardKeystrokes returns how many non-backspace events are in the log.
+func (e *Engine) ForwardKeystrokes() int {
+	n := 0
+	for _, k := range e.log {
+		if k.Typed != 0 {
+			n++
+		}
+	}
+	return n
+}
+
 // Progress returns (done, total) for the current mode:
 //   - ModeWords / ModeTime: (completedWords, wordTarget)
 //   - ModeQuote:            (typedRunes, totalTargetRunes)
 func (e *Engine) Progress() (done, total int) {
 	switch e.mode {
-	case config.ModeQuote:
+	case mode.ModeQuote:
 		typed := len(e.typed)
 		if typed > len(e.target) {
 			typed = len(e.target)

--- a/internal/typing/engine_benchmark_test.go
+++ b/internal/typing/engine_benchmark_test.go
@@ -1,0 +1,73 @@
+package typing_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/mode"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+func benchWordsTarget(n int) string {
+	words := make([]string, n)
+	for i := range words {
+		words[i] = "alpha"
+	}
+	return strings.Join(words, " ")
+}
+
+func benchCodeTarget(n int) string {
+	var b strings.Builder
+	for b.Len() < n {
+		b.WriteString("func main() {\n\tprintln(\"typeburn\")\n}\n")
+	}
+	return b.String()[:n]
+}
+
+func benchFilledEngine(target string, m mode.Mode, wordTarget int) *typing.Engine {
+	e := typing.New(target, m, wordTarget)
+	for i, r := range target {
+		e.Apply(r, int64(i+1))
+	}
+	return e
+}
+
+func BenchmarkEngineApplyWords100(b *testing.B) {
+	target := benchWordsTarget(100)
+	runes := []rune(target)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		e := typing.New(target, mode.ModeWords, 100)
+		for j, r := range runes {
+			e.Apply(r, int64(j+1))
+		}
+	}
+}
+
+func BenchmarkEngineApplyCode10k(b *testing.B) {
+	target := benchCodeTarget(10000)
+	runes := []rune(target)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		e := typing.New(target, mode.ModeCode, 0)
+		for j, r := range runes {
+			e.Apply(r, int64(j+1))
+		}
+	}
+}
+
+func BenchmarkEngineStatesCode10k(b *testing.B) {
+	e := benchFilledEngine(benchCodeTarget(10000), mode.ModeCode, 0)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = e.States()
+	}
+}
+
+func BenchmarkEngineLogCode10k(b *testing.B) {
+	e := benchFilledEngine(benchCodeTarget(10000), mode.ModeCode, 0)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = e.Log()
+	}
+}

--- a/internal/typing/snapshot_test.go
+++ b/internal/typing/snapshot_test.go
@@ -1,0 +1,39 @@
+package typing_test
+
+import (
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/mode"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+func TestTypedReturnsCurrentBufferCopy(t *testing.T) {
+	e := typing.New("hello", mode.ModeWords, 1)
+	e.Apply('h', 100)
+	e.Apply('x', 200)
+	e.Backspace(300)
+	e.Apply('e', 400)
+
+	got := e.Typed()
+	if string(got) != "he" {
+		t.Fatalf("Typed() = %q, want %q", string(got), "he")
+	}
+
+	got[0] = 'x'
+	again := e.Typed()
+	if string(again) != "he" {
+		t.Fatalf("Typed() leaked mutable state: got %q", string(again))
+	}
+}
+
+func TestForwardKeystrokesIgnoresBackspace(t *testing.T) {
+	e := typing.New("hello", mode.ModeWords, 1)
+	e.Apply('h', 100)
+	e.Apply('x', 200)
+	e.Backspace(300)
+	e.Apply('e', 400)
+
+	if got := e.ForwardKeystrokes(); got != 3 {
+		t.Fatalf("ForwardKeystrokes() = %d, want 3", got)
+	}
+}

--- a/internal/ui/history_table.go
+++ b/internal/ui/history_table.go
@@ -20,43 +20,6 @@ const (
 	colConsW = 7
 )
 
-// effWPM returns the effective WPM for new-best comparison as a float64.
-// Records written before the NetWPM field was added unmarshal as 0.0; the
-// fallback to float64(WPM) keeps the same integer scale so an old record's
-// best is not unfairly overridden by any new run with a lower rounded WPM.
-func effWPM(r storage.Record) float64 {
-	if r.NetWPM == 0 {
-		return float64(r.WPM)
-	}
-	return r.NetWPM
-}
-
-// bestWPMPerBucket returns the highest effective WPM for each mode+length bucket
-// across all provided records. The key format matches storage.IsNewBest scoping.
-// Effective WPM uses the persisted NetWPM float when present, falling back to
-// float64(WPM) for legacy records so the scale comparison is consistent.
-func bestWPMPerBucket(rows []storage.Record) map[string]float64 {
-	bests := make(map[string]float64)
-	for _, r := range rows {
-		key := histBucketKey(r.Mode, r.Length)
-		eff := effWPM(r)
-		if prev, ok := bests[key]; !ok || eff > prev {
-			bests[key] = eff
-		}
-	}
-	return bests
-}
-
-// histBucketKey mirrors storage.modeKey logic for UI use.
-func histBucketKey(mode string, length int) string {
-	switch mode {
-	case "time", "words":
-		return fmt.Sprintf("%s/%d", mode, length)
-	default:
-		return mode
-	}
-}
-
 // renderHistoryHeader renders the UPPERCASE header row with border rules above
 // and below, styled in RoleTextMuted per mockups §5.
 func renderHistoryHeader(th theme.Theme) string {

--- a/internal/ui/render_benchmark_test.go
+++ b/internal/ui/render_benchmark_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+func benchWordsTarget(n int) string {
+	words := make([]string, n)
+	for i := range words {
+		words[i] = "alpha"
+	}
+	return strings.Join(words, " ")
+}
+
+func benchCodeTarget(n int) string {
+	var b strings.Builder
+	for b.Len() < n {
+		b.WriteString("func main() {\n\tprintln(\"typeburn\")\n}\n")
+	}
+	return b.String()[:n]
+}
+
+func benchFilledEngine(target string, mode config.Mode, wordTarget int) *typing.Engine {
+	e := typing.New(target, mode, wordTarget)
+	for i, r := range target {
+		e.Apply(r, int64(i+1))
+	}
+	return e
+}
+
+func BenchmarkRenderWordStreamWords100(b *testing.B) {
+	target := benchWordsTarget(100)
+	e := benchFilledEngine(target, config.ModeWords, 100)
+	states := e.States()
+	typed := typedFromLog(e.Log())
+	targetRunes := []rune(target)
+	th := theme.Default()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = RenderWordStream(states, targetRunes, typed, 100, th)
+	}
+}
+
+func BenchmarkRenderCodeStreamCode10k(b *testing.B) {
+	target := benchCodeTarget(10000)
+	e := benchFilledEngine(target, config.ModeCode, 0)
+	states := e.States()
+	typed := typedFromLog(e.Log())
+	targetRunes := []rune(target)
+	th := theme.Default()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = RenderCodeStream(states, targetRunes, typed, 100, 20, th)
+	}
+}
+
+func BenchmarkTypingViewCode10k(b *testing.B) {
+	target := benchCodeTarget(10000)
+	th := theme.Default()
+	km := config.DefaultKeymap()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		m := NewTypingCode(target, th, km, false).SetSize(120, 40)
+		m.eng = benchFilledEngine(target, config.ModeCode, 0)
+		m.startMs = 1
+		m.nowMs = 100000
+		_ = m.View()
+	}
+}

--- a/internal/ui/screen_history_view.go
+++ b/internal/ui/screen_history_view.go
@@ -5,6 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
+	"github.com/bavanchun/Typeburn/internal/storage"
 	"github.com/bavanchun/Typeburn/internal/theme"
 )
 
@@ -46,7 +47,7 @@ func (m HistoryModel) View() string {
 
 		// Windowed rows.
 		vis := m.visibleCount()
-		bests := bestWPMPerBucket(m.rows)
+		bests := storage.BestWPMPerBucket(m.rows)
 
 		end := m.top + vis
 		if end > n {
@@ -54,12 +55,12 @@ func (m HistoryModel) View() string {
 		}
 		for i := m.top; i < end; i++ {
 			r := rows[i]
-			key := histBucketKey(r.Mode, r.Length)
+			key := storage.BestBucketKey(r.Mode, r.Length)
 			// Compare effective WPM against the persisted bucket best.
 			// Float equality is safe here: we compare the same stored value
-			// (effWPM(r)) against what bestWPMPerBucket already derived from
+			// (EffectiveWPM(r)) against what BestWPMPerBucket already derived from
 			// the same records — no recomputation drift possible.
-			isBestRow := effWPM(r) == bests[key]
+			isBestRow := storage.EffectiveWPM(r) == bests[key]
 			body.WriteString(renderHistoryRow(r, i == m.sel, isBestRow, m.th))
 			body.WriteString("\n")
 		}

--- a/internal/ui/screen_typing.go
+++ b/internal/ui/screen_typing.go
@@ -105,7 +105,7 @@ func (m TypingModel) handleTick(msg tickMsg) (TypingModel, tea.Cmd) {
 
 	// Recompute live WPM at ~250ms cadence to limit style recomputation.
 	if m.nowMs-m.lastPaintMs >= 250 {
-		m.headerWPM = liveWPM(m.eng.Log(), elapsed)
+		m.headerWPM = liveWPMFromCount(m.eng.ForwardKeystrokes(), elapsed)
 		m.lastPaintMs = m.nowMs
 	}
 

--- a/internal/ui/screen_typing_view.go
+++ b/internal/ui/screen_typing_view.go
@@ -45,7 +45,7 @@ func (m TypingModel) View() string {
 		stream = RenderCodeStream(
 			m.eng.States(),
 			[]rune(m.target),
-			typedFromLog(m.eng.Log()),
+			m.eng.Typed(),
 			cw,
 			streamHeight,
 			m.th,
@@ -54,7 +54,7 @@ func (m TypingModel) View() string {
 		stream = RenderWordStream(
 			m.eng.States(),
 			[]rune(m.target),
-			typedFromLog(m.eng.Log()),
+			m.eng.Typed(),
 			cw,
 			m.th,
 		)

--- a/internal/ui/typing_log_helpers.go
+++ b/internal/ui/typing_log_helpers.go
@@ -12,6 +12,11 @@ func liveWPM(log []typing.Keystroke, elapsedMs int64) float64 {
 	return metrics.LiveWPM(log, elapsedMs)
 }
 
+// liveWPMFromCount estimates current WPM from a forward-keystroke count.
+func liveWPMFromCount(forward int, elapsedMs int64) float64 {
+	return metrics.LiveWPMFromCount(forward, elapsedMs)
+}
+
 // typedFromLog reconstructs the current typed-rune slice by replaying the
 // keystroke log. Engine.typed is unexported; the log is the public API.
 // Backspace events (Typed==0) pop the last rune, mirroring Engine internals.

--- a/internal/words/for_mode.go
+++ b/internal/words/for_mode.go
@@ -1,7 +1,7 @@
 package words
 
 import (
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/mode"
 )
 
 // ForMode returns the target string for a typing test given the active mode
@@ -14,11 +14,11 @@ import (
 //   - ModeWords: length is the word count (10/25/50/100); returns exactly that
 //     many space-separated words.
 //   - ModeQuote: ql selects the desired quote bucket; length is ignored.
-func ForMode(g *Generator, mode config.Mode, length int, ql QuoteLen) string {
-	switch mode {
-	case config.ModeWords:
+func ForMode(g *Generator, m mode.Mode, length int, ql QuoteLen) string {
+	switch m {
+	case mode.ModeWords:
 		return g.Words(length)
-	case config.ModeQuote:
+	case mode.ModeQuote:
 		return g.Quote(ql).Text
 	default: // ModeTime and any future modes default to a time buffer
 		return g.TimeBuffer()

--- a/plans/260604-1354-architecture-performance-hardening/phase-01-benchmark-baseline.md
+++ b/plans/260604-1354-architecture-performance-hardening/phase-01-benchmark-baseline.md
@@ -1,0 +1,103 @@
+---
+phase: 1
+title: Benchmark Baseline
+status: completed
+priority: P1
+effort: 1.5h
+dependencies: []
+---
+
+# Phase 1: Benchmark Baseline
+
+## Context Links
+
+- Audit targets: `internal/typing`, `internal/metrics`, `internal/ui`,
+  `internal/storage`
+- Existing test strength: `typing` 96.2%, `metrics` 94.0%, `ui` 87.3%
+- Current gap: no `Benchmark*` functions found by `rg 'func Benchmark'`
+
+## Overview
+
+Create repeatable Go benchmarks for the audited hot paths. This phase must not
+change production behavior. It creates the data gate for later work.
+
+## Requirements
+
+- Functional: add benchmark functions only; no app behavior change.
+- Non-functional: benchmark data covers realistic and worst-case sizes, including
+  Code mode 10k runes.
+- Process: run baseline benchmarks before any optimization/refactor.
+
+## Architecture
+
+Benchmarks stay in package-local `_test.go` files so they can use existing
+constructors and test helpers without adding public API. Use deterministic test
+data and fixed timestamps. Avoid golden output comparison inside benchmarks.
+
+## File Inventory
+
+| File | Action | Rough size | Test impact |
+|---|---:|---:|---|
+| `internal/typing/engine_benchmark_test.go` | Create | <120 LOC | Engine apply/log/states |
+| `internal/metrics/metrics_benchmark_test.go` | Create | <140 LOC | Compute/live WPM/key heatmap |
+| `internal/ui/render_benchmark_test.go` | Create | <180 LOC | Word/code stream + TypingModel view |
+| `internal/storage/history_benchmark_test.go` | Create | <100 LOC | Best buckets/history append helpers |
+
+## Test Scenario Matrix
+
+| Scenario | Criticality | Benchmark |
+|---|---|---|
+| 100-word normal typing | High | `BenchmarkEngineApplyWords100` |
+| Code 10k sequential paste-like input | Critical | `BenchmarkEngineApplyCode10k` |
+| `Engine.States()` over 10k runes | Critical | `BenchmarkEngineStatesCode10k` |
+| `metrics.Compute()` over 10k log | High | `BenchmarkMetricsComputeCode10k` |
+| `metrics.LiveWPM()` over 10k log | Medium | `BenchmarkLiveWPMCode10k` |
+| Word stream render | High | `BenchmarkRenderWordStreamWords100` |
+| Code stream render 10k | Critical | `BenchmarkRenderCodeStreamCode10k` |
+| Full typing view Code 10k | Critical | `BenchmarkTypingViewCode10k` |
+| Best bucket over 200 records | Medium | `BenchmarkBestBucketHistory200` |
+
+## Dependency Map
+
+```text
+typing benchmarks -> internal/typing only
+metrics benchmarks -> typing.Keystroke + metrics
+ui benchmarks -> typing.Engine + ui renderers + theme/config
+storage benchmarks -> storage.Record helpers
+```
+
+## Implementation Steps
+
+1. Create deterministic target builders:
+   - words text around 100 words
+   - code text near 10k runes with newlines/tabs
+   - timed logs with fixed millisecond increments
+2. Add `internal/typing` benchmarks for `Apply`, `Backspace`, `Log`, `States`.
+3. Add `internal/metrics` benchmarks for `Compute`, `LiveWPM`, `KeyHeatmap`.
+4. Add `internal/ui` benchmarks for `RenderWordStream`, `RenderCodeStream`,
+   and full `TypingModel.View`.
+5. Add `internal/storage` benchmark for current best-bucket/new-best path.
+6. Run:
+   ```sh
+   go test ./internal/typing ./internal/metrics ./internal/ui ./internal/storage -bench . -benchmem
+   ```
+7. Save benchmark output in the PR description or a plan report, not as brittle
+   hardcoded thresholds.
+
+## Success Criteria
+
+- [ ] `rg 'func Benchmark' internal` finds benchmark coverage for all 4 areas.
+- [ ] Benchmark command runs successfully.
+- [ ] Benchmarks do not require network, terminal TTY, env-specific files, or
+      external tools.
+- [ ] No production code changed in this phase.
+- [ ] Phase 2 decision is made from measured data.
+
+## Risk Assessment
+
+- Risk: noisy benchmark numbers. Mitigation: focus on relative before/after and
+  allocations, not exact CI thresholds.
+- Risk: benchmark helpers grow files over 200 LOC. Mitigation: split by package
+  and keep builders local.
+- Risk: benchmark accidentally mutates shared state. Mitigation: create fresh
+  engine/model inside each benchmark iteration.

--- a/plans/260604-1354-architecture-performance-hardening/phase-02-typing-snapshot-optimization.md
+++ b/plans/260604-1354-architecture-performance-hardening/phase-02-typing-snapshot-optimization.md
@@ -1,0 +1,120 @@
+---
+phase: 2
+title: Typing Snapshot Optimization
+status: completed
+priority: P2
+effort: 1.5h
+dependencies:
+  - 1
+---
+
+# Phase 2: Typing Snapshot Optimization
+
+## Context Links
+
+- Hot path: `internal/ui/screen_typing_view.go`
+- Engine copy API: `internal/typing/engine.go`
+- Replay helper: `internal/ui/typing_log_helpers.go`
+- Live WPM path: `internal/ui/screen_typing.go`, `internal/metrics/live_wpm.go`
+
+## Overview
+
+Reduce typing-screen allocation/time only if Phase 1 proves a meaningful issue.
+Expected fix is a small immutable snapshot API on `typing.Engine`, not a
+renderer rewrite.
+
+## Requirements
+
+- Functional: rendered output and completion behavior unchanged.
+- Non-functional: lower `TypingModel.View` and/or live WPM hot-path allocations
+  for Code 10k or equivalent worst case.
+- Guardrail: skip production optimization if benchmarks show current cost is
+  already negligible.
+
+## Architecture
+
+Candidate approach:
+
+```go
+type Snapshot struct {
+    States []CharState
+    Typed  []rune
+    Log    []Keystroke // optional; include only if needed
+}
+
+func (e *Engine) Snapshot() Snapshot
+```
+
+The snapshot may copy data to preserve encapsulation, but should avoid multiple
+copies/replays per render. UI receives states + typed runes from one engine
+call. If only typed runes are needed, prefer narrower `Typed()` plus existing
+`States()`.
+
+## File Inventory
+
+| File | Action | Rough size | Test impact |
+|---|---:|---:|---|
+| `internal/typing/engine.go` | Modify | 161 LOC now | Add snapshot/typed API, keep <200 |
+| `internal/typing/engine_test.go` | Modify | 187 LOC now | May need split to stay <200 |
+| `internal/typing/snapshot_test.go` | Create | <120 LOC | Snapshot immutability/regression |
+| `internal/ui/screen_typing_view.go` | Modify | 76 LOC | Use snapshot/typed API |
+| `internal/ui/typing_log_helpers.go` | Modify/Delete helper | 30 LOC | Remove replay if obsolete |
+| `internal/ui/screen_typing_test.go` | Modify | 256 LOC now | Consider new focused test file |
+| `internal/ui/render_benchmark_test.go` | Modify | from Phase 1 | Before/after comparison |
+
+## Test Scenario Matrix
+
+| Scenario | Criticality | Protection |
+|---|---|---|
+| Snapshot cannot mutate engine internals | Critical | New unit test |
+| Apply/backspace state unchanged | Critical | Existing engine tests |
+| Word typing view unchanged semantically | High | Existing UI tests |
+| Code typing view with newlines/tabs unchanged | High | Existing code renderer tests |
+| Paste multi-rune behavior unchanged | Medium | Existing paste tests |
+| Benchmarks improve or justify skip | Critical | Phase 1 benchmarks |
+
+## Dependency Map
+
+```text
+typing.Engine snapshot API
+└── ui.TypingModel.View consumes snapshot
+    ├── RenderWordStream unchanged
+    └── RenderCodeStream unchanged
+```
+
+## Implementation Steps
+
+1. Review Phase 1 benchmark output.
+2. If no meaningful bottleneck, mark this phase as skipped/deferred in plan
+   notes and do not change code.
+3. If bottleneck exists, write tests first:
+   - snapshot/typed API returns expected runes after apply/backspace
+   - modifying returned slices does not mutate engine
+4. Add the narrowest engine API needed:
+   - prefer `Typed()` if only replay removal is needed
+   - use `Snapshot()` only if it removes multiple hot-path calls
+5. Update `TypingModel.View()` to avoid `typedFromLog(m.eng.Log())`.
+6. Remove or limit `typedFromLog` if no longer used by production.
+7. Re-run benchmarks from Phase 1 and compare before/after.
+8. Run targeted tests:
+   ```sh
+   go test ./internal/typing ./internal/ui -count=1
+   ```
+
+## Success Criteria
+
+- [ ] Production optimization is backed by benchmark data, or explicitly skipped.
+- [ ] No render behavior regressions.
+- [ ] Returned engine data cannot mutate engine internals.
+- [ ] Benchmark before/after shows lower allocations or time for the measured
+      hot path if code changed.
+- [ ] `go test ./internal/typing ./internal/ui -count=1` passes.
+
+## Risk Assessment
+
+- Risk: overexposing engine internals. Mitigation: copies or immutable contract
+  with tests.
+- Risk: optimizing away useful log API consistency. Mitigation: keep `Log()` for
+  metrics/post-hoc replay; add narrow UI helper only.
+- Risk: file-size violation in `engine.go` or tests. Mitigation: create
+  `snapshot_test.go` and split helpers.

--- a/plans/260604-1354-architecture-performance-hardening/phase-03-mode-layering-refactor.md
+++ b/plans/260604-1354-architecture-performance-hardening/phase-03-mode-layering-refactor.md
@@ -1,0 +1,128 @@
+---
+phase: 3
+title: Mode Layering Refactor
+status: completed
+priority: P1
+effort: 1.5h
+dependencies:
+  - 1
+---
+
+# Phase 3: Mode Layering Refactor
+
+## Context Links
+
+- Current mode definitions: `internal/config/settings.go`
+- Bubble Tea keymap: `internal/config/keymap.go`
+- Pure packages importing config: `internal/typing`, `internal/metrics`,
+  `internal/words`, `internal/storage`, `internal/runner`
+- Architecture doc drift: `docs/system-architecture.md`
+
+## Overview
+
+Move test mode definitions out of `internal/config` so typing/metrics/words and
+runner do not depend on the UI keymap package for `Mode`. This is architecture
+cleanup, not a behavior change. It deliberately keeps `config.Keymap` in
+`internal/config` per current repo rules.
+
+## Requirements
+
+- Functional: all existing mode strings and JSON values stay identical.
+- Non-functional: packages that only need `Mode` import `internal/mode`, not
+  `internal/config`.
+- Compatibility: persisted settings/history JSON remains backward-compatible.
+
+## Architecture
+
+Create a small domain package:
+
+```text
+internal/mode
+├── mode.go       # Mode enum: time, words, quote, code
+└── lengths.go    # LengthsFor
+```
+
+Then `config.Settings.DefaultMode` becomes `mode.Mode`. Existing callers import
+`internal/mode` directly when they only need mode constants/options. `config`
+continues to expose settings/keymap/XDG; keymap stays the Bubble Tea input
+boundary unless a later user-approved plan changes that.
+
+## File Inventory
+
+| File | Action | Rough size | Test impact |
+|---|---:|---:|---|
+| `internal/mode/mode.go` | Create | <80 LOC | New mode tests |
+| `internal/mode/mode_test.go` | Create | <120 LOC | LengthsFor + known modes |
+| `internal/config/settings.go` | Modify | 87 LOC | Settings uses `mode.Mode` |
+| `internal/config/settings_test.go` | Modify | 248 LOC now | Consider split if touched heavily |
+| `internal/config/mode_seam_sync_test.go` | Move/modify | 48 LOC | Move to `mode` or adapt imports |
+| `internal/typing/*.go` | Modify imports | small | Existing tests |
+| `internal/metrics/*.go` | Modify imports | small | Existing tests |
+| `internal/words/*.go` | Modify imports | small | Existing tests |
+| `internal/runner/session.go` | Modify imports | 54 LOC | Existing tests |
+| `internal/storage/*.go` | Usually unchanged | small | Existing tests |
+| `internal/ui`, `internal/app`, `internal/cli` | Modify imports | broad | Existing tests |
+
+## Test Scenario Matrix
+
+| Scenario | Criticality | Protection |
+|---|---|---|
+| Mode string values unchanged | Critical | `mode` tests |
+| Settings JSON still round-trips | Critical | `config` + `storage` tests |
+| Unknown mode normalizes to time | High | Existing settings tests |
+| Code mode has no length selector | High | Existing mode seam tests |
+| Mode-only packages stop importing config | Critical | `go list`/grep check |
+| CLI flag parsing accepts all modes | High | Existing CLI tests |
+
+## Dependency Map
+
+```text
+mode (new pure domain)
+├── config.Settings
+├── typing.Engine
+├── metrics.Compute
+├── words.ForMode
+├── runner.Session
+├── ui/app/cli call sites
+└── storage only if mode helpers are genuinely needed
+
+config.Keymap -> Bubble Tea remains allowed
+```
+
+## Implementation Steps
+
+1. Add `internal/mode` with `Mode` constants and `LengthsFor`.
+2. Move/adapt mode seam tests to `internal/mode`.
+3. Update `config.Settings` to use `mode.Mode`; keep JSON tags identical.
+4. Replace `config.Mode*` call sites with `mode.Mode*` where the caller does not
+   need settings/keymap.
+5. Keep `config.DefaultKeymap()` and `config.Keymap` unchanged unless a trivial
+   import cleanup is needed.
+6. Run:
+   ```sh
+   go test ./internal/mode ./internal/config ./internal/typing ./internal/metrics ./internal/words ./internal/runner -count=1
+   ```
+7. Verify mode-only packages no longer import config:
+   ```sh
+   go list -f '{{.ImportPath}} {{join .Imports " "}}' ./internal/typing ./internal/metrics ./internal/words ./internal/runner | rg 'internal/config'
+   ```
+   Expected: no matches after the refactor.
+
+## Success Criteria
+
+- [ ] New `internal/mode` package owns mode enum and length options.
+- [ ] Mode-only packages use `internal/mode`, not `internal/config`, when they
+      only need mode data.
+- [ ] Persisted settings/history compatibility is unchanged.
+- [ ] Existing CLI/UI behavior remains unchanged.
+- [ ] Targeted tests and import-edge check pass.
+
+## Risk Assessment
+
+- Risk: import cycles. Mitigation: `mode` imports nothing project-local.
+- Risk: widespread call-site churn. Mitigation: mechanical import change, no
+  behavior changes.
+- Risk: docs/tests still refer to `config.Mode` as source of truth. Mitigation:
+  Phase 5 docs sweep and rg for stale references.
+- Risk: reviewer asks to move `Keymap` too. Mitigation: reject in this plan
+  unless user explicitly approves reversing the current `CLAUDE.md` boundary.

--- a/plans/260604-1354-architecture-performance-hardening/phase-04-best-bucket-dry.md
+++ b/plans/260604-1354-architecture-performance-hardening/phase-04-best-bucket-dry.md
@@ -1,0 +1,106 @@
+---
+phase: 4
+title: Best Bucket DRY
+status: completed
+priority: P2
+effort: 1h
+dependencies:
+  - 1
+---
+
+# Phase 4: Best Bucket DRY
+
+## Context Links
+
+- Storage source: `internal/storage/new_best.go`
+- UI duplicate: `internal/ui/history_table.go`
+- History view call site: `internal/ui/screen_history_view.go`
+- Existing tests: `internal/storage/history_store_test.go`,
+  `internal/ui/screen_history_test.go`
+
+## Overview
+
+Remove duplicated best-bucket/effective-WPM logic between storage and UI. Keep
+the accepted legacy `NetWPM==0` fallback exactly as-is.
+
+## Requirements
+
+- Functional: history stars and `IsNewBest` behavior unchanged.
+- Non-functional: one source of truth for bucket key and effective WPM logic.
+- Compatibility: no storage schema change.
+
+## Architecture
+
+Preferred approach: export storage helpers with domain names:
+
+```go
+func EffectiveWPM(r Record) float64
+func BestBucketKey(mode string, length int) string
+func BestWPMPerBucket(records []Record) map[string]float64
+```
+
+UI history rendering consumes these helpers. `IsNewBest` also uses them. Keep
+storage as owner because best-bucket semantics belong to persisted history, not
+rendering.
+
+## File Inventory
+
+| File | Action | Rough size | Test impact |
+|---|---:|---:|---|
+| `internal/storage/new_best.go` | Modify | 82 LOC | Export helpers, keep old behavior |
+| `internal/storage/history_store_test.go` | Modify | 370 LOC now | Consider new `new_best_test.go` split |
+| `internal/storage/new_best_test.go` | Create | <140 LOC | Helper-level tests if splitting |
+| `internal/ui/history_table.go` | Modify | 149 LOC | Remove duplicate helpers |
+| `internal/ui/screen_history_view.go` | Modify | small | Use storage helpers |
+| `internal/ui/screen_history_test.go` | Existing | 234 LOC | Existing star tests should pass |
+
+## Test Scenario Matrix
+
+| Scenario | Criticality | Protection |
+|---|---|---|
+| First bucket result is best | High | Existing storage tests |
+| Higher NetWPM wins | Critical | Existing storage tests |
+| Equal WPM not new best | High | Existing storage tests |
+| Legacy `NetWPM==0` falls back to `WPM` | Critical | Existing storage test |
+| Code mode never best | High | Existing storage test |
+| History star marks same bucket best | High | Existing UI test |
+
+## Dependency Map
+
+```text
+storage.BestWPMPerBucket
+├── storage.IsNewBest
+└── ui.screen_history_view / history_table
+```
+
+## Implementation Steps
+
+1. Write or move tests for exported helper names before changing UI:
+   - `EffectiveWPM`
+   - `BestBucketKey`
+   - `BestWPMPerBucket`
+2. Rename unexported helpers or add exported wrappers in `storage`.
+3. Update `IsNewBest` to use exported helpers.
+4. Remove duplicate `effWPM`, `histBucketKey`, `bestWPMPerBucket` from UI.
+5. Update UI history rendering to call storage helpers.
+6. Run:
+   ```sh
+   go test ./internal/storage ./internal/ui -count=1
+   ```
+
+## Success Criteria
+
+- [ ] Best-bucket logic has one source of truth in `internal/storage`.
+- [ ] Legacy fallback behavior unchanged and tested.
+- [ ] History stars render unchanged.
+- [ ] No storage schema migration.
+- [ ] Targeted tests pass.
+
+## Risk Assessment
+
+- Risk: exported helper names become public-ish API. Mitigation: package is
+  internal; names should be clear and stable.
+- Risk: UI imports more storage semantics. Mitigation: UI already consumes
+  `storage.Record`; this reduces duplication.
+- Risk: accidental schema change. Mitigation: do not touch `Record` fields or
+  JSON tags.

--- a/plans/260604-1354-architecture-performance-hardening/phase-05-docs-and-verification.md
+++ b/plans/260604-1354-architecture-performance-hardening/phase-05-docs-and-verification.md
@@ -1,0 +1,121 @@
+---
+phase: 5
+title: Docs and Verification
+status: completed
+priority: P1
+effort: 1h
+dependencies:
+  - 1
+  - 2
+  - 3
+  - 4
+---
+
+# Phase 5: Docs and Verification
+
+## Context Links
+
+- Docs source of truth: `docs/system-architecture.md`,
+  `docs/codebase-summary.md`, `docs/code-standards.md`,
+  `docs/project-roadmap.md`
+- Required gates: `go test ./... -race -count=1`, `go vet ./...`, empty
+  `gofmt -l .`
+
+## Overview
+
+Sync docs to the final architecture and run the full verification gate. This
+phase closes the plan and prevents docs/source drift.
+
+## Requirements
+
+- Functional: docs accurately describe package layering, benchmark coverage,
+  Mode ownership, and best-bucket ownership.
+- Non-functional: full CI gate passes; benchmark command runs.
+- Process: whole-plan consistency sweep before implementation handoff.
+
+## Architecture
+
+Docs must describe actual source:
+
+```text
+internal/mode     -> pure test mode enum/options
+internal/config   -> settings, keymap, XDG paths; keymap is Bubble Tea boundary by repo rule
+internal/typing   -> engine; imports mode for completion/progress
+internal/metrics  -> metrics; imports mode/typing
+internal/storage  -> history/settings persistence + best bucket helpers
+internal/ui/app   -> Bubble Tea/Lip Gloss surfaces
+```
+
+## File Inventory
+
+| File | Action | Rough size | Test impact |
+|---|---:|---:|---|
+| `docs/system-architecture.md` | Modify | docs | Fix config/mode layering |
+| `docs/codebase-summary.md` | Modify | docs | Add `internal/mode`, benchmarks |
+| `docs/code-standards.md` | Modify if needed | docs | Update pure-layer wording |
+| `docs/project-roadmap.md` | Modify if needed | docs | Add completed hardening note |
+| `plans/.../plan.md` | Review | docs | Consistency sweep |
+| `plans/.../phase-*.md` | Review | docs | Consistency sweep |
+
+## Test Scenario Matrix
+
+| Scenario | Criticality | Command |
+|---|---|---|
+| Full race suite | Critical | `go test ./... -race -count=1` |
+| Vet clean | Critical | `go vet ./...` |
+| Format clean | Critical | `gofmt -l .` |
+| Benchmark suite runs | High | `go test ./internal/typing ./internal/metrics ./internal/ui ./internal/storage -bench . -benchmem` |
+| Mode-only imports clean | High | `go list -f ... ./internal/typing ./internal/metrics ./internal/words ./internal/runner | rg 'internal/config'` |
+| Docs no stale `config.Mode` ownership claims | Medium | `rg 'config\\.Mode|Zero Bubble Tea Imports|Benchmark' docs` |
+
+## Dependency Map
+
+```text
+P2/P3/P4 final source state -> docs sync -> full verification -> implementation handoff
+```
+
+## Implementation Steps
+
+1. Update `docs/system-architecture.md`:
+   - add `internal/mode`
+   - clarify `internal/config` has Bubble Tea keymap boundary
+   - remove stale zero-Bubble-Tea claim for `config`
+2. Update `docs/codebase-summary.md`:
+   - add package summary for `internal/mode`
+   - note benchmark files and intended use
+   - update best-bucket ownership
+3. Update `docs/code-standards.md` only if wording conflicts with source.
+4. Update `docs/project-roadmap.md` with a concise hardening entry if this work
+   is release-significant.
+5. Run stale-term sweep:
+   ```sh
+   rg 'config\\.Mode|Zero Bubble Tea Imports|typedFromLog|effWPM|histBucketKey' docs internal plans/260604-1354-architecture-performance-hardening
+   ```
+6. Run full gates:
+   ```sh
+   go test ./... -race -count=1
+   go vet ./...
+   gofmt -l .
+   go test ./internal/typing ./internal/metrics ./internal/ui ./internal/storage -bench . -benchmem
+   go list -f '{{.ImportPath}} {{join .Imports " "}}' ./internal/typing ./internal/metrics ./internal/words ./internal/runner | rg 'internal/config'
+   ```
+7. Re-read `plan.md` and every `phase-*.md`; remove stale assumptions created
+   by red-team/validation or implementation decisions.
+
+## Success Criteria
+
+- [ ] Docs match final package architecture.
+- [ ] No stale docs claim that `config` is pure/zero Bubble Tea if keymap remains
+      there.
+- [ ] Full race/vet/gofmt gates pass.
+- [ ] Benchmark command runs and output is available for review.
+- [ ] Plan files have no contradictions after consistency sweep.
+
+## Risk Assessment
+
+- Risk: docs overpromise performance gains. Mitigation: state measured results
+  only; no invented thresholds.
+- Risk: stale terms remain in journals. Mitigation: evergreen docs matter most;
+  old journals may preserve history and do not need rewriting.
+- Risk: plan files reference rejected decisions. Mitigation: whole-plan
+  consistency sweep before handoff.

--- a/plans/260604-1354-architecture-performance-hardening/plan.md
+++ b/plans/260604-1354-architecture-performance-hardening/plan.md
@@ -1,0 +1,135 @@
+---
+title: Architecture Performance Hardening
+description: >-
+  Measure Typeburn typing/render hot paths, fix only proven performance issues,
+  clean pure-core layering, dedupe best-bucket logic, and sync docs.
+status: completed
+priority: P2
+effort: 6h
+branch: fix/roadmap-v2-4-current-stable
+tags:
+  - refactor
+  - performance
+  - tech-debt
+blockedBy: []
+blocks: []
+created: '2026-06-04T06:54:53.850Z'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Architecture Performance Hardening
+
+## Overview
+
+This plan turns the architecture/performance audit into a controlled hardening
+track. Current app health is good: `go test ./...`, `go test ./... -race
+-count=1`, `go vet ./...`, and `gofmt -l .` were clean during audit. Core
+coverage is strong (`typing` 96.2%, `metrics` 94.0%, `ui` 87.3%).
+
+Do not optimize blind. First establish benchmark data. Then apply only small,
+evidence-backed changes: reduce typing-screen log replay/copy cost if measured,
+move mode-only dependencies out of `config`, dedupe best-bucket logic, and
+update docs to match source.
+
+## Scope Challenge
+
+- Existing code: `metrics.LiveWPM`, `typing.Engine.Log`, `typing.Engine.States`,
+  stream renderers, and storage best helpers already solve most behavior.
+- Minimum changes: add benchmarks; add an engine snapshot only if benchmarks
+  show render/log replay cost; split mode definitions; expose reusable best
+  helpers; sync docs.
+- Complexity: expected 12-18 touched files, 1 small new package, 5 phases. This
+  is justified because layering and benchmark work touch multiple packages.
+- Selected scope: HOLD. No feature expansion, no renderer rewrite, no new deps.
+
+## Audit Baseline
+
+| Area | Current evidence | Risk |
+|---|---|---|
+| CI gate | `go test`, race, vet, gofmt clean | Low |
+| Benchmarks | `go test ./... -run '^$' -bench . -benchmem` has no benchmark funcs | Medium |
+| Typing render | `TypingModel.View()` calls `States()` and `Log()` then replays via `typedFromLog()` | Medium |
+| Live WPM | Tick path calls `m.eng.Log()` then `metrics.LiveWPM()` every ~250ms | Medium |
+| Core mode deps | `typing`/`metrics`/`words` import `config` only for `Mode`; `config` also owns Bubble Tea key types by repo decision | Important architecture debt |
+| Best marker | `storage` and `ui` duplicate effective-WPM/bucket logic | Medium maintenance risk |
+| Docs | `docs/system-architecture.md` claims `config` has zero Bubble Tea imports | Medium drift |
+
+## Design Decisions
+
+- Measurement-first: Phase 2 optimization is gated by Phase 1 benchmark data.
+- Keep Bubble Tea Elm architecture unchanged.
+- Keep dependencies unchanged. No external benchmark/perf libs.
+- New domain package allowed: `internal/mode` for `Mode` and `LengthsFor`.
+- Keep `config.Keymap` in `internal/config` unless user explicitly approves a
+  larger boundary change; `CLAUDE.md` says that Bubble Tea key binding import is
+  deliberate.
+- Do not change persisted JSON shape unless tests prove unavoidable.
+- No plan/finding IDs in code comments, migration names, or tests.
+- Keep every Go file under 200 LOC; split benchmark files by package if needed.
+
+## Cross-Plan Dependencies
+
+None. All project `plans/*/plan.md` are `status: completed`. The only deferred
+phase in old plans is Obsidian hook work, which does not overlap Typeburn Go
+architecture/performance.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Benchmark Baseline](./phase-01-benchmark-baseline.md) | Completed |
+| 2 | [Typing Snapshot Optimization](./phase-02-typing-snapshot-optimization.md) | Completed |
+| 3 | [Mode Layering Refactor](./phase-03-mode-layering-refactor.md) | Completed |
+| 4 | [Best Bucket DRY](./phase-04-best-bucket-dry.md) | Completed |
+| 5 | [Docs and Verification](./phase-05-docs-and-verification.md) | Completed |
+
+## Dependencies
+
+- Phase 1 is the data gate.
+- Phase 2 depends on Phase 1. It may be skipped or reduced if benchmark data
+  shows no meaningful typing/render issue.
+- Phase 3 can run after Phase 1 and before/after Phase 2, but should land before
+  Phase 5 docs sync.
+- Phase 4 can run after Phase 1 and is independent of Phase 2/3 except final
+  verification.
+- Phase 5 depends on Phases 1-4.
+
+```text
+P1 Benchmark Baseline
+├── P2 Typing Snapshot Optimization (conditional)
+├── P3 Mode Layering Refactor
+└── P4 Best Bucket DRY
+    └── P5 Docs and Verification
+```
+
+## Success Criteria
+
+- Benchmarks exist and run with `go test ./internal/typing ./internal/metrics
+  ./internal/ui ./internal/storage -bench . -benchmem`.
+- If Phase 2 changes code, benchmark output shows lower allocations and/or time
+  for the Code-mode 10k render case without behavior regressions.
+- `internal/typing`, `internal/metrics`, `internal/words`, and `internal/runner`
+  no longer import `internal/config` just to use `Mode`.
+- Best marker logic has one source of truth for bucket key/effective WPM.
+- Docs match source architecture.
+- Final gates pass: `go test ./... -race -count=1`, `go vet ./...`, empty
+  `gofmt -l .`, and benchmark command completes.
+
+## Out of Scope
+
+- New typing modes, UI features, history schema migration, renderer
+  virtualization, async rendering, terminal telemetry, new dependencies.
+- Changing Bubble Tea, Lip Gloss, cobra/fang, update/self-update behavior.
+
+## Red-Team Notes
+
+- Do not use benchmark numbers as flaky CI assertions. Record baseline in
+  comments/docs or compare manually during review.
+- Do not split `Mode` in a way that creates import cycles between `mode`,
+  `config`, `runner`, and `ui`.
+- Do not move `config.Keymap` out of `config` in this plan; that would reverse
+  the current repo rule without explicit user approval.
+- Do not expose mutable engine internals. Any snapshot API must copy or return
+  immutable data by contract.
+- Do not “fix” the accepted legacy `NetWPM==0` ambiguity with a schema change.

--- a/plans/260604-1354-architecture-performance-hardening/reports/pm-260604-1425-architecture-performance-hardening-complete.md
+++ b/plans/260604-1354-architecture-performance-hardening/reports/pm-260604-1425-architecture-performance-hardening-complete.md
@@ -1,0 +1,51 @@
+---
+title: Architecture Performance Hardening Completion Report
+date: 2026-06-04
+plan: plans/260604-1354-architecture-performance-hardening/plan.md
+status: completed
+---
+
+# Architecture Performance Hardening Completion Report
+
+## Summary
+
+All 5 phases completed. Work stayed inside planned scope: benchmarks, measured
+typing hot-path optimization, mode layering cleanup, best-bucket dedupe, docs
+sync, and verification.
+
+## Results
+
+| Area | Result |
+|---|---|
+| Benchmarks | Added typing, metrics, UI render, storage best-bucket benchmarks |
+| Hot path | Typing tick now uses forward-keystroke count; view uses typed buffer copy instead of log replay |
+| Layering | `internal/mode` owns mode enum/length policy; core packages no longer import `internal/config` |
+| Storage/UI | `EffectiveWPM`, `BestBucketKey`, and `BestWPMPerBucket` centralized in `internal/storage` |
+| Docs | Architecture, codebase summary, standards, roadmap updated |
+| Plan | `ck plan validate --strict` passed |
+
+## Verification
+
+| Gate | Status |
+|---|---|
+| `go test ./... -race -count=1` | PASS |
+| `go vet ./...` | PASS |
+| `gofmt -l .` | PASS, empty output |
+| Core import boundary check | PASS, no production imports from core packages to `internal/config` |
+| Benchmark suite | PASS |
+
+## Benchmark Note
+
+Post-change `BenchmarkTypingViewCode10k` measured about 3.22 MB/op. Baseline was
+about 3.57 MB/op, so view allocation dropped by roughly 345 KB/op. Render time
+remains dominated by Lip Gloss/rune styling; no renderer rewrite done.
+
+## Review Findings
+
+No blocking issues found in final review. Remaining test imports of
+`internal/config` are pre-existing compatibility tests; new tests/benchmarks use
+`internal/mode`.
+
+## Unresolved Questions
+
+None.


### PR DESCRIPTION
## Summary
Controlled architecture/performance hardening from the audit track. No feature changes, no new deps, persisted JSON shape unchanged.

- **refactor(mode):** extract `Mode`/`LengthsFor` into `internal/mode`; pure-core packages no longer import `config` for mode. `config.Mode` kept as an alias.
- **perf(typing):** `Engine.Typed` / `Engine.ForwardKeystrokes` let the tick path compute live WPM via `LiveWPMFromCount` without copying/replaying the full log every ~250ms.
- **refactor(storage):** centralize best-bucket comparison (`BestBucketKey`, `EffectiveWPM`, `BestWPMPerBucket`); drop duplicated UI helpers.
- **test(bench):** baseline benchmarks for typing, metrics, render, storage.
- **docs:** sync codebase-summary / system-architecture / code-standards / roadmap; add plan + journal.

## Verification
Local CI gate green on the tree: `go vet ./...` clean, `gofmt -l .` empty, `go test ./... -race -count=1` all 16 packages OK.

No new release cut.