### PR TITLE
feat(ui): animated typing caret (blink, new-cell fade, trail)

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -103,7 +103,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.typing = t.SetSize(m.w, m.h)
 		m.screen = ScreenTyping
-		return m, nil
+		// Bootstrap the 100ms tick so the caret blinks before the first keystroke.
+		return m, m.typing.InitCmd()
 	}
 
 	// ResultMsg: test completed → persist record, detect new-best, show result.

--- a/internal/ui/caret_anim.go
+++ b/internal/ui/caret_anim.go
@@ -1,0 +1,123 @@
+package ui
+
+import (
+	"charm.land/lipgloss/v2"
+
+	"github.com/bavanchun/Typeburn/internal/anim"
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+// Caret animation timing. blinkHalfMs is half the 530ms blink cycle (the
+// long-standing Windows caret rate); caretFadeMs is the fast-frame window after
+// each keystroke during which the new cell fades and the vacated cell trails.
+const (
+	blinkHalfMs int64 = 265
+	caretFadeMs int64 = 150
+)
+
+// caretAnim carries per-frame caret timing into the stream renderers. The zero
+// value (cursorIdx == 0 but lastKeyMs == 0, blinkOn false) does NOT animate the
+// way disabledCaret does; always construct via the View or disabledCaret().
+//
+// When cursorIdx < 0 no caret overrides apply at all, so the render is
+// byte-identical to the static stream — this protects existing goldens and the
+// settled end state.
+type caretAnim struct {
+	nowMs     int64
+	lastKeyMs int64
+	blinkOn   bool
+	cursorIdx int // index of the Current cell; <0 = none (complete/disabled)
+}
+
+// disabledCaret returns a caretAnim that applies no overrides.
+func disabledCaret() caretAnim { return caretAnim{cursorIdx: -1} }
+
+// blinkOnAt derives the blink phase purely from time, so it needs no stored
+// toggle and stays deterministic under a pinned clock.
+func blinkOnAt(nowMs int64) bool {
+	if nowMs <= 0 {
+		return true
+	}
+	return (nowMs/blinkHalfMs)%2 == 0
+}
+
+// elapsed is milliseconds since the last keystroke (clamped at ≥0).
+func (c caretAnim) elapsed() int64 {
+	d := c.nowMs - c.lastKeyMs
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+// fadeActive reports whether the post-keystroke fast-frame window is still open.
+// This is what HasActiveAnim keys on, so the 33ms loop self-stops ~150ms after
+// the last keystroke and falls back to the 100ms blink cadence.
+func (c caretAnim) fadeActive() bool {
+	return c.lastKeyMs > 0 && c.elapsed() < caretFadeMs
+}
+
+// caretCellStyle returns the animated style for the cell at distance d from the
+// cursor (0 = cursor, 1 = freshly-typed cell, 2 = just-vacated trail) and whether
+// an override applies. When it returns false the renderer keeps the base style,
+// so non-animated frames cost nothing extra and settle byte-identical.
+//
+// Color themes interpolate foreground; under NO_COLOR (theme.Color == nil) the
+// animation degrades to an attribute step (bold/faint) with identical cell width.
+func (c caretAnim) caretCellStyle(d int, st typing.CharState, th theme.Theme) (lipgloss.Style, bool) {
+	switch d {
+	case 0:
+		// Cursor cell: blink. When "on" (or steady) the base already renders the
+		// cursor block, so no override is needed; when "off" it looks like the
+		// upcoming untyped cell. NO_COLOR: base cursor is Reverse(true); off drops
+		// the reverse (RoleTextFaint), so the blink is an attribute toggle.
+		if c.blinkOn {
+			return lipgloss.NewStyle(), false
+		}
+		return th.Style(theme.RoleTextFaint), true
+	case 1:
+		// Freshly-typed correct cell fades accent → muted over the window.
+		if st != typing.Correct || !c.fadeActive() {
+			return lipgloss.NewStyle(), false
+		}
+		return c.fadeStyle(th, theme.RoleAccent, theme.RoleTextMuted, true), true
+	case 2:
+		// Just-vacated correct cell trails one notch dim → muted over the window.
+		if st != typing.Correct || !c.fadeActive() {
+			return lipgloss.NewStyle(), false
+		}
+		return c.fadeStyle(th, theme.RoleTextFaint, theme.RoleTextMuted, false), true
+	}
+	return lipgloss.NewStyle(), false
+}
+
+// fadeStyle builds the interpolated style for an animated cell. boldStep selects
+// the NO_COLOR fallback: true → bold for the first half of the window (the new
+// cell), false → faint for the whole window (the trail). The settled colors equal
+// the cell's base role, so the end frame matches the static render.
+func (c caretAnim) fadeStyle(th theme.Theme, from, to theme.Role, boldStep bool) lipgloss.Style {
+	fc, tc := th.Color(from), th.Color(to)
+	if fc == nil || tc == nil { // NO_COLOR: attribute step, never color math
+		if boldStep {
+			if c.elapsed() < caretFadeMs/2 {
+				return lipgloss.NewStyle().Bold(true)
+			}
+			return lipgloss.NewStyle()
+		}
+		return lipgloss.NewStyle().Faint(true)
+	}
+	t := anim.EaseOutQuad(anim.Clamp01(float64(c.elapsed()) / float64(caretFadeMs)))
+	return lipgloss.NewStyle().Foreground(anim.LerpColor(fc, tc, t))
+}
+
+// indexOfCurrent returns the index of the Current (cursor) cell, or -1 if none
+// (a completed test has no cursor).
+func indexOfCurrent(states []typing.CharState) int {
+	for i, s := range states {
+		if s == typing.Current {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/ui/caret_anim_test.go
+++ b/internal/ui/caret_anim_test.go
@@ -1,0 +1,192 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+// statesFromTyped builds a states slice: n0 leading Correct cells, a Current
+// cursor cell, then the rest Untyped — the common "typed a prefix" shape.
+func statesTyped(correct, total int) []typing.CharState {
+	st := make([]typing.CharState, total)
+	for i := range st {
+		switch {
+		case i < correct:
+			st[i] = typing.Correct
+		case i == correct:
+			st[i] = typing.Current
+		default:
+			st[i] = typing.Untyped
+		}
+	}
+	return st
+}
+
+func TestBlinkOnAt_Phase(t *testing.T) {
+	if !blinkOnAt(0) {
+		t.Error("blinkOnAt(0) should be on (pre-start steady)")
+	}
+	if !blinkOnAt(10) { // 10/265 = 0 → on
+		t.Error("blinkOnAt(10) should be on")
+	}
+	if blinkOnAt(300) { // 300/265 = 1 → off
+		t.Error("blinkOnAt(300) should be off")
+	}
+	if !blinkOnAt(600) { // 600/265 = 2 → on
+		t.Error("blinkOnAt(600) should be on")
+	}
+}
+
+// A disabled caret must render byte-identically to the static stream.
+func TestRenderWordStreamAnim_DisabledMatchesStatic(t *testing.T) {
+	th := theme.Default()
+	target := runesOf("hello world")
+	typed := runesOf("hello")
+	states := statesTyped(5, len(target))
+
+	static := RenderWordStream(states, target, typed, 40, th)
+	anim := renderWordStreamAnim(states, target, typed, 40, th, disabledCaret(), &streamTokenCache{})
+	if static != anim {
+		t.Errorf("disabled caret differs from static render:\nstatic=%q\nanim  =%q", static, anim)
+	}
+}
+
+// A settled caret (fade window elapsed, blink on) applies no overrides, so it
+// also matches the static render exactly — the end frame is byte-identical.
+func TestRenderWordStreamAnim_SettledMatchesStatic(t *testing.T) {
+	th := theme.Default()
+	target := runesOf("hello world")
+	typed := runesOf("hello")
+	states := statesTyped(5, len(target))
+
+	ca := caretAnim{nowMs: 100000, lastKeyMs: 100000 - 1000, blinkOn: true, cursorIdx: 5}
+	if ca.fadeActive() {
+		t.Fatal("precondition: fade should be inactive after 1s")
+	}
+	static := RenderWordStream(states, target, typed, 40, th)
+	anim := renderWordStreamAnim(states, target, typed, 40, th, ca, &streamTokenCache{})
+	if static != anim {
+		t.Errorf("settled caret differs from static render")
+	}
+}
+
+// During the fade window the freshly-typed cell is restyled, so the animated
+// output differs from static — but only in SGR, never in runes/width.
+func TestRenderWordStreamAnim_FadeChangesStyleOnly(t *testing.T) {
+	th := theme.Default()
+	target := runesOf("hello world")
+	typed := runesOf("hello")
+	states := statesTyped(5, len(target))
+
+	ca := caretAnim{nowMs: 100000, lastKeyMs: 100000, blinkOn: true, cursorIdx: 5}
+	static := RenderWordStream(states, target, typed, 40, th)
+	anim := renderWordStreamAnim(states, target, typed, 40, th, ca, &streamTokenCache{})
+
+	if static == anim {
+		t.Error("fade-active caret should differ from static (new-cell fade not applied)")
+	}
+	if strip(static) != strip(anim) {
+		t.Errorf("fade changed runes/layout, not just SGR:\nstatic=%q\nanim=%q", strip(static), strip(anim))
+	}
+}
+
+// Under NO_COLOR the caret animation must stay layout-identical: same runes,
+// same line count, same per-line width — only attributes differ.
+func TestRenderWordStreamAnim_NoColorLayoutIdentical(t *testing.T) {
+	th := theme.Load("default", true) // NO_COLOR / attribute-only
+	target := runesOf("hello world")
+	typed := runesOf("hello")
+	states := statesTyped(5, len(target))
+
+	static := RenderWordStream(states, target, typed, 40, th)
+	// blink off + fade active = the most overrides under NO_COLOR.
+	ca := caretAnim{nowMs: 100000, lastKeyMs: 100000, blinkOn: false, cursorIdx: 5}
+	anim := renderWordStreamAnim(states, target, typed, 40, th, ca, &streamTokenCache{})
+
+	if strip(static) != strip(anim) {
+		t.Errorf("NO_COLOR caret not layout-identical:\nstatic=%q\nanim=%q", strip(static), strip(anim))
+	}
+}
+
+// caretCellStyle gating: cursor blinks; fade/trail only apply to Correct cells
+// inside the window.
+func TestCaretCellStyle_Gating(t *testing.T) {
+	th := theme.Default()
+	on := caretAnim{nowMs: 1000, lastKeyMs: 1000, blinkOn: true, cursorIdx: 3}
+	off := caretAnim{nowMs: 1000, lastKeyMs: 1000, blinkOn: false, cursorIdx: 3}
+
+	// d=0 cursor: no override when on (base draws block), override when off.
+	if _, ok := on.caretCellStyle(0, typing.Current, th); ok {
+		t.Error("cursor d=0 with blink on should use base (no override)")
+	}
+	if _, ok := off.caretCellStyle(0, typing.Current, th); !ok {
+		t.Error("cursor d=0 with blink off should override (faint)")
+	}
+	// d=1 new cell: override only when Correct + in window.
+	if _, ok := on.caretCellStyle(1, typing.Correct, th); !ok {
+		t.Error("new cell d=1 Correct in-window should override")
+	}
+	if _, ok := on.caretCellStyle(1, typing.Incorrect, th); ok {
+		t.Error("new cell d=1 non-Correct should not override")
+	}
+	// Out of window → no fade override.
+	stale := caretAnim{nowMs: 5000, lastKeyMs: 1000, blinkOn: true, cursorIdx: 3}
+	if _, ok := stale.caretCellStyle(1, typing.Correct, th); ok {
+		t.Error("new cell d=1 out of window should not override")
+	}
+	if _, ok := stale.caretCellStyle(2, typing.Correct, th); ok {
+		t.Error("trail d=2 out of window should not override")
+	}
+}
+
+// The prefix-token cache must be reused across frames with no content change,
+// and rebuilt after invalidation — this is what keeps animated allocs bounded.
+func TestPrefixCacheReuse(t *testing.T) {
+	th := theme.Default()
+	target := runesOf("hello world foo")
+	typed := runesOf("hello")
+	states := statesTyped(5, len(target))
+	ca := caretAnim{nowMs: 100000, lastKeyMs: 100000, blinkOn: true, cursorIdx: 5}
+	cache := &streamTokenCache{}
+
+	_ = renderWordStreamAnim(states, target, typed, 40, th, ca, cache)
+	if !cache.valid {
+		t.Fatal("cache should be valid after first render")
+	}
+	firstArr := &cache.base[0]
+
+	_ = renderWordStreamAnim(states, target, typed, 40, th, ca, cache)
+	if &cache.base[0] != firstArr {
+		t.Error("cache base rebuilt on a no-change frame (not reused)")
+	}
+
+	cache.invalidate()
+	if cache.valid {
+		t.Error("invalidate did not clear valid")
+	}
+	_ = renderWordStreamAnim(states, target, typed, 40, th, ca, cache)
+	if !cache.valid {
+		t.Error("cache not rebuilt after invalidation")
+	}
+}
+
+// HasActiveAnim opens only inside the fade window after a keystroke.
+func TestHasActiveAnim_Window(t *testing.T) {
+	m := newTestTyping(config.ModeWords, 10)
+	if m.HasActiveAnim(1000) {
+		t.Error("no keystroke yet → inactive")
+	}
+	m.lastKeyMs = 1000
+	if !m.HasActiveAnim(1000) {
+		t.Error("at keystroke → active")
+	}
+	if !m.HasActiveAnim(1000 + caretFadeMs - 1) {
+		t.Error("inside window → active")
+	}
+	if m.HasActiveAnim(1000 + caretFadeMs) {
+		t.Error("at window end → inactive (self-stop)")
+	}
+}

--- a/internal/ui/code_stream_renderer.go
+++ b/internal/ui/code_stream_renderer.go
@@ -32,6 +32,22 @@ func RenderCodeStream(
 	width, height int,
 	th theme.Theme,
 ) string {
+	return renderCodeStreamAnim(states, target, typed, width, height, th, disabledCaret())
+}
+
+// renderCodeStreamAnim is RenderCodeStream with caret animation applied. The
+// cursor blink and the ≤2 cells behind it get their animated styles; with a
+// disabled caret (cursorIdx < 0) the output equals RenderCodeStream exactly, so
+// existing goldens hold. Code mode has no token cache (its viewport recompute is
+// the pre-existing cost); only the ≤3 animated cells differ per frame.
+func renderCodeStreamAnim(
+	states []typing.CharState,
+	target []rune,
+	typed []rune,
+	width, height int,
+	th theme.Theme,
+	ca caretAnim,
+) string {
 	if width < 1 {
 		width = 40
 	}
@@ -85,6 +101,14 @@ func RenderCodeStream(
 			r = ' '
 		}
 		st := styleFor(states[i])
+		// Caret animation: override the cursor cell and the ≤2 cells behind it.
+		if ca.cursorIdx >= 0 {
+			if d := ca.cursorIdx - i; d >= 0 && d <= 2 {
+				if ast, ok := ca.caretCellStyle(d, states[i], th); ok {
+					st = ast
+				}
+			}
+		}
 		if states[i] == typing.Current {
 			caretRow = len(rows) // caret lives in the row being built now
 		}

--- a/internal/ui/screen_typing.go
+++ b/internal/ui/screen_typing.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"time"
-
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/bavanchun/Typeburn/internal/config"
@@ -28,13 +26,24 @@ type TypingModel struct {
 	headerWPM   float64 // last computed live WPM for header
 	lastPaintMs int64   // throttle: last time header WPM was recomputed
 
-	blink bool // wired from settings (Phase 7); steady block default = false
+	blink bool // wired from settings; false = steady block, true = blinking
 
 	th   theme.Theme
 	keys config.Keymap
 
 	// seed used when ctrl+r generates a new test (0 = time-based random)
 	seed int64
+
+	// Caret animation state. lastKeyMs is the time of the most recent keystroke
+	// (drives the new-cell fade + trail window). frameLoopArmed guards the
+	// idle→active edge so exactly one 33ms frame loop runs regardless of typing
+	// speed. nowFn is the injectable clock seam (defaults to time.Now) so caret
+	// goldens are deterministic. wordCache holds the static prefix of styled
+	// word-stream tokens so only the ≤3 animated cells re-Render per frame.
+	lastKeyMs      int64
+	frameLoopArmed bool
+	nowFn          func() int64
+	wordCache      *streamTokenCache
 }
 
 // AbortMsg is emitted when the user presses esc on the typing screen.
@@ -70,6 +79,7 @@ func newTypingWithSeed(
 	return TypingModel{
 		eng: s.Engine, mode: s.Mode, length: s.Length, ql: s.QuoteLen,
 		target: s.Target, th: th, keys: km, blink: blink, seed: seed,
+		nowFn: defaultNowFn, wordCache: &streamTokenCache{},
 	}
 }
 
@@ -90,7 +100,12 @@ func (m TypingModel) Update(msg tea.Msg) (TypingModel, tea.Cmd) {
 	case FrameTickMsg:
 		// Animation frame: store the shared clock so View-side caret tweens can
 		// advance. Never touches WPM/completion — that is the timer tick's job.
+		// When the fade window has closed, disarm so the root's re-arm check stops
+		// the loop and the next keystroke can bootstrap a fresh one.
 		m.nowMs = msg.T.UnixMilli()
+		if !m.HasActiveAnim(m.nowMs) {
+			m.frameLoopArmed = false
+		}
 		return m, nil
 	case tea.KeyPressMsg:
 		return m.handleKey(msg.Key())
@@ -143,6 +158,7 @@ func (m TypingModel) handleKey(k tea.Key) (TypingModel, tea.Cmd) {
 	if k.Code == tea.KeyBackspace {
 		if m.startMs != 0 {
 			m.eng.Backspace(m.nowMs)
+			m.wordCache.invalidate() // engine state changed; rebuild base tokens
 		}
 		return m, nil
 	}
@@ -154,32 +170,8 @@ func (m TypingModel) handleKey(k tea.Key) (TypingModel, tea.Cmd) {
 	return m, nil
 }
 
-// applyText feeds printable runes into the engine and starts the timer on the
-// first keystroke.
-func (m TypingModel) applyText(text string) (TypingModel, tea.Cmd) {
-	nowMs := time.Now().UnixMilli()
-	firstKey := m.startMs == 0
-	if firstKey {
-		m.startMs = nowMs
-		m.nowMs = nowMs
-	}
-	for _, r := range text {
-		m.eng.Apply(r, nowMs)
-	}
-	// Words/Quote: check completion after each keystroke.
-	if m.mode != config.ModeTime && m.eng.Complete(nowMs) {
-		return m, m.completeCmd(nowMs)
-	}
-	if firstKey {
-		return m, tickCmd()
-	}
-	return m, nil
-}
-
-// HasActiveAnim reports whether the typing screen has a live animation at nowMs,
-// so the frame driver knows whether to keep running 33ms frames. Real caret
-// animation timing is wired in a later phase; for now the screen reports idle.
-func (m TypingModel) HasActiveAnim(nowMs int64) bool { return false }
-
-// Test lifecycle actions (restartSame, newTest, completeCmd) live in
-// screen_typing_actions.go to keep this file focused on Update/key handling.
+// Keystroke application (applyText) and the caret clock seam live in
+// screen_typing_input.go; caret animation hooks (HasActiveAnim, InitCmd,
+// caretAnimState) in screen_typing_caret.go; test lifecycle actions
+// (restartSame, newTest, completeCmd) in screen_typing_actions.go — keeping this
+// file focused on Update/message routing and key dispatch.

--- a/internal/ui/screen_typing_actions.go
+++ b/internal/ui/screen_typing_actions.go
@@ -9,10 +9,14 @@ import (
 	"github.com/bavanchun/Typeburn/internal/theme"
 )
 
-// restartSame resets engine and timer but keeps the same target text.
+// restartSame resets engine and timer but keeps the same target text. It also
+// clears caret state and the token cache so a stale fade never renders on the
+// fresh test's first frame.
 func (m TypingModel) restartSame() TypingModel {
 	m.eng = runner.RebuildEngine(m.target, m.mode, m.length)
 	m.startMs, m.nowMs, m.lastPaintMs, m.headerWPM = 0, 0, 0, 0
+	m.lastKeyMs, m.frameLoopArmed = 0, false
+	m.wordCache.invalidate()
 	return m
 }
 
@@ -52,6 +56,7 @@ func (m TypingModel) TargetText() string { return m.target }
 func (m TypingModel) ApplySettings(s config.Settings, th theme.Theme) TypingModel {
 	m.blink = s.BlinkCursor
 	m.th = th
+	m.wordCache.invalidate() // theme change alters base token styles
 	return m
 }
 

--- a/internal/ui/screen_typing_caret.go
+++ b/internal/ui/screen_typing_caret.go
@@ -1,0 +1,36 @@
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+// HasActiveAnim reports whether a fast-frame caret animation is live at nowMs:
+// true only inside the post-keystroke fade/trail window. The blink itself rides
+// the 100ms timer tick (not the frame loop), so once the fade window closes the
+// 33ms loop self-stops and the caret keeps blinking at the cheaper cadence.
+func (m TypingModel) HasActiveAnim(nowMs int64) bool {
+	return m.lastKeyMs > 0 && nowMs-m.lastKeyMs < caretFadeMs
+}
+
+// InitCmd bootstraps the 100ms timer tick when the typing screen becomes active
+// so the caret blinks BEFORE the first keystroke (the tick otherwise starts only
+// once typing begins). The root returns this when entering ScreenTyping.
+func (m TypingModel) InitCmd() tea.Cmd { return tickCmd() }
+
+// caretAnimState builds the per-frame caret animation descriptor from the current
+// model clock and cursor position. When blink is off (steady block) the cursor is
+// always "on"; otherwise the blink phase derives purely from nowMs.
+func (m TypingModel) caretAnimState(states []typing.CharState) caretAnim {
+	blinkOn := true
+	if m.blink {
+		blinkOn = blinkOnAt(m.nowMs)
+	}
+	return caretAnim{
+		nowMs:     m.nowMs,
+		lastKeyMs: m.lastKeyMs,
+		blinkOn:   blinkOn,
+		cursorIdx: indexOfCurrent(states),
+	}
+}

--- a/internal/ui/screen_typing_code.go
+++ b/internal/ui/screen_typing_code.go
@@ -18,13 +18,15 @@ import (
 func NewTypingCode(target string, th theme.Theme, km config.Keymap, blink bool) TypingModel {
 	s := runner.NewCodeSession(target)
 	return TypingModel{
-		eng:    s.Engine,
-		mode:   s.Mode,
-		target: s.Target,
-		th:     th,
-		keys:   km,
-		blink:  blink,
-		seed:   0,
+		eng:       s.Engine,
+		mode:      s.Mode,
+		target:    s.Target,
+		th:        th,
+		keys:      km,
+		blink:     blink,
+		seed:      0,
+		nowFn:     defaultNowFn,
+		wordCache: &streamTokenCache{},
 	}
 }
 

--- a/internal/ui/screen_typing_input.go
+++ b/internal/ui/screen_typing_input.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+)
+
+// defaultNowFn is the production caret clock: wall-clock epoch milliseconds.
+func defaultNowFn() int64 { return time.Now().UnixMilli() }
+
+// nowMillis returns the current epoch-ms via the injectable clock seam, falling
+// back to wall-clock when nowFn is unset (e.g. a zero-value model in a test).
+func (m TypingModel) nowMillis() int64 {
+	if m.nowFn != nil {
+		return m.nowFn()
+	}
+	return time.Now().UnixMilli()
+}
+
+// applyText feeds printable runes into the engine and starts the timer on the
+// first keystroke. It also records the keystroke time (driving the caret fade +
+// trail), invalidates the token cache, and bootstraps the 33ms frame loop on the
+// idle→active edge only.
+func (m TypingModel) applyText(text string) (TypingModel, tea.Cmd) {
+	nowMs := m.nowMillis()
+	firstKey := m.startMs == 0
+	if firstKey {
+		m.startMs = nowMs
+		m.nowMs = nowMs
+	}
+	for _, r := range text {
+		m.eng.Apply(r, nowMs)
+	}
+	m.lastKeyMs = nowMs
+	m.wordCache.invalidate() // engine state changed; rebuild base tokens
+
+	// Words/Quote: check completion after each keystroke.
+	if m.mode != config.ModeTime && m.eng.Complete(nowMs) {
+		return m, m.completeCmd(nowMs)
+	}
+
+	var cmds []tea.Cmd
+	if firstKey {
+		cmds = append(cmds, tickCmd())
+	}
+	// Bootstrap the frame loop ONLY on the idle→active edge: returning it per
+	// keystroke would multiply overlapping tea.Tick timers that never self-stop.
+	if !m.frameLoopArmed {
+		m.frameLoopArmed = true
+		cmds = append(cmds, FrameTickCmd())
+	}
+	return m, tea.Batch(cmds...)
+}

--- a/internal/ui/screen_typing_view.go
+++ b/internal/ui/screen_typing_view.go
@@ -34,7 +34,13 @@ func (m TypingModel) View() string {
 	)
 
 	// Select renderer based on mode: Code uses the literal code stream renderer;
-	// all other modes use the word stream renderer (golden-tested, unchanged).
+	// all other modes use the word stream renderer. Both take the per-frame caret
+	// animation; a settled caret renders identically to the static stream.
+	states := m.eng.States()
+	target := []rune(m.target)
+	typed := m.eng.Typed()
+	ca := m.caretAnimState(states)
+
 	var stream string
 	if m.mode == config.ModeCode {
 		// streamHeight = total height minus fixed overhead rows; clamp ≥1.
@@ -42,22 +48,9 @@ func (m TypingModel) View() string {
 		if streamHeight < 1 {
 			streamHeight = 1
 		}
-		stream = RenderCodeStream(
-			m.eng.States(),
-			[]rune(m.target),
-			m.eng.Typed(),
-			cw,
-			streamHeight,
-			m.th,
-		)
+		stream = renderCodeStreamAnim(states, target, typed, cw, streamHeight, m.th, ca)
 	} else {
-		stream = RenderWordStream(
-			m.eng.States(),
-			[]rune(m.target),
-			m.eng.Typed(),
-			cw,
-			m.th,
-		)
+		stream = renderWordStreamAnim(states, target, typed, cw, m.th, ca, m.wordCache)
 	}
 
 	footer := RenderFooter(TypingHints(), m.w, m.th)

--- a/internal/ui/word_stream_anim.go
+++ b/internal/ui/word_stream_anim.go
@@ -1,0 +1,84 @@
+package ui
+
+import (
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/typing"
+)
+
+// streamTokenCache holds the static prefix of styled word-stream tokens so the
+// caret animation only re-Renders the ≤3 animated cells per frame instead of
+// every rune. The v2 cell-diff renderer saves output bytes but NOT the upstream
+// per-rune Style.Render/alloc cost, which would otherwise run for the whole
+// stream at 33fps during the fade window. The cache is invalidated on any
+// content or theme change (keystroke/backspace/restart/new-test/theme swap);
+// width is irrelevant because wrapping is a separate pass over the same tokens.
+type streamTokenCache struct {
+	base  []string
+	valid bool
+}
+
+// invalidate marks the cache stale; the next render rebuilds the base tokens.
+func (c *streamTokenCache) invalidate() {
+	if c != nil {
+		c.valid = false
+	}
+}
+
+// renderWordStreamAnim renders the word-stream with caret animation applied. It
+// reuses cached base tokens (rebuilding only on content/theme change) and
+// re-Renders only the ≤3 animated cells around the cursor, then wraps. With a
+// disabled caret (cursorIdx < 0) the output equals RenderWordStream exactly.
+func renderWordStreamAnim(
+	states []typing.CharState,
+	target []rune,
+	typed []rune,
+	width int,
+	th theme.Theme,
+	ca caretAnim,
+	cache *streamTokenCache,
+) string {
+	if width < 1 {
+		width = 40
+	}
+
+	var base []string
+	if cache != nil && cache.valid && len(cache.base) == len(states) {
+		base = cache.base
+	} else {
+		base = buildWordTokens(states, target, typed, th)
+		if cache != nil {
+			cache.base = base
+			cache.valid = true
+		}
+	}
+
+	tokens := base
+	if ca.cursorIdx >= 0 {
+		tokens = make([]string, len(base))
+		copy(tokens, base)
+		applyCaretOverrides(tokens, states, target, typed, ca, th)
+	}
+	return wrapTokens(tokens, states, target, typed, width)
+}
+
+// applyCaretOverrides re-Renders the cursor cell and the ≤2 cells behind it with
+// their animated styles. It never changes a cell's rune or width — only its SGR.
+func applyCaretOverrides(
+	tokens []string,
+	states []typing.CharState,
+	target, typed []rune,
+	ca caretAnim,
+	th theme.Theme,
+) {
+	for d := 0; d <= 2; d++ {
+		i := ca.cursorIdx - d
+		if i < 0 || i >= len(tokens) {
+			continue
+		}
+		st, ok := ca.caretCellStyle(d, states[i], th)
+		if !ok {
+			continue
+		}
+		tokens[i] = st.Render(string(runeAtIndex(i, target, typed)))
+	}
+}

--- a/internal/ui/word_stream_renderer.go
+++ b/internal/ui/word_stream_renderer.go
@@ -9,17 +9,70 @@ import (
 	"github.com/bavanchun/Typeburn/internal/typing"
 )
 
+// runeAtIndex returns the single display rune at index i: a target rune, then an
+// extra typed rune past the target, then a blank for the trailing cursor cell.
+func runeAtIndex(i int, target, typed []rune) rune {
+	if i < len(target) {
+		return target[i]
+	}
+	if i < len(typed) {
+		return typed[i]
+	}
+	return ' '
+}
+
+// buildWordTokens renders one styled string per rune from its CharState. This is
+// the single source of base styling shared by the static and animated renderers,
+// so a settled animated frame is byte-identical to the static stream.
+func buildWordTokens(states []typing.CharState, target, typed []rune, th theme.Theme) []string {
+	stUntyped := th.Style(theme.RoleTextFaint)
+	stCorrect := th.Style(theme.RoleTextMuted)
+	stIncorrect := th.Style(theme.RoleError) // .Underline already in theme
+	stIncorrectSpace := th.Style(theme.RoleErrorBg)
+	stExtra := th.Style(theme.RoleError).Faint(true)
+	stCurrent := th.Style(theme.RoleCursorBg)
+
+	tokens := make([]string, len(states))
+	for i := range states {
+		r := runeAtIndex(i, target, typed)
+		ch := string(r)
+
+		var st lipgloss.Style
+		switch states[i] {
+		case typing.Correct:
+			st = stCorrect
+		case typing.Incorrect:
+			st = stIncorrect
+		case typing.IncorrectSpace:
+			// Wrong char where a space was expected or vice-versa; show as a
+			// background-highlighted block so the missed boundary is visible.
+			if r == ' ' {
+				ch = " "
+			}
+			st = stIncorrectSpace
+		case typing.Extra:
+			st = stExtra
+		case typing.Current:
+			// Block cursor: show a space if current position is at end of target.
+			if r == ' ' {
+				ch = " "
+			}
+			st = stCurrent
+		default: // Untyped
+			st = stUntyped
+		}
+		tokens[i] = st.Render(ch)
+	}
+	return tokens
+}
+
 // RenderWordStream renders the typing word-stream as a multi-line string.
 //
 // Each rune in target is styled according to its CharState. Extra typed runes
 // (past the target length) are appended at the end. Wrapping is a hard
-// character-cell wrap at `width`: when the next rune would overflow the line
-// it starts a new line, so a word longer than `width` IS split between runes
-// (never within a multi-byte rune). A space landing at/after the boundary
-// also flushes so the following word begins on a fresh line. This is not a
-// word-aware (scan-back) wrap.
-//
-// Rendering is rune-safe: all iteration uses []rune, not byte slices.
+// character-cell wrap at `width` (rune-counted, not byte-counted, since styled
+// tokens carry ANSI escapes). This is the static, animation-free render used by
+// non-typing callers and golden tests.
 func RenderWordStream(
 	states []typing.CharState,
 	target []rune,
@@ -30,62 +83,7 @@ func RenderWordStream(
 	if width < 1 {
 		width = 40
 	}
-
-	// Build pre-computed styles once to avoid re-allocating per rune.
-	stUntypedStyle := th.Style(theme.RoleTextFaint)
-	stCorrectStyle := th.Style(theme.RoleTextMuted)
-	stIncorrectStyle := th.Style(theme.RoleError) // .Underline already in theme
-	stIncorrectSpaceStyle := th.Style(theme.RoleErrorBg)
-	stExtraStyle := th.Style(theme.RoleError).Faint(true)
-	stCurrentStyle := th.Style(theme.RoleCursorBg)
-
-	// Build styled tokens: one styled string per rune.
-	total := len(states)
-	tokens := make([]string, total)
-
-	for i := 0; i < total; i++ {
-		var r rune
-		if i < len(target) {
-			r = target[i]
-		} else if i < len(typed) {
-			r = typed[i]
-		} else {
-			r = ' '
-		}
-
-		ch := string(r)
-
-		var st lipgloss.Style
-		switch states[i] {
-		case typing.Correct:
-			st = stCorrectStyle
-		case typing.Incorrect:
-			st = stIncorrectStyle
-		case typing.IncorrectSpace:
-			// Wrong char where a space was expected or vice-versa; show as
-			// a background-highlighted block so the missed boundary is visible.
-			if r == ' ' {
-				ch = " " // keep as space so the bg block is visible
-			}
-			st = stIncorrectSpaceStyle
-		case typing.Extra:
-			st = stExtraStyle
-		case typing.Current:
-			// Block cursor: show a space if current position is at end of target.
-			if r == ' ' {
-				ch = " "
-			}
-			st = stCurrentStyle
-		default: // Untyped
-			st = stUntypedStyle
-		}
-
-		tokens[i] = st.Render(ch)
-	}
-
-	// Hard character-cell wrap at width columns. We wrap on rune counts (not
-	// byte length) because styled tokens carry ANSI escapes that inflate bytes;
-	// the raw rune count of the current line is tracked instead.
+	tokens := buildWordTokens(states, target, typed, th)
 	return wrapTokens(tokens, states, target, typed, width)
 }
 
@@ -110,15 +108,7 @@ func wrapTokens(
 	}
 
 	for i, tok := range tokens {
-		// Determine the raw rune (single cell) for width accounting.
-		var r rune
-		if i < len(target) {
-			r = target[i]
-		} else if i < len(typed) {
-			r = typed[i]
-		} else {
-			r = ' '
-		}
+		r := runeAtIndex(i, target, typed)
 		// One terminal cell per rune (ASCII/Latin). CJK double-width is not
 		// handled — deferred (roadmap m5, "CJK width support if quotes added").
 		cellW := 1
@@ -140,7 +130,6 @@ func wrapTokens(
 		}
 	}
 
-	// Flush any remaining content.
 	if lineBuilder.Len() > 0 {
 		lines = append(lines, lineBuilder.String())
 	}


### PR DESCRIPTION
## Phase 3 — Caret animation

Third phase of the UI/UX Animation System. Brings the typing caret to life on
the one perf-sensitive hot path.

### Behaviour
- **Blink** — derived purely from `nowMs` (530ms cycle), rides the existing 100ms
  timer tick (no fast frames). Caret blinks **before** the first keystroke
  (root returns `InitCmd` on entering ScreenTyping).
- **New-cell fade** — freshly-typed correct cell eases `RoleAccent → RoleTextMuted`
  over ~150ms; **trail** — just-vacated cell decays dim → muted. Both ride the
  33ms frame loop, which **self-stops** ~150ms after the last keystroke.
- **One loop, any speed** — bootstrapped on the idle→active edge only
  (`frameLoopArmed`), cleared when the window closes.

### Invariants
- **NO_COLOR layout-identical** — blink→reverse, fade→bold step, trail→faint step;
  same runes / line count / per-line width (asserted).
- **Settled = static** — disabled/settled caret renders byte-identical to the old
  static stream, so existing goldens are unchanged.
- **Prefix-token cache** — only the ≤3 animated cells re-`Render` per frame; base
  stream cached, invalidated on keystroke/backspace/restart/new-test/theme change.
  Threaded into both word and code renderers.
- **Deterministic** — injectable `nowFn` clock seam; caret state reset on
  restartSame/newTest (no stale fade).

### Housekeeping
Split into `<200 LOC` files by concern: `caret_anim.go`, `word_stream_anim.go`,
`screen_typing_input.go`, `screen_typing_caret.go`.

`go test -race`, `go vet`, `gofmt -l` all clean.