### PR TITLE
feat(app): self-stopping animation frame driver

### DIFF
--- a/internal/app/anim_driver.go
+++ b/internal/app/anim_driver.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bavanchun/Typeburn/internal/ui"
+)
+
+// The frame-tick command and cadence live in package ui (ui.FrameTickCmd /
+// ui.FrameInterval) so screen sub-models can also bootstrap the loop on the
+// idle→active edge; the root only decides whether to re-arm via maybeFrameCmd.
+
+// animActive reports whether any animation is live at nowMs: the active screen's
+// own animation OR a root-owned transition. This is the signal that decides
+// whether the frame loop re-arms — the basis of the self-stop behavior.
+func (m Model) animActive(nowMs int64) bool {
+	switch m.screen {
+	case ScreenTyping:
+		if m.typing.HasActiveAnim(nowMs) {
+			return true
+		}
+	case ScreenResult:
+		if m.result.HasActiveAnim(nowMs) {
+			return true
+		}
+	}
+	return m.transitionActive(nowMs)
+}
+
+// maybeFrameCmd returns a frame re-arm command iff an animation is still live at
+// the current animNowMs, else nil. Returning nil is exactly what stops the loop.
+func (m Model) maybeFrameCmd() tea.Cmd {
+	if m.animActive(m.animNowMs) {
+		return ui.FrameTickCmd()
+	}
+	return nil
+}
+
+// handleFrameTick stamps the shared animation clock (animNowMs), forwards the
+// tick to the active screen so it can advance its own tween state, then re-arms
+// the loop only while an animation remains live.
+func (m Model) handleFrameTick(msg ui.FrameTickMsg) (tea.Model, tea.Cmd) {
+	m.animNowMs = msg.T.UnixMilli()
+
+	var subCmd tea.Cmd
+	switch m.screen {
+	case ScreenTyping:
+		m.typing, subCmd = m.typing.Update(msg)
+	case ScreenResult:
+		m.result, subCmd = m.result.Update(msg)
+	}
+	return m, tea.Batch(subCmd, m.maybeFrameCmd())
+}
+
+// transitionActive reports whether a root-owned screen transition is mid-flight
+// at nowMs. Transitions span two screens, so only the root can track them; the
+// real state lands with the screen-transition feature, which replaces this body
+// with a live check. Until then there is no transition to be live.
+func (m Model) transitionActive(nowMs int64) bool {
+	return false
+}

