### PR TITLE
feat(anim): pure motion-math core package

### DIFF
--- a/docs/mdocs/20260618/01-20260618.md
+++ b/docs/mdocs/20260618/01-20260618.md
@@ -1,0 +1,7 @@
+# UI/UX animation
+
+First I need you /scout all project for understand it before brainstorm any thing.
+
+Second let research the best technology for apply UI/UX for this app make it impressive.
+
+

--- a/internal/anim/clock.go
+++ b/internal/anim/clock.go
@@ -1,0 +1,36 @@
+package anim
+
+// Clock aggregates a set of tweens and reports whether any are still running.
+// The frame driver polls Active(nowMs) to decide whether to re-arm its tick, so
+// the animation loop self-stops once every tween has completed.
+type Clock struct {
+	tweens []Tween
+}
+
+// Add registers a tween with the clock.
+func (c *Clock) Add(tw Tween) { c.tweens = append(c.tweens, tw) }
+
+// Active reports whether at least one tween is not yet done at nowMs.
+func (c *Clock) Active(nowMs int64) bool {
+	for _, tw := range c.tweens {
+		if !tw.Done(nowMs) {
+			return true
+		}
+	}
+	return false
+}
+
+// Prune drops every tween that has completed at nowMs, keeping the slice small
+// for long-lived clocks. Order of remaining tweens is preserved.
+func (c *Clock) Prune(nowMs int64) {
+	kept := c.tweens[:0]
+	for _, tw := range c.tweens {
+		if !tw.Done(nowMs) {
+			kept = append(kept, tw)
+		}
+	}
+	c.tweens = kept
+}
+
+// Len returns the number of tweens currently tracked (after any pruning).
+func (c *Clock) Len() int { return len(c.tweens) }

--- a/internal/anim/clock_test.go
+++ b/internal/anim/clock_test.go
@@ -1,0 +1,43 @@
+package anim
+
+import "testing"
+
+func TestClockActiveTransitions(t *testing.T) {
+	var c Clock
+	c.Add(Tween{StartMs: 0, DurMs: 100})
+	c.Add(Tween{StartMs: 50, DurMs: 100}) // ends at 150
+
+	if !c.Active(0) {
+		t.Errorf("Active(0) false, want true")
+	}
+	if !c.Active(120) { // first done, second still live
+		t.Errorf("Active(120) false, want true")
+	}
+	if c.Active(150) { // both done
+		t.Errorf("Active(150) true, want false")
+	}
+}
+
+func TestClockEmptyInactive(t *testing.T) {
+	var c Clock
+	if c.Active(0) {
+		t.Errorf("empty clock should be inactive")
+	}
+}
+
+func TestClockPrune(t *testing.T) {
+	var c Clock
+	c.Add(Tween{StartMs: 0, DurMs: 100}) // done at 100
+	c.Add(Tween{StartMs: 0, DurMs: 500}) // done at 500
+	c.Prune(200)
+	if c.Len() != 1 {
+		t.Errorf("after prune Len=%d want 1", c.Len())
+	}
+	if !c.Active(200) {
+		t.Errorf("surviving tween should keep clock active")
+	}
+	c.Prune(600)
+	if c.Len() != 0 {
+		t.Errorf("after full prune Len=%d want 0", c.Len())
+	}
+}

--- a/internal/anim/color.go
+++ b/internal/anim/color.go
@@ -1,0 +1,35 @@
+package anim
+
+import "image/color"
+
+// LerpColor linearly interpolates between two colors in 8-bit RGB space.
+// It works on stdlib image/color so this package never imports lipgloss; the
+// caller converts the returned color.RGBA to a lipgloss color at the UI seam.
+//
+// If either input is nil (the NO_COLOR signal from theme.Color), it returns nil
+// so callers can branch to an attribute-only render path instead of color math.
+// t is clamped to [0,1]. The returned color is fully opaque (A=255).
+func LerpColor(from, to color.Color, t float64) color.Color {
+	if from == nil || to == nil {
+		return nil
+	}
+	t = Clamp01(t)
+
+	fr, fg, fb, _ := from.RGBA() // each channel 0–65535
+	tr, tg, tb, _ := to.RGBA()
+
+	return color.RGBA{
+		R: lerpChannel(fr, tr, t),
+		G: lerpChannel(fg, tg, t),
+		B: lerpChannel(fb, tb, t),
+		A: 255,
+	}
+}
+
+// lerpChannel interpolates one 0–65535 channel pair and scales to 0–255.
+// Division by 257 maps 65535→255 exactly (255*257 == 65535).
+func lerpChannel(from, to uint32, t float64) uint8 {
+	f := float64(from)
+	v := f + (float64(to)-f)*t
+	return uint8(v/257 + 0.5)
+}

--- a/internal/anim/color_test.go
+++ b/internal/anim/color_test.go
@@ -1,0 +1,60 @@
+package anim
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestLerpColorEndpoints(t *testing.T) {
+	from := color.RGBA{R: 0, G: 0, B: 0, A: 255}
+	to := color.RGBA{R: 255, G: 255, B: 255, A: 255}
+
+	if got := LerpColor(from, to, 0).(color.RGBA); got != from {
+		t.Errorf("t=0 got %+v want %+v", got, from)
+	}
+	if got := LerpColor(from, to, 1).(color.RGBA); got != to {
+		t.Errorf("t=1 got %+v want %+v", got, to)
+	}
+}
+
+func TestLerpColorMidpoint(t *testing.T) {
+	from := color.RGBA{R: 0, G: 0, B: 0, A: 255}
+	to := color.RGBA{R: 200, G: 100, B: 50, A: 255}
+	got := LerpColor(from, to, 0.5).(color.RGBA)
+	want := color.RGBA{R: 100, G: 50, B: 25, A: 255}
+	if got != want {
+		t.Errorf("midpoint got %+v want %+v", got, want)
+	}
+}
+
+func TestLerpColorClampsT(t *testing.T) {
+	from := color.RGBA{R: 10, G: 20, B: 30, A: 255}
+	to := color.RGBA{R: 200, G: 100, B: 50, A: 255}
+	if got := LerpColor(from, to, -1).(color.RGBA); got != from {
+		t.Errorf("t<0 should clamp to from, got %+v", got)
+	}
+	if got := LerpColor(from, to, 5).(color.RGBA); got != to {
+		t.Errorf("t>1 should clamp to to, got %+v", got)
+	}
+}
+
+func TestLerpColorNilPassthrough(t *testing.T) {
+	x := color.RGBA{R: 1, G: 2, B: 3, A: 255}
+	if got := LerpColor(nil, x, 0.5); got != nil {
+		t.Errorf("LerpColor(nil,x) = %v want nil", got)
+	}
+	if got := LerpColor(x, nil, 0.5); got != nil {
+		t.Errorf("LerpColor(x,nil) = %v want nil", got)
+	}
+	if got := LerpColor(nil, nil, 0.5); got != nil {
+		t.Errorf("LerpColor(nil,nil) = %v want nil", got)
+	}
+}
+
+// 65535/257 == 255 exactly: a full-white color.RGBA round-trips through RGBA().
+func TestLerpColorFullChannelExact(t *testing.T) {
+	white := color.RGBA{R: 255, G: 255, B: 255, A: 255}
+	if got := LerpColor(white, white, 0.5).(color.RGBA); got != white {
+		t.Errorf("white lerp got %+v want %+v", got, white)
+	}
+}

--- a/internal/anim/easing.go
+++ b/internal/anim/easing.go
@@ -1,0 +1,42 @@
+// Package anim holds pure, UI-free motion math: easing curves, color and value
+// interpolation, a time-driven tween, and a clock that reports whether any
+// animation is still live. It imports no Bubble Tea / Lip Gloss types — callers
+// convert returned values at the UI boundary. Every animation is a pure
+// function of (startMs, nowMs, durMs), mirroring metrics.Compute's post-hoc
+// replay, so renders are deterministic and unit-testable.
+package anim
+
+// Clamp01 constrains t to the [0,1] range. All easing functions assume their
+// input is already clamped; callers building progress from raw time should
+// clamp first (Tween.Progress does).
+func Clamp01(t float64) float64 {
+	if t < 0 {
+		return 0
+	}
+	if t > 1 {
+		return 1
+	}
+	return t
+}
+
+// EaseOutCubic decelerates toward the end: fast start, slow finish.
+// f(t) = (t-1)^3 + 1. f(0)=0, f(1)=1.
+func EaseOutCubic(t float64) float64 {
+	u := t - 1
+	return u*u*u + 1
+}
+
+// EaseOutQuad decelerates with a gentler curve than cubic. f(t) = t*(2-t).
+// Used for the WPM count-up so the final digits settle smoothly.
+func EaseOutQuad(t float64) float64 {
+	return t * (2 - t)
+}
+
+// EaseInOutQuad accelerates to the midpoint then decelerates. Piecewise:
+// 2t^2 for t<0.5, then -1 + (4-2t)t. f(0)=0, f(0.5)=0.5, f(1)=1.
+func EaseInOutQuad(t float64) float64 {
+	if t < 0.5 {
+		return 2 * t * t
+	}
+	return -1 + (4-2*t)*t
+}

--- a/internal/anim/easing_test.go
+++ b/internal/anim/easing_test.go
@@ -1,0 +1,65 @@
+package anim
+
+import "testing"
+
+func TestClamp01(t *testing.T) {
+	cases := []struct{ in, want float64 }{
+		{-1, 0}, {-0.001, 0}, {0, 0}, {0.5, 0.5}, {1, 1}, {1.0001, 1}, {99, 1},
+	}
+	for _, c := range cases {
+		if got := Clamp01(c.in); got != c.want {
+			t.Errorf("Clamp01(%v)=%v want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// easingFns are the shaping curves; all must satisfy f(0)=0, f(1)=1 and stay
+// within [0,1] across the domain (monotonic non-decreasing).
+func TestEasingEndpointsAndMonotonic(t *testing.T) {
+	fns := map[string]func(float64) float64{
+		"EaseOutCubic":  EaseOutCubic,
+		"EaseOutQuad":   EaseOutQuad,
+		"EaseInOutQuad": EaseInOutQuad,
+	}
+	for name, f := range fns {
+		if got := f(0); !approx(got, 0) {
+			t.Errorf("%s(0)=%v want 0", name, got)
+		}
+		if got := f(1); !approx(got, 1) {
+			t.Errorf("%s(1)=%v want 1", name, got)
+		}
+		prev := f(0)
+		for i := 1; i <= 100; i++ {
+			x := float64(i) / 100
+			v := f(x)
+			if v < -1e-9 || v > 1+1e-9 {
+				t.Errorf("%s(%v)=%v out of [0,1]", name, x, v)
+			}
+			if v < prev-1e-9 {
+				t.Errorf("%s not monotonic at %v: %v < %v", name, x, v, prev)
+			}
+			prev = v
+		}
+	}
+}
+
+func TestEaseInOutQuadMidpoint(t *testing.T) {
+	if got := EaseInOutQuad(0.5); !approx(got, 0.5) {
+		t.Errorf("EaseInOutQuad(0.5)=%v want 0.5", got)
+	}
+}
+
+func TestEaseOutQuadFasterStart(t *testing.T) {
+	// EaseOut curves should be above the linear line in the first half.
+	if EaseOutQuad(0.25) <= 0.25 {
+		t.Errorf("EaseOutQuad(0.25)=%v should exceed linear 0.25", EaseOutQuad(0.25))
+	}
+	if EaseOutCubic(0.25) <= 0.25 {
+		t.Errorf("EaseOutCubic(0.25)=%v should exceed linear 0.25", EaseOutCubic(0.25))
+	}
+}
+
+func approx(a, b float64) bool {
+	d := a - b
+	return d < 1e-9 && d > -1e-9
+}

--- a/internal/anim/tween.go
+++ b/internal/anim/tween.go
@@ -1,0 +1,50 @@
+package anim
+
+// Tween describes a single timed animation: it starts at StartMs, runs for
+// DurMs milliseconds, and shapes its progress with Ease. All fields are plain
+// data so a Tween is cheap to copy and trivial to construct inline.
+type Tween struct {
+	StartMs int64
+	DurMs   int64
+	// Ease maps linear progress [0,1] to eased progress [0,1]. If nil, linear.
+	Ease func(float64) float64
+}
+
+// Progress returns the eased progress at nowMs, clamped to [0,1]: 0 at or
+// before StartMs, 1 at or after StartMs+DurMs. A zero DurMs is treated as an
+// instantly-complete tween (returns 1 once started) to avoid divide-by-zero.
+func (tw Tween) Progress(nowMs int64) float64 {
+	if tw.DurMs <= 0 {
+		if nowMs < tw.StartMs {
+			return 0
+		}
+		return 1
+	}
+	raw := float64(nowMs-tw.StartMs) / float64(tw.DurMs)
+	raw = Clamp01(raw)
+	if tw.Ease == nil {
+		return raw
+	}
+	return tw.Ease(raw)
+}
+
+// Done reports whether the tween has reached or passed its end time.
+func (tw Tween) Done(nowMs int64) bool {
+	return nowMs >= tw.StartMs+tw.DurMs
+}
+
+// LerpFloat interpolates between from and to by t (caller supplies eased t).
+func LerpFloat(from, to, t float64) float64 {
+	return from + (to-from)*t
+}
+
+// LerpInt interpolates between two ints by t and rounds to the nearest int.
+// Used by the result count-up; rounding (not truncation) makes it land exactly
+// on the target at t=1.
+func LerpInt(from, to int, t float64) int {
+	v := float64(from) + (float64(to)-float64(from))*t
+	if v < 0 {
+		return int(v - 0.5)
+	}
+	return int(v + 0.5)
+}

--- a/internal/anim/tween_test.go
+++ b/internal/anim/tween_test.go
@@ -1,0 +1,82 @@
+package anim
+
+import "testing"
+
+func TestTweenProgressBounds(t *testing.T) {
+	tw := Tween{StartMs: 1000, DurMs: 200} // linear (Ease nil)
+	cases := []struct {
+		now  int64
+		want float64
+	}{
+		{900, 0},    // before start
+		{1000, 0},   // at start
+		{1100, 0.5}, // midpoint
+		{1200, 1},   // at end
+		{1300, 1},   // after end
+	}
+	for _, c := range cases {
+		if got := tw.Progress(c.now); !approx(got, c.want) {
+			t.Errorf("Progress(%d)=%v want %v", c.now, got, c.want)
+		}
+	}
+}
+
+func TestTweenProgressEased(t *testing.T) {
+	tw := Tween{StartMs: 0, DurMs: 100, Ease: EaseOutQuad}
+	// At raw t=0.5, EaseOutQuad(0.5) = 0.75.
+	if got := tw.Progress(50); !approx(got, 0.75) {
+		t.Errorf("eased Progress(50)=%v want 0.75", got)
+	}
+}
+
+func TestTweenZeroDuration(t *testing.T) {
+	tw := Tween{StartMs: 100, DurMs: 0}
+	if got := tw.Progress(99); got != 0 {
+		t.Errorf("zero-dur before start = %v want 0", got)
+	}
+	if got := tw.Progress(100); got != 1 {
+		t.Errorf("zero-dur at start = %v want 1", got)
+	}
+	if !tw.Done(100) {
+		t.Errorf("zero-dur should be Done at start")
+	}
+}
+
+func TestTweenDone(t *testing.T) {
+	tw := Tween{StartMs: 1000, DurMs: 200}
+	if tw.Done(1199) {
+		t.Errorf("Done(1199) true, want false")
+	}
+	if !tw.Done(1200) {
+		t.Errorf("Done(1200) false, want true")
+	}
+}
+
+func TestLerpFloat(t *testing.T) {
+	if got := LerpFloat(0, 10, 0.5); !approx(got, 5) {
+		t.Errorf("LerpFloat = %v want 5", got)
+	}
+	if got := LerpFloat(4, 8, 0); !approx(got, 4) {
+		t.Errorf("LerpFloat t=0 = %v want 4", got)
+	}
+}
+
+func TestLerpInt(t *testing.T) {
+	cases := []struct {
+		from, to int
+		t        float64
+		want     int
+	}{
+		{0, 100, 0, 0},
+		{0, 100, 1, 100},
+		{0, 100, 0.5, 50},
+		{0, 10, 0.25, 3}, // 2.5 rounds to 3 (round-half-up)
+		{0, 9, 0.999, 9}, // near-end lands on target
+		{10, 0, 0.5, 5},  // descending
+	}
+	for _, c := range cases {
+		if got := LerpInt(c.from, c.to, c.t); got != c.want {
+			t.Errorf("LerpInt(%d,%d,%v)=%d want %d", c.from, c.to, c.t, got, c.want)
+		}
+	}
+}

--- a/plans/260618-1454-ui-ux-animation-system/phase-01-anim-core-package.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-01-anim-core-package.md
@@ -1,0 +1,69 @@
+---
+phase: 1
+title: "Anim core package"
+status: pending
+priority: P1
+effort: "4h"
+dependencies: []
+---
+
+# Phase 1: Anim core package
+
+## Overview
+Create `internal/anim`, a **pure, UI-free** package holding all motion math:
+easing curves, RGB color interpolation, a generic tween, and a clock that tracks
+whether any animation is still live. No Bubble Tea / Lip Gloss imports — it joins
+`typing`/`metrics`/`words` as testable pure logic. Everything downstream depends on this.
+
+**Spring removed (red-team YAGNI):** no consumer in P3–P6 uses a spring; all use
+tweens + easing. Do **not** build `spring.go`. Add it back only if a real consumer appears.
+
+## Requirements
+- Functional: easing fns, `LerpColor`, `Tween`/`LerpInt`/`LerpFloat`, `Clock.Active()`.
+- Non-functional: zero UI deps; deterministic (pure fns of time); 100% table-tested;
+  each file < 200 LOC.
+
+## Architecture
+Time model: every animation is a pure function of `(startMs, nowMs, durMs) → progress∈[0,1]`,
+then `progress → eased → value`. No goroutines, no internal clocks — the caller
+supplies `nowMs` (epoch-ms), mirroring `metrics.Compute`'s post-hoc replay.
+
+Color interpolation works on `image/color.Color` (stdlib) so the package never
+imports lipgloss. Callers convert the returned RGB to a lipgloss color at the
+UI boundary. `LerpColor(from, to, t)` returns `color.RGBA`; if either input is
+`nil` (NO_COLOR), it returns `nil` so callers can branch to attribute-only.
+
+## Related Code Files
+- Create: `internal/anim/easing.go` — `EaseOutCubic`, `EaseInOutQuad`, `EaseOutQuad`, `Clamp01`.
+- Create: `internal/anim/color.go` — `LerpColor(from, to color.Color, t float64) color.Color`.
+- Create: `internal/anim/tween.go` — `Tween{StartMs, DurMs, Ease}` + `Progress(nowMs)`, `Done(nowMs)`, `LerpInt`, `LerpFloat`.
+- Create: `internal/anim/clock.go` — `Clock` aggregating active tweens; `Active(nowMs) bool`.
+- Create: `internal/anim/easing_test.go`, `color_test.go`, `tween_test.go`, `clock_test.go`.
+
+## Implementation Steps
+1. `easing.go`: implement (research-confirmed formulas):
+   - `EaseOutCubic(t) = (t-1)^3 + 1`
+   - `EaseInOutQuad(t)` piecewise (accelerate→decelerate)
+   - `EaseOutQuad(t) = t*(2-t)` (count-up curve)
+   - `Clamp01(t)` guard. All take/return `float64` in [0,1].
+2. `tween.go`: `Tween{StartMs int64; DurMs int64; Ease func(float64) float64}`.
+   - `Progress(nowMs) float64` = `Ease(Clamp01((nowMs-StartMs)/DurMs))`; returns 0 before start, 1 after end.
+   - `Done(nowMs) bool` = `nowMs >= StartMs+DurMs`.
+   - `LerpFloat(from, to, t)`, `LerpInt(from, to, t)` helpers (count-up uses `LerpInt`).
+3. `color.go`: `LerpColor` — `from.RGBA()`/`to.RGBA()` give 0–65535; lerp each channel,
+   `/257` to 0–255, return `color.RGBA{R,G,B,255}`. `nil` in either → `nil` out.
+4. `clock.go`: `Clock` holds a slice of `Tween`; `Active(nowMs)` true if any `!Done(nowMs)`;
+   `Add`, `Prune(nowMs)`. This is the signal the frame driver (P2) polls to self-stop.
+5. Tests: table-driven, real values — boundary t=0/0.5/1, monotonicity, `LerpColor` channel
+   math + `nil` passthrough, `LerpInt` endpoints, `Done`/`Active` transitions.
+
+## Success Criteria
+- [ ] `go test ./internal/anim/ -race -count=1` green; table-driven, no mocks.
+- [ ] `go list -deps ./internal/anim` shows **no** `charm.land`/`charmbracelet` imports.
+- [ ] Every file < 200 LOC; `gofmt -l` empty; `go vet ./internal/anim/` clean.
+- [ ] `LerpColor(nil, x, t)` and `LerpColor(x, nil, t)` both return `nil`.
+
+## Risk Assessment
+- RGBA `/257` rounding: acceptable (research-confirmed); assert exact endpoints in tests.
+- Keep the surface minimal (YAGNI): only ship what P3–P6 consume (easing, tween/lerp,
+  color, clock). No spring, no speculative helpers.

--- a/plans/260618-1454-ui-ux-animation-system/phase-02-frame-driver.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-02-frame-driver.md
@@ -1,0 +1,95 @@
+---
+phase: 2
+title: "Frame driver"
+status: pending
+priority: P1
+effort: "5h"
+dependencies: [1]
+---
+
+# Phase 2: Frame driver
+
+## Overview
+Add the self-stopping animation frame loop and plumb a shared `nowMs` to screen
+`View()`s. This is the single, app-owned driver every animated moment hooks into.
+The existing 100ms `timer.go` tick is **not touched**.
+
+## Requirements
+- Functional: new `FrameTickMsg`; app re-arms a ~33ms tick only while ≥1 screen has
+  live animation; screens expose `HasActiveAnim(nowMs) bool`; `nowMs` reaches View.
+- Non-functional: zero ticks scheduled when fully idle; no change to existing tested
+  timer/WPM/completion paths; files < 200 LOC.
+
+## Architecture
+**Message:** `FrameTickMsg{ t time.Time }` in `internal/ui/messages.go` (sibling of the
+existing `tickMsg`, distinct type so routing is unambiguous).
+
+**Driver ownership:** `app.Model` owns animation orchestration in a new
+`internal/app/anim_driver.go`:
+- `frameInterval = 33 * time.Millisecond` (single const; P7 may retune).
+- `frameTickCmd()` → `tea.Tick(frameInterval, ...)` returning `FrameTickMsg` (single-fire;
+  re-armed only when animation remains active — mirrors `timer.go:17` pattern).
+- `m.animActive(nowMs) bool` = OR of the active screen's `HasActiveAnim(nowMs)` plus any
+  in-flight root-owned transition (P6).
+- On `FrameTickMsg`: stamp `m.animNowMs`, forward to active screen's `Update` so it can
+  advance its own tween state, then return `frameTickCmd()` **iff** `animActive` else `nil`.
+
+**Kicking the loop:** any event that *starts* an animation must return `frameTickCmd()`
+once to bootstrap the loop (e.g. ResultMsg entry in P4, first keystroke in P3,
+transition start in P6). Self-arming keeps it going; self-stop ends it.
+
+**nowMs plumbing:** add `animNowMs int64` to `app.Model`. Screens that animate take
+`nowMs` via their existing `View()`—**preferred**: store `nowMs` on the sub-model when
+forwarding `FrameTickMsg` in `Update` (no `View()` signature churn; matches how
+`TypingModel.nowMs` already works at `screen_typing.go:28`). View reads the stored field.
+
+**Interface (kept tiny to protect <200 LOC on root):**
+```go
+// implemented by screens that animate (typing, result)
+type Animatable interface{ HasActiveAnim(nowMs int64) bool }
+```
+
+## Related Code Files
+- Create: `internal/app/anim_driver.go` — `frameInterval`, `frameTickCmd`, `animActive`, FrameTick routing.
+- Create: `internal/app/anim_driver_test.go` — self-stop logic (active→re-arm, idle→nil).
+- Modify: `internal/ui/messages.go` — add `FrameTickMsg`.
+- Modify: `internal/app/model.go` — add `animNowMs`; handle `FrameTickMsg` in `Update`;
+  `Init()` stays `nil` (idle = no tick).
+- Modify: screen sub-models (P3/P4/P6) to implement `HasActiveAnim` + store `nowMs`
+  (declared here, populated by later phases).
+
+## Implementation Steps
+1. Add `FrameTickMsg{ t time.Time }` to `messages.go`.
+2. `anim_driver.go`: const + `frameTickCmd()`; `func (m Model) animActive(nowMs int64) bool`
+   switching on `m.screen` to call the active sub-model's `HasActiveAnim`, OR transition state.
+3. In `model.go Update`, add an **explicit** `case ui.FrameTickMsg:` branch **before** the
+   generic delegation (the generic block at `model.go:165-189` must NOT be the path that
+   handles it — otherwise the sub-model's cmd is returned and `maybeFrameCmd` is lost). The
+   branch: set `m.animNowMs = msg.t.UnixMilli()`; forward to the active screen's `Update` to
+   capture `subCmd` (so it stores `nowMs`); `return m, tea.Batch(subCmd, m.maybeFrameCmd())`
+   where `maybeFrameCmd` returns `frameTickCmd()` if `animActive` else `nil`.
+4. **Sub-models must handle the message:** add a `case ui.FrameTickMsg:` to
+   `TypingModel.Update` and `ResultModel.Update` that stores `nowMs = msg.t.UnixMilli()` and
+   returns `(m, nil)`. Without this case the "advance tweens" forwarding silently no-ops and
+   nothing animates. (Real per-screen logic lands in P3/P4; the case + field land here.)
+5. Define `HasActiveAnim(nowMs) bool` on `TypingModel` and `ResultModel` returning `false`
+   for now (real logic in P3/P4) so the interface compiles.
+6. Unit-test the self-stop: a model reporting active re-arms (`tea.Batch` non-nil frame cmd);
+   reporting idle returns no frame cmd. Assert `FrameTickMsg` never advances WPM/completion.
+
+## Success Criteria
+- [ ] With all screens reporting idle, `FrameTickMsg` handling returns no frame re-arm (loop stops).
+- [ ] When a screen reports active, handling returns `tea.Batch(subCmd, frameTickCmd())` (non-nil frame cmd).
+- [ ] `FrameTickMsg` is handled by an explicit root case, not the generic delegation block.
+- [ ] `TypingModel`/`ResultModel.Update` each have a `FrameTickMsg` case that stores `nowMs`.
+- [ ] `Init()` still returns `nil`; launching the app schedules no frame tick until an animation starts.
+- [ ] Existing `timer.go` tick + WPM/completion tests unchanged and green.
+- [ ] `go test ./... -race`, `go vet`, `gofmt -l` all clean; files < 200 LOC.
+
+## Risk Assessment
+- **Double-tick coupling:** during typing both the 100ms timer tick and 33ms frame tick run.
+  Acceptable (independent loops); ensure `FrameTickMsg` never advances WPM/completion (separation of concerns).
+- **Root model growth:** keep all driver logic in `anim_driver.go`; `model.go` gains only a
+  thin `case` + one field to stay < 200 LOC.
+- **Forgotten bootstrap:** if a phase starts an animation but forgets to return `frameTickCmd()`,
+  nothing animates. P7 adds an integration test asserting the loop arms on ResultMsg.

--- a/plans/260618-1454-ui-ux-animation-system/phase-03-caret-animation.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-03-caret-animation.md
@@ -1,0 +1,119 @@
+---
+phase: 3
+title: "Caret animation"
+status: pending
+priority: P2
+effort: "6h"
+dependencies: [2]
+---
+
+# Phase 3: Caret animation
+
+## Overview
+Make the typing caret feel alive: **blink** (slow cycle), **new-cell fade**
+(freshly-typed cell eases accent→normal), and **leave-trail** (the cell just
+vacated dim-decays). This is the one feature on the perf-sensitive typing hot
+path; the v2 cell-diff renderer keeps it cheap, but it is validated by benchmark in P7.
+
+## Requirements
+- Functional: combined blink + new-cell fade + trail on `Current`/recently-typed cells.
+- Non-functional: WPM/completion path untouched; NO_COLOR → attribute-only (reverse
+  blink, faint fade/trail, no color math); zero layout change; cheap idle.
+
+## Architecture
+**State (on `TypingModel`):** `lastKeyMs int64` (set in `applyText`), `frameLoopArmed bool`
+(idle→active edge guard), and `nowFn func() int64` (clock seam, defaults to
+`time.Now().UnixMilli`; test-overridable — mirrors the existing `seed` injection at
+`screen_typing.go:36,60`). No new heap per keystroke. `caretBlinkOn` is **derived**, not stored.
+
+**Blink:** rides the existing 100ms timer tick via time-threshold — `caretBlinkOn =
+(nowMs/blinkHalfMs)%2==0` with `blinkHalfMs=265` (530ms cycle, research-confirmed Windows
+standard). No fast frames needed for blink alone. **Pre-start blink:** the 100ms `tickCmd`
+does not run before the first keystroke today (`Init` nil; `NewTyping` starts no tick), so the
+caret would sit static while the user decides to start. Bootstrap a `tickCmd()` on entry to
+ScreenTyping (in the `StartTestMsg` handler at `model.go:82`) so the pre-start caret blinks.
+
+**Fade + trail need fast frames:** active only for `fadeMs≈150` after `lastKeyMs`.
+`HasActiveAnim(nowMs)` returns `nowMs-lastKeyMs < fadeMs` → frame driver runs 33ms frames
+during the post-keystroke window, then self-stops back to 100ms blink cadence when typing pauses.
+
+**Bootstrap on the idle→active edge ONLY (red-team P1):** `applyText` must NOT return
+`frameTickCmd()` on every keystroke — overlapping 33ms `tea.Tick` timers would multiply and
+never cleanly self-stop. Return the frame bootstrap only when `frameLoopArmed` is false, then
+set it true; clear `frameLoopArmed` when `HasActiveAnim` goes false (checked in the FrameTick
+handler before deciding to re-arm). Net: exactly one live frame loop regardless of typing speed.
+
+**Rendering integration (`word_stream_renderer.go` + `code_stream_renderer.go`):**
+- Extend `RenderWordStream`/`RenderCodeStream` to accept a small `caretAnim` struct
+  (`nowMs`, `lastKeyMs`, `blinkOn`, `cursorIdx`) — keep signatures cohesive (one struct, not 4 args).
+- **Current cell (cursor):** when `blinkOn` false, render as the non-cursor underlying state
+  (cursor "off"); when true, `RoleCursorBg`. Under NO_COLOR, blink toggles `Reverse(true)` on/off
+  (already the attr mapping at `theme.go:105`).
+- **New-cell fade:** the most-recently-typed correct cell (index `cursorIdx-1`) interpolates
+  foreground `RoleAccent → RoleTextMuted` over `fadeMs` via `anim.LerpColor` + `EaseOutQuad`.
+  NO_COLOR fallback: render bold for first ~half of fade, then normal (attribute step, not color).
+- **Trail (separable sub-step):** the cell at `cursorIdx-2` (just-vacated) renders one notch
+  dimmer (`RoleTextFaint`) decaying to `RoleTextMuted` over `fadeMs`. NO_COLOR: `Faint(true)`
+  for the window, then normal. Implement blink+fade first, then trail as a clearly-isolated
+  addition so the P7 golden review can drop it without touching the rest (it is the weakest UX
+  bet per both researchers — but it was a confirmed user choice, so cutting it requires asking).
+
+**Mandatory prefix-token cache (red-team P2 — NOT deferred):** the v2 cell-diff renderer saves
+terminal *output bytes* but NOT the per-frame CPU/GC cost of building styled tokens upstream
+(`word_stream_renderer.go:42-84` allocates one `Render` string per rune, every frame → ~18k
+allocs/s for a 100-word test at 33fps). So the renderer caches the **static prefix** of styled
+tokens (everything except the ≤2 animated cells) and only re-`Render`s those ≤2 cells per frame;
+the cache invalidates on keystroke (state change) and on resize. This is a P3 design requirement,
+not a P7 contingency. Only the ≤2 animated cells get per-frame styles — bounded work, not O(n).
+
+**Blink-setting interaction:** `settings.BlinkCursor` already exists (`screen_typing.go:31`).
+If `blink=false`, force `blinkOn=true` always (steady block) but **keep** fade+trail (they are
+independent of the blink toggle). Document this so the toggle's contract is clear.
+
+## Related Code Files
+- Create: `internal/ui/caret_anim.go` — `caretAnim` struct + `resolveCaretStyles(...)` helper
+  (returns the ≤2 animated cell styles given nowMs/lastKeyMs/blinkOn + theme; NO_COLOR-aware).
+- Create: `internal/ui/caret_anim_test.go` — fade endpoints, trail decay, NO_COLOR attr fallback, blink phase.
+- Modify: `internal/ui/screen_typing.go` — add `lastKeyMs`, `frameLoopArmed`, `nowFn`; set
+  `lastKeyMs=nowFn()` in `applyText`; bootstrap `frameTickCmd()` only on the idle→active edge;
+  `HasActiveAnim`; `FrameTickMsg` case storing `nowMs`; **reset `lastKeyMs=0` + `frameLoopArmed=false`
+  in `restartSame`/`newTest`** (`screen_typing.go:128-134`) so a stale fade never renders on a
+  fresh test's first frame.
+- Modify: `internal/ui/word_stream_renderer.go` — thread `caretAnim`, apply animated cell styles.
+- Modify: `internal/ui/code_stream_renderer.go` — same, for Code mode (deliberate duplication kept).
+- Modify: `internal/ui/screen_typing_view.go` — pass `caretAnim` into the renderer.
+
+## Implementation Steps
+1. `caret_anim.go`: define struct + `resolveCaretStyles`; pure given theme + times; branch on
+   `th.Color(RoleAccent)==nil` for NO_COLOR attr path.
+2. `screen_typing.go`: add `nowFn` (default `time.Now().UnixMilli`); record `lastKeyMs=nowFn()`
+   in `applyText`; implement `HasActiveAnim`; bootstrap `frameTickCmd()` via `tea.Batch` **only**
+   on the idle→active edge (guard with `frameLoopArmed`); add `FrameTickMsg` case; reset caret
+   state in `restartSame`/`newTest`.
+3. Thread the struct through `screen_typing_view.go` → `RenderWordStream`/`RenderCodeStream`,
+   including the static prefix-token cache (invalidate on keystroke/resize).
+4. In the renderers, after building cached base tokens, overwrite the ≤2 animated indices with
+   `resolveCaretStyles` output. Never change `ch`/width.
+5. Tests: inject `nowFn` + pinned `nowMs`; assert NO_COLOR output differs from static only in
+   attribute SGR (same runes, same line count, same per-line rune width); fade/trail color
+   endpoints; blink phase; prefix cache reused across frames (alloc count bounded).
+
+## Success Criteria
+- [ ] Caret blinks at 530ms; fresh cell visibly fades; vacated cell trails — in a color theme.
+- [ ] Under `NO_COLOR=1`, caret uses reverse/faint/bold only; **layout-identical** (same runes, line count, rune width) to static.
+- [ ] Typing a 100-word test: WPM/accuracy/consistency identical to pre-change (no hot-path semantic drift).
+- [ ] Frame loop self-stops within ~150ms of the last keystroke (paused typing → no 33ms ticks).
+- [ ] Sustained fast typing keeps exactly ONE frame loop live (no multiplying `tea.Tick` timers).
+- [ ] Caret blinks on the typing screen BEFORE the first keystroke.
+- [ ] `restartSame`/`newTest` clear caret state — no stale fade on the fresh test's first frame.
+- [ ] Caret goldens are deterministic via injected `nowFn` (no wall-clock read in the tested path).
+- [ ] `make test-race`, `go vet`, `gofmt -l` clean; new files < 200 LOC.
+
+## Risk Assessment
+- **Trail legibility (UX researcher flag):** dim trail may read as noise at high speed. Mitigation:
+  keep trail subtle (one faint notch, ≤150ms); if golden review finds it distracting, drop trail and
+  keep blink+fade (escalate to user — it was a confirmed choice, do not silently cut).
+- **teatest golden churn:** animated frames are time-dependent. Mitigation: tests pin `nowMs`
+  explicitly; golden captures use a fixed `lastKeyMs` so output is deterministic.
+- **Hot-path cost:** full word-stream rebuild at 33fps. Mitigated by v2 cell-diff; **benchmarked in P7**;
+  if regressed, cache the static prefix of tokens.

--- a/plans/260618-1454-ui-ux-animation-system/phase-04-result-reveal.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-04-result-reveal.md
@@ -1,0 +1,84 @@
+---
+phase: 4
+title: "Result reveal"
+status: pending
+priority: P2
+effort: "5h"
+dependencies: [2]
+---
+
+# Phase 4: Result reveal
+
+## Overview
+Animate the Result screen entrance: the big WPM digits **count up** 0→final, the
+sparkline **draws in** left→right, and stat cards **stagger-fade** in. The Result
+screen is not perf-critical, so this is the lowest-risk visible win.
+
+## Requirements
+- Functional: WPM count-up (~600ms easeOutQuad), sparkline progressive reveal,
+  staggered stat-card appearance; all settle to the exact final frame.
+- Non-functional: no layout jitter (reserve max digit width); NO_COLOR → cards/sparkline
+  appear via attribute step (faint→normal) not color fade; always-on.
+
+## Architecture
+**Entry trigger:** Result screen begins animating when it becomes active. The root sets a
+`revealStartMs` when routing `ResultMsg` (`model.go:97` path / `handleResultMsg`) and bootstraps
+the frame loop with `frameTickCmd()`. **Every `ResultMsg` must unconditionally (re)set
+`revealStartMs = animNowMs`** (and P5's `isNewBest`/`celebrateStartMs`) so a second result never
+inherits an already-elapsed window from the prior result — the `ResultModel` is reused on the
+root (`model.go:21`), so stale state would otherwise suppress the animation or fire spurious confetti.
+
+**State (on `ResultModel`):** `revealStartMs int64`, `nowMs int64` (stamped from `FrameTickMsg`).
+All reveal values derive purely from `(revealStartMs, nowMs)`.
+
+**Count-up:** display value = `anim.LerpInt(0, finalWPM, EaseOutQuad(progress))` with
+`countUpMs=600`. **Reserve width** for the final digit count (e.g. right-align in a fixed cell)
+so 9→10→100 never shifts the big-digit block. Big digits render via existing `ascii_big_digits.go`.
+
+**Sparkline draw-in:** reuse `sparkline.go`; reveal the first `n=int(barCount*progress)` bars,
+render remaining positions as blank cells of equal width (no reflow). `drawInMs=500`.
+
+**Stat-card stagger:** each `StatCard` (`stat_card.go`) has an offset start
+(`card[i].start = revealStartMs + i*staggerMs`, `staggerMs≈120`); before its start the card
+renders faint/placeholder at full width, then fades to normal. NO_COLOR: faint→normal attribute step.
+
+**HasActiveAnim:** `true` while `nowMs < revealStartMs + totalRevealMs`
+(`totalRevealMs = max(countUpMs, drawInMs, lastCardStart+cardFadeMs)`), else `false` → self-stop.
+
+**Update hint / new-best badge:** unchanged in this phase except that the new-best badge’s
+appearance time is exposed so P5 can hang the celebration off it.
+
+## Related Code Files
+- Create: `internal/ui/screen_result_reveal.go` — reveal state + pure helpers
+  (`countUpValue`, `sparkReveal`, `cardVisible`), NO_COLOR-aware.
+- Create: `internal/ui/screen_result_reveal_test.go` — count-up endpoints/monotonic, spark bar count,
+  card stagger gating, width-reservation invariant, NO_COLOR attr path.
+- Modify: `internal/ui/screen_result.go` — add `revealStartMs`/`nowMs`; `HasActiveAnim`;
+  stamp `nowMs` on `FrameTickMsg`.
+- Modify: `internal/ui/screen_result_view.go` + `result_render_helpers.go` — consume reveal helpers.
+- Modify: `internal/app/model_result.go` (handleResultMsg site) — set `revealStartMs`, bootstrap frame cmd.
+
+## Implementation Steps
+1. `screen_result_reveal.go`: pure functions of `(revealStartMs, nowMs)`; constants `countUpMs`,
+   `drawInMs`, `staggerMs`, `cardFadeMs`.
+2. Wire `revealStartMs` at the ResultMsg handling site; return `frameTickCmd()` to start the loop.
+3. Stamp `nowMs` from `FrameTickMsg` in `ResultModel.Update`; implement `HasActiveAnim`.
+4. Replace the static WPM render with `countUpValue(...)`; ensure fixed-width digit slot.
+5. Gate sparkline + stat cards through reveal helpers; verify equal-width placeholders.
+6. Tests pin `nowMs`; assert final frame equals the pre-animation static render exactly.
+
+## Success Criteria
+- [ ] WPM counts 0→final over ~600ms with easeOut; lands exactly on final (no off-by-one blur).
+- [ ] Sparkline fills left→right; stat cards appear staggered; no horizontal jitter at any frame.
+- [ ] Final settled frame is **byte-identical** to the current static Result render (golden test).
+- [ ] Under `NO_COLOR`, reveal uses faint→normal only; layout-identical (line count + rune width).
+- [ ] `HasActiveAnim` false after `totalRevealMs`; loop self-stops.
+- [ ] A second consecutive result animates fresh (no inherited elapsed window from the prior result).
+- [ ] `make test-race`, `go vet`, `gofmt -l` clean; files < 200 LOC.
+
+## Risk Assessment
+- **Width jitter on digit growth (UX flag):** mitigated by reserved fixed-width digit slot; test asserts
+  constant rendered width across the count-up.
+- **Golden churn:** Result goldens become time-dependent; pin `nowMs` and add a dedicated
+  "settled frame == static" golden to lock the end state.
+- **Double-counting with update hint:** ensure the muted update-hint footer is excluded from reveal timing.

--- a/plans/260618-1454-ui-ux-animation-system/phase-05-new-best-celebration.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-05-new-best-celebration.md
@@ -1,0 +1,82 @@
+---
+phase: 5
+title: "New-best celebration"
+status: pending
+priority: P3
+effort: "4h"
+dependencies: [2, 4]
+---
+
+# Phase 5: New-best celebration
+
+## Overview
+When a test beats the per-mode personal best (the ★), fire a short, self-contained
+sparkle/confetti burst around the badge. Triggers **only on a new best** (never on
+ordinary results), then settles. Overlays existing cells — never shifts layout.
+
+## Requirements
+- Functional: ~1s particle burst anchored to the new-best badge; new-best only; one-shot.
+- Non-functional: overlay onto blank/padding cells only (no reflow); NO_COLOR → attribute
+  sparkle (reverse/bold) with identical cell count; stdlib particle math.
+
+## Architecture
+**Trigger:** the root already computes new-best when handling `ResultMsg`
+(`model.go:97` → `handleResultMsg`, the only place that detects new-best per CLAUDE.md).
+Pass an `isNewBest bool` into `ResultModel` on **every** `ResultMsg` (true OR false — never
+leave prior-result residue, or an ordinary result inherits `isNewBest=true` and fires spurious
+confetti). When true, set `celebrateStartMs = revealStartMs` (or slightly after the badge
+appears) so the burst rides the same frame loop from P4; when false, zero `celebrateStartMs`.
+
+**Particle model (`celebration.go`):** small fixed-capacity set (research: 5–7 cells) in a
+bounded region. Each particle: `{dx, dy, bornMs, lifeMs, glyph}`. Deterministic "randomness"
+without `math/rand` global: derive jitter from `(index, revealStartMs)` so renders are
+reproducible for golden tests. **Glyphs are ASCII width-1 ONLY** (`* + · .`) — no `✧`/non-BMP
+runes: the renderer hard-codes `cellW := 1` (`word_stream_renderer.go:124`), and a double-width
+or missing-glyph rune would break layout. Assert every glyph has display width 1.
+
+**Lifetime / render (red-team P2 — NOT the toast technique):** at `nowMs`, a particle is visible
+while `nowMs-bornMs < lifeMs` (`lifeMs≈250–300`); it twinkles on a short sub-cycle. The
+persistence-toast at `model_view.go:74` only rewrites the *single last line*; confetti needs a 2D
+region, and surgically replacing a rune at a visual column inside an already-SGR-styled line is
+error-prone (byte offset ≠ column offset). **Therefore restrict the burst to full-width blank
+MARGIN rows** (unstyled padding lines above/below the result card block), where rune replacement
+is trivial and width-safe. Never splice into styled content lines.
+
+**NO_COLOR:** particles render via `Reverse(true)`/`Bold(true)` on the glyph instead of accent color.
+Cell count and rune width unchanged → layout-identical (glyph content differs by design).
+
+**HasActiveAnim:** `ResultModel` extends its active window to include
+`nowMs < celebrateStartMs + celebrateMs` (`celebrateMs≈1000`).
+
+## Related Code Files
+- Create: `internal/ui/celebration.go` — particle set, `renderCelebration(nowMs, region, theme) []overlayCell`.
+- Create: `internal/ui/celebration_test.go` — particle lifetime, deterministic jitter, NO_COLOR attr,
+  overlay never changes line count / line width.
+- Modify: `internal/ui/screen_result.go` — `isNewBest`, `celebrateStartMs`; extend `HasActiveAnim`.
+- Modify: `internal/ui/screen_result_view.go` — apply celebration overlay onto the rendered frame.
+- Modify: `internal/app/model_result.go` — pass `isNewBest` into ResultModel construction.
+
+## Implementation Steps
+1. `celebration.go`: define particles anchored to a region rect; deterministic jitter from index+seed;
+   `renderCelebration` returns overlay cell positions+styled glyphs.
+2. Plumb `isNewBest` from the root’s new-best detection into `ResultModel`.
+3. Set `celebrateStartMs` (only when `isNewBest`); extend `HasActiveAnim` window.
+4. In result view, after composing the frame, splat overlay cells onto existing positions
+   (reuse the line-splice technique from `model_view.go`), guarding against out-of-bounds.
+5. Tests: assert overlay preserves `len(lines)` and each line’s rune width; NO_COLOR attr-only;
+   non-new-best result emits zero particles.
+
+## Success Criteria
+- [ ] New best → visible ~1s sparkle in the card’s blank margin rows; ordinary result → nothing.
+- [ ] A non-new-best result immediately following a new-best emits ZERO particles (no residue).
+- [ ] All glyphs are ASCII display-width 1 (asserted); overlay only touches blank margin rows.
+- [ ] Overlay never changes line count or any line’s rune width (asserted).
+- [ ] Under `NO_COLOR`, sparkle is attribute-only; layout-identical (line count + rune width).
+- [ ] Burst is one-shot; `HasActiveAnim` false after `celebrateMs`; loop self-stops.
+- [ ] `make test-race`, `go vet`, `gofmt -l` clean; files < 200 LOC.
+
+## Risk Assessment
+- **Annoyance / overuse:** restricted to new-best only and one-shot — matches research guidance.
+- **Overlay clipping at min terminal (60×20):** clamp region to the result frame bounds; if the
+  badge area is too tight, degrade to a minimal in-line sparkle rather than risk overrun.
+- **Determinism vs `math/rand`:** use index+seed jitter (no global RNG) so golden tests are stable.

--- a/plans/260618-1454-ui-ux-animation-system/phase-06-screen-transitions.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-06-screen-transitions.md
@@ -1,0 +1,99 @@
+---
+phase: 6
+title: "Screen transitions"
+status: pending
+priority: P2
+effort: "5h"
+dependencies: [2]
+---
+
+# Phase 6: Screen transitions
+
+## Overview
+Soften hard screen cuts with a short transition, primarily **Typing → Result**.
+Color themes get a **dim-curtain crossfade**; `NO_COLOR`/`mono` get a **directional
+wipe** (attribute-only, identical cell count) — this is the auto-adapt that preserves
+the layout-identical invariant (line count + rune width). Transitions are root-owned because they span two screens.
+
+## Requirements
+- Functional: ~250ms transition on Typing→Result (others may stay instant cuts);
+  crossfade in color, wipe under NO_COLOR.
+- Non-functional: never reflow; root `View()` stays the single chokepoint; self-stopping;
+  files < 200 LOC.
+
+## Architecture
+**Why root-owned:** a transition shows the *outgoing* frame and the *incoming* frame
+together, which only `app.Model.View()` can compose (it already routes all screens at
+`model_view.go:48`). Screen sub-models can’t see each other.
+
+**State (`app.Model`):** `transition *transitionState` with
+`{ fromFrame string; toScreen Screen; startMs, durMs int64 }`. `nil` = no transition.
+
+**Capture-then-animate:** when a transition-worthy nav occurs (e.g. `ResultMsg`), snapshot the
+**already-composed, placed** outgoing frame (the post-`lipgloss.Place` string that
+`model_view.go:60-63` produced for the user's *last* render — carry it forward rather than
+re-rendering the typing model after completion, which could paint a different frame) into
+`fromFrame`, set `toScreen`, `startMs=animNowMs`, bootstrap `frameTickCmd()`.
+
+**Render (`transition.go`):** given `progress = anim.EaseInOutQuad(...)`:
+- **Color (crossfade):** dim the `fromFrame` toward background and the incoming frame up from dim.
+  Implemented as an attribute-layer crossfade: outgoing wrapped in `Faint(true)` while
+  `progress<0.5`, incoming wrapped in `Faint(true)` while `progress<1`, swapping at the midpoint.
+  (Honest limitation: true per-cell alpha isn’t possible; faint-curtain is the terminal equivalent.)
+- **NO_COLOR (wipe):** reveal the incoming frame row-by-row over `from`:
+  `visibleRows = int(totalRows*progress)`; top `visibleRows` lines come from `toFrame`, the rest
+  from `fromFrame`. Pure string-line slicing — same width, same line count.
+- Resolve color vs NO_COLOR via `th.Color(RoleBg)==nil`.
+
+**Completion (derived expiry — red-team P1):** `View()` is a value receiver and **cannot** mutate
+`transition`; and a self-stopping loop must not depend on a "final cleanup tick" that may never be
+scheduled (the loop stops *because* the transition ended). So expiry is **derived, not mutated in
+View**: `View` treats the transition as active only while `m.animNowMs < startMs+durMs`, otherwise
+it ignores `fromFrame` and renders `toScreen` normally. The actual nil-out of `transition` happens
+lazily in `Update` on the next message (any KeyPress/tick), which is harmless because View already
+stopped using it. This removes the stall hazard with zero reliance on a trailing tick.
+
+**Cancellation (red-team P2):** `transition` is invalidated when its geometry or target becomes
+stale: `WindowSizeMsg` (`model.go:131`) cancels it (snap to `toScreen`) — the snapshot was taken
+at the old width and would mismatch; `AbortMsg` (`model.go:109`) clears it. These prevent old-width
+`fromFrame` bleeding over a new-width `toFrame`.
+
+**Scope guard (YAGNI):** implement Typing→Result only. Home→Typing stays an instant cut (user just
+pressed enter; immediacy is correct). Other navs stay instant unless the user later asks.
+
+## Related Code Files
+- Create: `internal/app/transition.go` — `transitionState`, `renderTransition(from, to string, progress float64, noColor bool) string`.
+- Create: `internal/app/transition_test.go` — wipe row math, crossfade midpoint swap, line-count/width invariants, NO_COLOR branch.
+- Modify: `internal/app/model_view.go` — when `transition != nil`, return `renderTransition(...)` (still via `altView`, single chokepoint).
+- Modify: `internal/app/model_result.go` (ResultMsg site) — capture `fromFrame`, set transition, bootstrap frame cmd.
+- Modify: `internal/app/anim_driver.go` — include `transition` liveness in `animActive` (declared P2; populated here).
+
+## Implementation Steps
+1. `transition.go`: define state + `renderTransition`; split both frames to `[]string` lines, pad
+   to equal line counts/widths defensively, compose per mode.
+2. At the ResultMsg site, snapshot outgoing frame (call the typing View used by `model_view.go:60`),
+   set `transition`, return `frameTickCmd()`.
+3. In `model_view.go`, branch to `renderTransition` only while `animNowMs < startMs+durMs`
+   (derived expiry); otherwise fall through to the normal per-screen switch. Do NOT mutate in View.
+4. Nil-out `transition` lazily in `Update` (next message after expiry); cancel it on
+   `WindowSizeMsg` and `AbortMsg`.
+5. Tests: wipe reveals exactly `floor(rows*progress)` rows; crossfade swaps at 0.5; both preserve
+   line count and per-line rune width; NO_COLOR path never emits color; expired transition is
+   ignored by View even if not yet nil-ed; resize/abort cancel cleanly.
+
+## Success Criteria
+- [ ] Typing→Result shows a ~250ms crossfade (color) / wipe (NO_COLOR), then the live Result reveal.
+- [ ] Transition never changes total line count or any line’s rune width (asserted both modes).
+- [ ] `model_view.go` remains the single return chokepoint (all paths via `altView`).
+- [ ] Transition expiry is derived in View (no value-receiver mutation); no stale-frame stall.
+- [ ] Resize during a transition snaps to `toScreen` (no old-width bleed); abort clears it.
+- [ ] `make test-race`, `go vet`, `gofmt -l` clean; files < 200 LOC.
+
+## Risk Assessment
+- **Faint-nesting reliability:** wrapping an already-styled frame in `Faint(true)` may not override
+  inner SGR on every terminal. Mitigation: if unreliable in manual check, fall back to the wipe for
+  color themes too (wipe is robust everywhere) — note the decision in P7 docs.
+- **Snapshot timing:** capturing the outgoing frame must happen before state flips to Result.
+  Order the ResultMsg handler to snapshot first.
+- **Degraded/min-size interaction:** transition must respect the 60×20 degraded gate
+  (`model_view.go:32`) — skip transition when degraded.

--- a/plans/260618-1454-ui-ux-animation-system/phase-07-hardening-and-docs.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-07-hardening-and-docs.md
@@ -1,0 +1,81 @@
+---
+phase: 7
+title: "Hardening and docs"
+status: pending
+priority: P1
+effort: "4h"
+dependencies: [3, 4, 5, 6]
+---
+
+# Phase 7: Hardening and docs
+
+## Overview
+Close out: benchmark the typing hot path, prove the NO_COLOR layout-identical
+invariant across every animated screen, refresh goldens deterministically, retune
+frame cadence if needed, enforce size/lint gates, and update docs. This is the
+gate that decides the cadence and whether any flagged risk (trail, faint-nesting)
+gets cut.
+
+## Requirements
+- Functional: full CI-equivalent green; settled-state goldens equal pre-animation output.
+- Non-functional: typing hot path shows no meaningful regression; binary-size cap respected; docs current.
+
+## Architecture
+**Determinism harness:** all animation is a pure function of `nowMs`, so tests inject fixed
+timestamps. Add a tiny test helper to render a screen at an explicit `nowMs` for golden capture
+at chosen frames (start / mid / settled).
+
+**Benchmark gate:** add `internal/ui` benchmark(s) that render the typing word-stream for a
+100-word and a Code-mode buffer with an active caret animation, comparing against a static render.
+The static-prefix token cache is **already built in P3** (mandatory), so the benchmark here
+*verifies* it works: animated allocs/op must stay close to static (only the ≤2 animated cells
+re-`Render`ed). If the benchmark shows the cache isn't engaging, fix P3's cache before proceeding.
+Record the chosen `frameInterval` (33ms vs 50ms) here based on the benchmark + a manual SSH smoke check.
+
+**Invariant proof:** a table test renders every animated screen (typing, result, celebration,
+transition) with `NO_COLOR=1` at several `nowMs` and asserts each line’s **rune width and line
+count** match the static render. NOTE this is the **layout-identical** guarantee (line count +
+rune width), which is the architecturally meaningful invariant. It is NOT literal byte-identity:
+the celebration overlays glyphs onto blank margin cells (rune *content* changes, width does not).
+The plan/docs use "layout-identical" wording accordingly.
+
+## Related Code Files
+- Create: `internal/ui/anim_bench_test.go` — static vs animated render benchmarks.
+- Create: `internal/ui/nocolor_layout_invariant_test.go` — per-screen rune-width/line-count equality under NO_COLOR.
+- Create: `internal/app/anim_edge_cases_test.go` — resize mid-transition (snap), abort mid-reveal
+  (state cleared), ctrl+r mid-caret-fade (caret reset), two consecutive results (second animates
+  fresh; non-best after best → no confetti), min-terminal 60×20 (transition/celebration skip/clamp).
+- Modify: golden files under `internal/ui` / `internal/app` testdata — re-capture with pinned `nowMs`.
+- Modify: `docs/codebase-summary.md` — add `internal/anim` package + per-screen animation notes.
+- Modify: `docs/system-architecture.md` — document the dual-tick model (100ms timer + 33ms self-stopping frame loop) and the NO_COLOR auto-adapt seam.
+- Modify: `docs/project-roadmap.md` — record shipped animation feature.
+- Modify: `README.md` — one line under Features (e.g., "subtle motion: animated caret, result reveal, celebration; auto-adapts to NO_COLOR").
+- Modify: `CHANGELOG`/release notes as the repo convention dictates (no version bump here unless asked).
+
+## Implementation Steps
+1. Add deterministic golden helper; re-capture animated-screen goldens at start/mid/settled.
+2. Write the NO_COLOR layout-invariant table test across all four moments.
+3. Write benchmarks; run `go test -bench` for the typing path; decide on prefix-cache + cadence.
+4. Run the full gate: `go test ./... -race -count=1`, `go vet ./...`, `gofmt -l .` (empty), `make size-check`.
+5. Update all docs listed above; ensure no plan-artifact references leak into code comments
+   (explain the *why*, e.g. "self-stopping frame loop bounds idle cost", not "per phase 2").
+6. Final whole-plan consistency pass: confirm constants (`frameInterval`, `blinkHalfMs`, `countUpMs`,
+   `celebrateMs`, transition `durMs`) are consistent across phases and docs.
+
+## Success Criteria
+- [ ] `go test ./... -race -count=1` green; `go vet` clean; `gofmt -l .` empty; `make size-check` passes.
+- [ ] Settled frame of every animated screen is byte-identical to its pre-animation static render
+      (the *settled* end state IS byte-identical; only mid-animation differs, and celebration only by content).
+- [ ] NO_COLOR layout-invariant test (rune width + line count) passes for typing, result, celebration, transition.
+- [ ] Edge-case tests pass: resize/abort/ctrl+r/double-result/min-terminal.
+- [ ] Typing hot-path benchmark confirms the P3 prefix-cache engages (animated allocs/op ≈ static).
+- [ ] Chosen `frameInterval` recorded with rationale; idle app schedules zero frame ticks.
+- [ ] Docs (`codebase-summary`, `system-architecture`, `roadmap`, `README`) updated; no plan refs in code.
+
+## Risk Assessment
+- **Golden flakiness:** any non-pinned timestamp reintroduces flakiness — assert all animated goldens
+  inject `nowMs`; fail the phase if any golden reads wall-clock.
+- **Binary-size creep:** new package + render code may approach the cap; if `size-check` fails, trim
+  the spring (if unused) and dead helpers before relaxing the cap.
+- **Scope-cut escalation:** if benchmark/UX review argues for dropping trail or color-crossfade, present
+  the data to the user (these were confirmed choices) — do not silently remove.

--- a/plans/260618-1454-ui-ux-animation-system/plan.md
+++ b/plans/260618-1454-ui-ux-animation-system/plan.md
@@ -1,0 +1,123 @@
+---
+title: "UI/UX Animation System"
+description: "Stdlib-only terminal motion system for Typeburn: pure anim package, self-stopping frame driver, animated caret, result reveal, new-best celebration, and screen transitions — always-on, NO_COLOR auto-adapting."
+status: pending
+priority: P2
+branch: "main"
+tags: [ui, animation, motion, tui]
+blockedBy: []
+blocks: []
+created: "2026-06-18T08:01:27.729Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# UI/UX Animation System
+
+## Overview
+
+Add a motion layer to Typeburn's Bubble Tea v2 / Lip Gloss v2 TUI to make it feel
+alive without breaking its strict architecture. Four moments: an animated caret
+(blink + new-cell fade + leave-trail), a result reveal (WPM count-up + sparkline
+draw-in + stat stagger), a new-best celebration burst, and screen transitions
+(crossfade in color / wipe under NO_COLOR).
+
+**Hard constraints carried from brainstorm (`docs/mdocs/20260618/01-20260618.md`):**
+- **Stdlib only** — hand-rolled easing/interpolation; no harmonica, no bubbles.
+- **Always on** — no reduced-motion toggle; motion **auto-adapts** under
+  `NO_COLOR`/`mono` to attribute-only variants so layout stays **layout-identical
+  (line count + rune width preserved)**. NOTE: this is *layout*-identical, not
+  literally *byte*-identical — the celebration (P5) overlays glyphs onto blank
+  padding cells, changing rune *content* of those cells while preserving width.
+  Flagged for user confirmation (see Open decisions).
+- **Pure-logic layering preserved** — new `internal/anim` package is UI-free
+  (joins `typing`/`metrics`/`words`); UI deps stay in `ui`/`app`/`theme`.
+- **<200 LOC per file**, allowed deps unchanged (stdlib + charm.land/* + cobra + x/*).
+
+**Key enabling facts (from research):**
+- Bubble Tea v2's cell-diff "Cursed Renderer" emits writes only for changed cells
+  → full-frame redraw at 30fps is cheap; an unchanged `View` costs ~zero.
+- `tea.Tick(d, fn)` fires **once**; loops are built by re-arming in `Update` →
+  a self-stopping frame loop is idiomatic and burns zero CPU when idle.
+- Color interp: `color.Color.RGBA()` (0–65535) → `/257` → `lipgloss.Color("#RRGGBB")`.
+- `theme.Color(Role)` returns `nil` under NO_COLOR → the auto-adapt detection hook.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Anim core package](./phase-01-anim-core-package.md) | Pending |
+| 2 | [Frame driver](./phase-02-frame-driver.md) | Pending |
+| 3 | [Caret animation](./phase-03-caret-animation.md) | Pending |
+| 4 | [Result reveal](./phase-04-result-reveal.md) | Pending |
+| 5 | [New-best celebration](./phase-05-new-best-celebration.md) | Pending |
+| 6 | [Screen transitions](./phase-06-screen-transitions.md) | Pending |
+| 7 | [Hardening and docs](./phase-07-hardening-and-docs.md) | Pending |
+
+## Build order & dependencies
+
+```
+P1 (anim pkg) ──► P2 (frame driver) ──┬─► P3 (caret)
+                                       ├─► P4 (result reveal) ──► P5 (celebration)
+                                       └─► P6 (transitions)
+                                                  └─► P7 (hardening + docs)
+```
+
+- P1 → P2 are the foundation; P3/P4/P6 are independent consumers of P2.
+- P5 depends on P4 (celebration overlays the result reveal).
+- P7 closes out: benchmarks, golden/NO_COLOR layout-identical verification, docs.
+
+## Cross-cutting design decisions
+
+1. **Two independent tick loops, by design.** The existing 100ms `timer.go` tick
+   (WPM/Time-mode completion) stays **untouched** to preserve tested behavior. A
+   **new** `FrameTickMsg` anim tick (~33ms) drives visuals and is **self-stopping**:
+   it re-arms only while ≥1 animation is live. Caret *blink* (slow, ~530ms cycle)
+   can ride the 100ms tick via a time-threshold; the fast 33ms frames are needed
+   only during the ~150ms fade/trail windows, so idle/paused typing falls back to
+   cheap cadence automatically.
+2. **`nowMs` is passed down, never read ad-hoc.** Animations are pure functions of
+   `(startMs, nowMs, durationMs)` so they stay deterministic and unit-testable
+   (mirrors how `metrics.Compute` replays a log post-hoc).
+3. **NO_COLOR auto-adapt is centralized.** A single helper resolves "do we have
+   color?" via `theme.Color(Role) != nil`; every animation asks it and swaps to
+   attribute-only (reverse/faint/bold, wipe instead of fade, no extra cells).
+4. **No layout mutation, ever.** Count-up reserves max digit width; confetti
+   overlays existing blank cells; transitions never reflow. Guarded by golden tests.
+
+## Open decisions deferred to validation/red-team
+
+- Frame cadence: 33ms (30fps) default vs 50ms (20Hz) SSH-safer. Benchmark gate in P7.
+- Caret trail jitter risk (UX researcher flagged) — verify legibility at speed in P3.
+- **"byte-identical" wording**: the brainstorm constraint said "byte-identical layout".
+  Resolved as **layout-identical** (line count + rune width). Celebration glyphs change
+  rune content of blank cells but not layout — confirm this reading is acceptable to user.
+
+## Red-team resolutions (applied to phases)
+
+Deep-mode adversarial review surfaced and these are now folded into the phases:
+- **FrameTick routing (P1):** root adds an explicit `case ui.FrameTickMsg` returning
+  `tea.Batch(subCmd, maybeFrameCmd())`; `TypingModel`/`ResultModel.Update` add a
+  `FrameTickMsg` case that stores `nowMs` — without it nothing animates. (P2, P3, P4)
+- **Bootstrap-on-edge (P1):** frame loop is bootstrapped only on the idle→active edge
+  via an explicit `frameLoopArmed bool`, never per-keystroke — otherwise overlapping
+  `tea.Tick` timers multiply and never self-stop. (P3)
+- **Transition clear (P1):** `View()` is a value receiver and cannot mutate state, and
+  the self-stopping loop could deadlock its own cleanup. Transition expiry is therefore
+  **derived** (`animNowMs >= startMs+durMs` → ignore it in View) and nil-out happens on
+  the next Update message — no reliance on a final cleanup tick. (P6)
+- **Prefix-token cache is mandatory in P3** (not deferred): cell-diff saves terminal
+  bytes but NOT the per-frame `Render`/alloc cost upstream in `word_stream_renderer.go`.
+- **Clock seam:** `applyText` gets an injectable `nowFn` (mirrors existing `seed`) so
+  caret goldens are deterministic; teatest cannot pin `time.Now()` otherwise. (P3)
+- **Celebration overlay** restricted to ASCII width-1 glyphs on full-width blank margin
+  rows (not surgical column splicing into SGR-styled lines). (P5)
+- **Edge cases added:** resize cancels active transition; abort/ctrl+r reset caret +
+  transition state; every `ResultMsg` unconditionally resets reveal + new-best state. (P4, P5, P6)
+- **Spring cut (YAGNI):** no consumer uses it; removed from P1.
+- **Pre-start blink:** typing screen bootstraps a tick on entry so the caret blinks
+  before the first keystroke. (P3)
+
+## Dependencies
+
+No cross-plan dependencies. All prior Typeburn plans in `plans/` are shipped/independent.

--- a/plans/reports/researcher-animation-patterns-bubble-tea-v2-20260618.md
+++ b/plans/reports/researcher-animation-patterns-bubble-tea-v2-20260618.md
@@ -1,0 +1,558 @@
+# Animation Patterns for Bubble Tea v2 + Lip Gloss v2 — Technical Report
+
+**Date:** 2026-06-18  
+**Scope:** STDLIB-ONLY animation system for Typeburn TUI (no harmonica, no bubbles)  
+**Confidence:** High (source: official pkg.go.dev, GitHub upgrade guides, live codebase verification)
+
+---
+
+## Executive Summary
+
+Bubble Tea v2 is animation-ready. The framework provides:
+- **Self-stopping frame loops** via `tea.Tick(d, fn)` with re-arming on demand
+- **Cell-based differential rendering** (Cursed Renderer) that makes frequent redraws cheap
+- **`tea.View` struct** enabling declarative rendering without string diffing
+- **Lip Gloss v2 color API** accepting `color.Color` for true-color interpolation
+
+With stdlib-only easing (cubic, quadratic) and critical-damping springs, you can build smooth animations without external dependencies. The Typeburn codebase already uses this pattern (100ms ticks in `internal/ui/timer.go`); animation support scales down to 30fps with no architectural changes.
+
+---
+
+## 1. Self-Stopping Frame Loop (Idiomatic v2)
+
+### Signature
+
+```go
+func tea.Tick(d time.Duration, fn func(time.Time) Msg) Cmd
+```
+
+**Key property:** Tick sends a *single* message; **you must re-arm it** to loop.
+
+### Pattern
+
+```go
+type FrameTickMsg struct{ t time.Time }
+
+func (m *Model) Init() tea.Cmd {
+    // Start the animation loop on app init or transition
+    return tea.Tick(animFrameInterval(), func(t time.Time) tea.Msg {
+        return FrameTickMsg{t: t}
+    })
+}
+
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case FrameTickMsg:
+        // Advance frame
+        m.frameIdx++
+        
+        // Stop condition: animation complete
+        if m.frameIdx >= m.frameDurationFrames {
+            m.isAnimating = false
+            return m, nil  // ← **Return nil to stop the loop**
+        }
+        
+        // Re-arm the tick to continue
+        return m, tea.Tick(animFrameInterval(), func(t time.Time) tea.Msg {
+            return FrameTickMsg{t: t}
+        })
+    }
+    return m, nil
+}
+```
+
+### Stopping Cleanly
+
+- **Stop:** Return `nil` instead of a Tick command
+- **Restart:** Return a new Tick command when animation should resume
+- **No CPU burn:** When `isAnimating = false`, Update doesn't return a Tick, so the event loop goes idle
+
+### Conditional Re-arming (Efficient)
+
+```go
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    case FrameTickMsg:
+        // ... update state ...
+        
+        if m.isAnimating {
+            return m, tea.Tick(animFrameInterval(), /* ... */)  // Loop
+        }
+        return m, nil  // Stop if animation end reached
+}
+```
+
+### `tea.Every` vs `tea.Tick`
+
+**`tea.Every(duration, fn func(time.Time) Msg) Cmd`** exists in v2 but **syncs to the system clock** (useful for synchronized multi-component ticks). For independent animation loops, **use `tea.Tick`** (ignores system clock, runs at your specified interval).
+
+### Frame Interval for 30fps
+
+```go
+func animFrameInterval() time.Duration {
+    // 30 fps → 33.33ms per frame
+    return time.Duration(float64(time.Second) / 30.0)  // ~33ms
+}
+```
+
+**Typeburn precedent:** `internal/ui/timer.go` uses `100*time.Millisecond` for live-WPM updates; dropping to 33ms for visual animation is a clean scale-down.
+
+---
+
+## 2. Color Interpolation in Lip Gloss v2
+
+### API Overview
+
+Lip Gloss v2 accepts **`color.Color` interface** (stdlib `image/color`).
+
+```go
+import "charm.land/lipgloss/v2"
+
+c1 := lipgloss.Color("#FF0000")  // Create from hex
+c2 := lipgloss.Color("#0000FF")
+
+style := lipgloss.NewStyle().
+    Foreground(c1).
+    Background(c2)
+
+output := style.Render("Text")
+```
+
+### Constructing Colors
+
+Three input formats:
+
+| Format | Example | Range |
+|--------|---------|-------|
+| **ANSI 16** (4-bit) | `lipgloss.Color("5")` | 0–15 |
+| **ANSI 256** (8-bit) | `lipgloss.Color("86")` | 0–255 |
+| **True Color** (24-bit hex) | `lipgloss.Color("#EB4268")` | `#000000`–`#FFFFFF` |
+
+### RGB Interpolation (Frame-by-Frame)
+
+```go
+func interpolateRGB(from, to color.Color, progress float64) color.Color {
+    // progress ∈ [0, 1]
+    
+    // Extract RGBA (returns 0–65535 range)
+    r1, g1, b1, _ := from.RGBA()
+    r2, g2, b2, _ := to.RGBA()
+    
+    // Interpolate in uint32 space
+    r := uint32(float64(r1)*(1-progress) + float64(r2)*progress)
+    g := uint32(float64(g1)*(1-progress) + float64(g2)*progress)
+    b := uint32(float64(b1)*(1-progress) + float64(b2)*progress)
+    
+    // Normalize from 0–65535 to 0–255 (divide by 257)
+    rn := r / 257
+    gn := g / 257
+    bn := b / 257
+    
+    // Reconstruct as hex
+    hexStr := fmt.Sprintf("#%02X%02X%02X", rn, gn, bn)
+    return lipgloss.Color(hexStr)
+}
+```
+
+**Typical animation loop:**
+
+```go
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    case FrameTickMsg:
+        // Compute progress (0→1)
+        progress := float64(m.frameIdx) / float64(m.frameDurationFrames)
+        
+        // Interpolate color
+        m.animColor = interpolateRGB(m.colorFrom, m.colorTo, progress)
+        
+        // Rebuild style with new color
+        m.animStyle = lipgloss.NewStyle().
+            Foreground(m.animColor).
+            Bold(true)
+        
+        return m, tea.Tick(/* ... */)
+}
+
+func (m *Model) View() tea.View {
+    text := m.animStyle.Render("Hello")
+    return tea.NewView(text)
+}
+```
+
+### Applied to Typeburn
+
+Typeburn uses semantic `Role` enum (e.g., `RoleAccent`, `RoleError`) mapped in `internal/theme/theme.go`. To animate:
+
+```go
+// theme/theme.go Style() method already knows how to resolve roles:
+colorFrom := t.colors[RoleAccent]
+colorTo   := t.colors[RoleSuccess]
+
+// In animation loop:
+animColor := interpolateRGB(colorFrom, colorTo, progress)
+style := lipgloss.NewStyle().Foreground(animColor)
+```
+
+**NO_COLOR support:** Themes support attribute-only rendering. Animated colors automatically fall back to attributes when `NO_COLOR=1` is set (see `theme.go:attrOnlyStyle()`).
+
+---
+
+## 3. How Charm's Components Animate (Reference)
+
+### Bubbles/Spinner Pattern
+
+The `bubbles/spinner` component (though not used here) demonstrates the canonical pattern:
+
+```go
+// Init: start the spinner
+func (m Model) Init() tea.Cmd {
+    return m.spinner.Tick  // spinner exposes a Cmd
+}
+
+// Update: delegate to spinner, get back next Cmd
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    m.spinner, cmd = m.spinner.Update(msg)
+    return m, cmd
+}
+```
+
+**Key insight:** The component is stateful (holds frame index internally); ticked externally via a `TickMsg`. Cadence (typically 50–100ms) is managed by the component's `Tick` Cmd.
+
+### For Stdlib-Only (No Bubbles)
+
+You don't need bubbles. Implement the same pattern inline:
+
+```go
+type AnimationModel struct {
+    frameIdx        int
+    frameDuration   int
+    isAnimating     bool
+}
+
+// Your own tick message
+type FrameTickMsg struct{ t time.Time }
+
+// Your own Tick command
+func (a *AnimationModel) nextTick() tea.Cmd {
+    if !a.isAnimating {
+        return nil  // Stop
+    }
+    return tea.Tick(33*time.Millisecond, func(t time.Time) tea.Msg {
+        return FrameTickMsg{t: t}
+    })
+}
+```
+
+---
+
+## 4. Rendering Cost & Damage Diffing
+
+### Bubble Tea v2 Rendering Architecture
+
+**Cell-Based Differential Renderer (Cursed Renderer):**
+
+Bubble Tea v2 uses the ncurses-based Cursed Renderer, which:
+- Tracks **dirty cells** (only cells that changed)
+- Sends **only differential updates** to the terminal (not full screen redraws)
+- Compares View content *cell-by-cell*, not string-by-string
+
+### Performance Impact
+
+**Official claim:** "Orders of magnitude" faster than v1.
+
+- **Local:** Snappier UI at high frame rates
+- **SSH:** Significantly lower bandwidth usage (cost reduction in cloud)
+
+### View() Signature (v2)
+
+```go
+func (m Model) View() tea.View {
+    s := "Content..."
+    return tea.NewView(s)  // Returns tea.View struct, not string
+}
+```
+
+The `tea.View` struct is **declarative**, enabling the renderer to:
+- Detect what changed
+- Avoid sending unchanged cells
+- Apply attributes/colors only to dirty regions
+
+### Returning the Same String Is Cheap
+
+If you return an identical `View`:
+
+```go
+func (m Model) View() tea.View {
+    // If this string is identical to last frame...
+    s := renderScreen(m)
+    return tea.NewView(s)
+}
+```
+
+**Result:** The cell-based renderer detects zero changes and sends **nothing** to the terminal. No CPU burn, no bandwidth waste.
+
+### Practical Implication
+
+Rendering a full 60×20 terminal at 30fps (33ms per frame) is **not a performance concern** in v2. The differential renderer handles it. You can safely:
+- Re-render the full view every frame
+- Animate colors, text, layout at 30fps
+- Rely on the framework to optimize
+
+**This is v2's major win over v1** — v1's line-based diff would send full lines on any pixel change; v2 sends only the cells that changed.
+
+---
+
+## 5. Easing Functions (Stdlib-Only)
+
+Use these canonical formulas directly in your animation code. No external deps.
+
+### EaseOutCubic (slow start, fast finish)
+
+```go
+func EaseOutCubic(t float64) float64 {
+    // t ∈ [0.0, 1.0]
+    t = t - 1
+    return t*t*t + 1
+}
+```
+
+**Use case:** Fade out, shrink, slide off-screen (decelerating exit).
+
+### EaseInOutQuad (accelerate → decelerate)
+
+```go
+func EaseInOutQuad(t float64) float64 {
+    // t ∈ [0.0, 1.0]
+    if t < 0.5 {
+        return 2 * t * t
+    }
+    t = t*2 - 1
+    return -0.5 * (t*(t-2) - 1)
+}
+```
+
+**Use case:** Smooth movement (snappy start, gentle finish).
+
+### Usage Example
+
+```go
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    case FrameTickMsg:
+        progress := float64(m.frameIdx) / float64(m.frameDurationFrames)
+        eased := EaseInOutQuad(progress)
+        
+        // Apply to position/scale/opacity
+        m.x = m.xStart + (m.xEnd - m.xStart) * eased
+        
+        return m, tea.Tick(/* ... */)
+}
+```
+
+---
+
+## 6. Critically Damped Spring (Stdlib-Only)
+
+For smooth motion that reaches equilibrium **without oscillating**, even if the target overshoots.
+
+### Setup
+
+```go
+type Spring struct {
+    pos    float64  // Current position
+    vel    float64  // Current velocity
+    target float64  // Equilibrium position
+    omega  float64  // Angular frequency (~3.0 for snappy feel)
+}
+```
+
+**Critical damping formula:** damping coefficient `c = 2 * omega` (ensures ζ = 1, no oscillation).
+
+### Step Function (Symplectic Euler Integration)
+
+```go
+func (s *Spring) Step(dt float64) {
+    // Precompute time-scaled coefficients
+    expTerm     := math.Exp(-s.omega * dt)
+    timeExp     := dt * expTerm
+    timeExpFreq := timeExp * s.omega
+    
+    // Position update coefficients
+    posPosCoef := timeExpFreq + expTerm
+    posVelCoef := timeExp
+    
+    // Velocity update coefficients
+    velPosCoef := -s.omega * timeExpFreq
+    velVelCoef := -timeExpFreq + expTerm
+    
+    // Apply updates (relative to target)
+    oldPos := s.pos - s.target
+    s.pos = oldPos*posPosCoef + s.vel*posVelCoef + s.target
+    s.vel = oldPos*velPosCoef + s.vel*velVelCoef
+}
+```
+
+### Animation Loop Integration
+
+```go
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    case FrameTickMsg:
+        dt := 0.033  // 33ms frame time, in seconds
+        m.spring.target = m.targetValue
+        m.spring.Step(dt)
+        
+        // Use m.spring.pos for rendering
+        m.displayValue = m.spring.pos
+        
+        return m, tea.Tick(33*time.Millisecond, /* ... */)
+}
+```
+
+### Tuning
+
+- **omega ≈ 3.0:** Snappy (reaches target in ~0.5–1s)
+- **omega ≈ 1.0:** Floaty (reaches target in ~1–2s)
+- Higher omega = faster response, risk of jerky motion if dt is too large
+- Lower omega = smoother but sluggish
+
+### Why Critical Damping?
+
+- **Reaches equilibrium in minimum time** (no oscillation to settle)
+- Ideal for camera pans, value fading, transitions
+- Robust to target changes mid-animation (smooth interruption)
+
+---
+
+## 7. V1 → V2 Differences (Animation-Relevant)
+
+| Aspect | v1 | v2 | Impact |
+|--------|----|----|--------|
+| **View() return type** | `string` | `tea.View` struct | Enables cell-diff rendering; safe to re-render every frame |
+| **`tea.Tick` signature** | — | `tea.Tick(d, fn func(time.Time) Msg) Cmd` | No change; still single-fire; must re-arm in Update |
+| **`tea.Every`** | — | `tea.Every(d, fn func(time.Time) Msg) Cmd` | v2 addition; syncs to system clock (not used for independent animations) |
+| **Renderer** | Line-based diff | Cell-based Cursed Renderer | Orders of magnitude faster; full-screen 30fps redraws are cheap |
+| **Lip Gloss colors** | `color.Color` interface | Same | No changes to color API between v1 and v2 |
+
+**Key finding:** No breaking changes to animation APIs between v1 and v2. The win is in rendering efficiency.
+
+---
+
+## 8. Recommended Architecture for Typeburn
+
+### Phase Structure
+
+1. **Define a frame message:**
+   ```go
+   type FrameTickMsg struct{ t time.Time }
+   ```
+
+2. **Add animation state to screen models** (e.g., TypingModel, ResultModel):
+   ```go
+   type TypingModel struct {
+       // ... existing fields ...
+       animFrameIdx       int
+       animDurationFrames int
+       isAnimating        bool
+       animColor          color.Color
+       animStyle          lipgloss.Style
+   }
+   ```
+
+3. **Start animation on transition:**
+   ```go
+   func (m TypingModel) startAnimation() (TypingModel, tea.Cmd) {
+       m.isAnimating = true
+       m.animFrameIdx = 0
+       return m, tea.Tick(33*time.Millisecond, func(t time.Time) tea.Msg {
+           return FrameTickMsg{t: t}
+       })
+   }
+   ```
+
+4. **Update on frame tick:**
+   ```go
+   case FrameTickMsg:
+       if !m.isAnimating {
+           return m, nil  // Guard: shouldn't receive tick if not animating
+       }
+       
+       progress := float64(m.animFrameIdx) / float64(m.animDurationFrames)
+       eased := EaseInOutQuad(progress)
+       
+       m.animColor = interpolateRGB(m.colorFrom, m.colorTo, eased)
+       m.animStyle = lipgloss.NewStyle().Foreground(m.animColor)
+       
+       m.animFrameIdx++
+       if m.animFrameIdx >= m.animDurationFrames {
+           m.isAnimating = false
+           return m, nil  // Stop loop
+       }
+       
+       return m, tea.Tick(33*time.Millisecond, /* ... */)
+   ```
+
+5. **Render with animated style:**
+   ```go
+   func (m TypingModel) View() tea.View {
+       var s strings.Builder
+       if m.isAnimating {
+           s.WriteString(m.animStyle.Render("Animated text"))
+       }
+       s.WriteString(/* ... rest of view ... */)
+       return tea.NewView(s.String())
+   }
+   ```
+
+### File Organization
+
+Keep animation helpers in a new `internal/animation/` package:
+
+```
+internal/animation/
+├── easing.go              # EaseOutCubic, EaseInOutQuad
+├── spring.go              # Spring struct + Step()
+├── interpolate.go         # interpolateRGB()
+└── animation.go           # Shared types (FrameTickMsg, etc.)
+```
+
+Or add them directly to `internal/ui/timer.go` (already animation-focused).
+
+---
+
+## Implementation Checklist
+
+- [ ] Define `FrameTickMsg` type in `internal/ui/messages.go` (alongside existing `StartTestMsg`, etc.)
+- [ ] Add easing functions to `internal/animation/easing.go` (or `internal/ui/easing.go`)
+- [ ] Add `interpolateRGB()` to `internal/animation/colors.go`
+- [ ] Add `Spring` struct + `Step()` to `internal/animation/spring.go` (optional; use if spring easing desired)
+- [ ] Update screen models (e.g., `ResultModel`) to hold animation state
+- [ ] Add frame-tick handler to screen `Update()` methods
+- [ ] Call animation start on screen transition (e.g., when showing result)
+- [ ] Update `View()` to use animated styles
+- [ ] Run `make test-race` to verify no race conditions
+- [ ] Test at 30fps (33ms ticks) on a slow terminal (SSH) to confirm rendering efficiency
+
+---
+
+## Unresolved Questions
+
+1. **Animation triggering:** Should animation start automatically when a screen appears, or on-demand (e.g., via a keystroke)? Depends on UX design.
+
+2. **Frame cadence flexibility:** Should all animations use 33ms ticks, or would some benefit from 50ms (20fps) to save bandwidth on slow terminals? Recommend 33ms for typing-test UX (results reveal fast); measure in testing.
+
+3. **Interpolation accuracy:** The `interpolateRGB()` function divides by 257 to normalize uint32 (0–65535) to uint8 (0–255). Confirm rounding is acceptable or use proper scaling (multiply by 255, divide by 65535).
+
+4. **Spring stiffness mapping:** No guidance on omega values for typical Typeburn use cases (result reveal, transition timing). Recommend empirical tuning with omega ∈ [1.0, 5.0].
+
+5. **Simultaneous animations:** If multiple screen elements animate in parallel, do they share one `FrameTickMsg` or define separate tick types? Current Typeburn app.Model routes to one active screen at a time (no parallelism), so single `FrameTickMsg` should suffice. Revisit if multi-screen animation is added.
+
+---
+
+## Sources
+
+- [Bubble Tea v2 pkg.go.dev — tea.Tick, tea.Every](https://pkg.go.dev/charm.land/bubbletea/v2)
+- [Bubble Tea v2 Upgrade Guide — View() changes](https://github.com/charmbracelet/bubbletea/blob/main/UPGRADE_GUIDE_V2.md)
+- [Bubble Tea v2 Release — Cursed Renderer (PR #1200)](https://github.com/charmbracelet/bubbletea/pull/1200)
+- [Lip Gloss v2 pkg.go.dev — Color API](https://pkg.go.dev/charm.land/lipgloss/v2)
+- [Gotween — Easing implementations](https://github.com/paddycarey/gotween/blob/master/gotween.go)
+- [RyanJuckett — Critically Damped Springs](https://www.ryanjuckett.com/damped-springs/)
+- [Typeburn timer.go — Existing Tick pattern](https://github.com/bavanchun/Typeburn/blob/main/internal/ui/timer.go)
+- [Typeburn theme.go — Color and Role system](https://github.com/bavanchun/Typeburn/blob/main/internal/theme/theme.go)


### PR DESCRIPTION
## Phase 1 — Anim core package

First phase of the UI/UX Animation System (`plans/260618-1454-ui-ux-animation-system/`).

Adds `internal/anim`, a **pure, UI-free** package holding all motion math:

- `easing.go` — `EaseOutCubic`, `EaseOutQuad`, `EaseInOutQuad`, `Clamp01`
- `color.go` — `LerpColor` over `image/color` (nil-passthrough for the NO_COLOR branch)
- `tween.go` — `Tween{StartMs,DurMs,Ease}` + `Progress`/`Done`, `LerpInt`/`LerpFloat`
- `clock.go` — `Clock` aggregating tweens; `Active(nowMs)` powers the self-stopping frame loop

### Guarantees
- No `charm.land`/`bubbletea`/`lipgloss` imports (`go list -deps` clean) — joins `typing`/`metrics`/`words` as pure logic
- Deterministic: every value is a function of `(startMs, nowMs, durMs)`
- Table-driven tests, no mocks; every file < 200 LOC
- `go test -race`, `go vet`, `gofmt -l` all clean

Also lands the plan + research artifacts for the full 7-phase system.