--- a/internal/app/anim_driver_test.go
+++ b/internal/app/anim_driver_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/ui"
+)
+
+// ui.FrameTickCmd's command, when run, must produce a FrameTickMsg carrying the
+// fire time — this is what re-arms the loop.
+func TestFrameTickCmd_ProducesFrameTickMsg(t *testing.T) {
+	cmd := ui.FrameTickCmd()
+	if cmd == nil {
+		t.Fatal("ui.FrameTickCmd returned nil")
+	}
+	msg := cmd()
+	if _, ok := msg.(ui.FrameTickMsg); !ok {
+		t.Fatalf("FrameTickCmd produced %T, want ui.FrameTickMsg", msg)
+	}
+}
+
+// With every screen reporting idle, a frame tick must NOT re-arm: the batch
+// collapses to nil so the loop self-stops.
+func TestHandleFrameTick_StopsWhenIdle(t *testing.T) {
+	m := newTestModel()
+	now := time.UnixMilli(5000)
+
+	model, cmd := m.handleFrameTick(ui.FrameTickMsg{T: now})
+	got := model.(Model)
+
+	if got.animNowMs != 5000 {
+		t.Errorf("animNowMs=%d want 5000", got.animNowMs)
+	}
+	if cmd != nil {
+		t.Errorf("idle frame tick re-armed (cmd != nil); loop should self-stop")
+	}
+}
+
+// maybeFrameCmd is the self-stop seam: nil when nothing is live.
+func TestMaybeFrameCmd_NilWhenIdle(t *testing.T) {
+	m := newTestModel()
+	m.screen = ScreenTyping
+	if cmd := m.maybeFrameCmd(); cmd != nil {
+		t.Errorf("maybeFrameCmd non-nil while typing idle")
+	}
+	m.screen = ScreenResult
+	if cmd := m.maybeFrameCmd(); cmd != nil {
+		t.Errorf("maybeFrameCmd non-nil while result idle")
+	}
+}
+
+// A frame tick must never advance WPM/completion: routing it through the typing
+// screen leaves the screen idle (no spurious test start, loop stops).
+func TestFrameTick_DoesNotStartTest(t *testing.T) {
+	m := newTestModel()
+	m.screen = ScreenTyping
+	m.typing = ui.NewTyping(config.ModeTime, 30, 0, m.theme, m.keys, false).SetSize(80, 24)
+
+	model, _ := m.handleFrameTick(ui.FrameTickMsg{T: time.UnixMilli(1234)})
+	got := model.(Model)
+	if got.animActive(got.animNowMs) {
+		t.Errorf("frame tick made an idle typing screen report active")
+	}
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -48,6 +48,12 @@ type Model struct {
 	// failing persist site and cleared on the next keypress (any key) so the
 	// notice behaves like a dismissible toast; it never blocks input.
 	persistErr string
+
+	// animNowMs is the shared animation clock: the epoch-ms of the most recent
+	// FrameTickMsg. Animated screens read it (stored on the sub-model) so every
+	// moment derives purely from time, mirroring metrics.Compute's replay. Zero
+	// until the first frame tick fires.
+	animNowMs int64
 }
 
 // New builds the root model with the given theme, settings, optional code
@@ -78,6 +84,13 @@ func (m Model) Init() tea.Cmd { return nil }
 // Update handles global concerns (resize, quit, navigation) and delegates to
 // the active screen sub-model.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// FrameTickMsg: animation frame. Handled by an explicit root branch (never
+	// the generic delegation below) so the self-stopping re-arm command is not
+	// lost. Stamps animNowMs, forwards to the active screen, re-arms iff live.
+	if ft, ok := msg.(ui.FrameTickMsg); ok {
+		return m.handleFrameTick(ft)
+	}
+
 	// StartTestMsg: Home screen requested a test start.
 	if sm, ok := msg.(ui.StartTestMsg); ok {
 		var t ui.TypingModel

--- a/internal/ui/frame_tick.go
+++ b/internal/ui/frame_tick.go
@@ -1,0 +1,25 @@
+package ui
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// FrameInterval is the cadence of the self-stopping animation frame loop. It is
+// independent of the 100ms timer tick (timer.go): the frame loop only runs while
+// at least one screen — or a root-owned transition — reports a live animation,
+// and self-stops back to zero scheduled ticks once everything settles.
+//
+// It lives in package ui (not app) so both the root driver's re-arm and a screen
+// sub-model's bootstrap-on-edge can schedule the same single-fire tick.
+const FrameInterval = 33 * time.Millisecond
+
+// FrameTickCmd schedules a single animation frame tick producing a FrameTickMsg.
+// The loop stays alive only by re-arming this in Update while an animation is
+// live (mirrors timer.go's single-fire re-arm), so an idle app schedules none.
+func FrameTickCmd() tea.Cmd {
+	return tea.Tick(FrameInterval, func(t time.Time) tea.Msg {
+		return FrameTickMsg{T: t}
+	})
+}

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -4,10 +4,20 @@
 package ui
 
 import (
+	"time"
+
 	"github.com/bavanchun/Typeburn/internal/config"
 	"github.com/bavanchun/Typeburn/internal/metrics"
 	"github.com/bavanchun/Typeburn/internal/words"
 )
+
+// FrameTickMsg drives the self-stopping animation frame loop owned by the root
+// app.Model. It is a distinct type from the 100ms timer's tickMsg so routing is
+// unambiguous: the timer tick advances WPM/completion, the frame tick advances
+// only visual tween state. T is the fire time; the field is exported because the
+// command that produces it lives in the app package. The loop re-arms in Update
+// only while an animation is live, so an idle app schedules zero frame ticks.
+type FrameTickMsg struct{ T time.Time }
 
 // ResultMsg is emitted by TypingModel when a test finishes. The root model
 // receives it and transitions to ScreenResult.

--- a/internal/ui/screen_result.go
+++ b/internal/ui/screen_result.go
@@ -31,6 +31,11 @@ type ResultModel struct {
 	w, h int
 	th   theme.Theme
 	km   config.Keymap
+
+	// nowMs is the shared animation clock, stamped from each FrameTickMsg. The
+	// result reveal derives every animated value purely from it; real reveal
+	// timing is wired in a later phase.
+	nowMs int64
 }
 
 // NewResult constructs a ResultModel from a completed ResultMsg. The isBest
@@ -79,6 +84,11 @@ func (m ResultModel) WithUpdateHint(hint *update.Result) ResultModel {
 //   - 3            → History (placeholder until Phase 8)
 //   - ctrl+c       → quit (handled globally by root; forwarded here for completeness)
 func (m ResultModel) Update(msg tea.Msg) (ResultModel, tea.Cmd) {
+	if ft, ok := msg.(FrameTickMsg); ok {
+		// Animation frame: store the shared clock so the reveal can advance.
+		m.nowMs = ft.T.UnixMilli()
+		return m, nil
+	}
 	kp, ok := msg.(tea.KeyPressMsg)
 	if !ok {
 		return m, nil
@@ -111,6 +121,11 @@ func (m ResultModel) restartSameCmd() tea.Cmd {
 		return StartTestMsg{Mode: mode, Length: length, QuoteLen: ql, CodeText: ct}
 	}
 }
+
+// HasActiveAnim reports whether the result screen has a live animation at nowMs,
+// so the frame driver knows whether to keep running 33ms frames. Real reveal /
+// celebration timing is wired in later phases; for now it reports idle.
+func (m ResultModel) HasActiveAnim(nowMs int64) bool { return false }
 
 // NavHistoryMsg is emitted when the user navigates to the History screen from
 // the Result screen. The root routes it to ScreenHistory.

--- a/internal/ui/screen_typing.go
+++ b/internal/ui/screen_typing.go
@@ -87,6 +87,11 @@ func (m TypingModel) Update(msg tea.Msg) (TypingModel, tea.Cmd) {
 		return m, nil
 	case tickMsg:
 		return m.handleTick(msg)
+	case FrameTickMsg:
+		// Animation frame: store the shared clock so View-side caret tweens can
+		// advance. Never touches WPM/completion — that is the timer tick's job.
+		m.nowMs = msg.T.UnixMilli()
+		return m, nil
 	case tea.KeyPressMsg:
 		return m.handleKey(msg.Key())
 	case tea.PasteMsg:
@@ -170,6 +175,11 @@ func (m TypingModel) applyText(text string) (TypingModel, tea.Cmd) {
 	}
 	return m, nil
 }
+
+// HasActiveAnim reports whether the typing screen has a live animation at nowMs,
+// so the frame driver knows whether to keep running 33ms frames. Real caret
+// animation timing is wired in a later phase; for now the screen reports idle.
+func (m TypingModel) HasActiveAnim(nowMs int64) bool { return false }
 
 // Test lifecycle actions (restartSame, newTest, completeCmd) live in
 // screen_typing_actions.go to keep this file focused on Update/key handling.


### PR DESCRIPTION
## Phase 2 — Frame driver

Second phase of the UI/UX Animation System. Adds the single, app-owned
animation loop every animated moment will hook into. The existing 100ms
`timer.go` tick is **not touched**.

### What lands
- `ui.FrameTickMsg` + `ui.FrameTickCmd()` / `ui.FrameInterval` (33ms) — the
  single-fire frame tick. Placed in `ui` (not `app`) so a screen sub-model can
  bootstrap the loop on the idle→active edge *and* the root can re-arm it.
- `app/anim_driver.go`:
  - `animActive(nowMs)` — OR of the active screen's `HasActiveAnim` + a
    root-owned transition (stub until the transitions phase)
  - `maybeFrameCmd()` — re-arm **iff** live; nil is exactly what self-stops the loop
  - `handleFrameTick()` — stamp `animNowMs`, forward to active screen, re-arm
- Root `Update` routes `FrameTickMsg` via an **explicit** branch (never the
  generic delegation) so the re-arm command can't be dropped.
- `TypingModel`/`ResultModel` each get a `FrameTickMsg` case (store `nowMs`) and
  a `HasActiveAnim` hook returning idle for now.

### Guarantees
- Idle app schedules **zero** frame ticks (`Init` stays nil)
- Frame ticks never advance WPM/completion (separate from the timer loop)
- Self-stop logic unit-tested; `go test -race`, `go vet`, `gofmt -l` clean; files < 200 LOC