### PR TITLE
feat(ui): result screen entrance reveal

### DIFF
--- a/internal/app/anim_driver_test.go
+++ b/internal/app/anim_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/metrics"
 	"github.com/bavanchun/Typeburn/internal/ui"
 )
 
@@ -62,5 +63,38 @@ func TestFrameTick_DoesNotStartTest(t *testing.T) {
 	got := model.(Model)
 	if got.animActive(got.animNowMs) {
 		t.Errorf("frame tick made an idle typing screen report active")
+	}
+}
+
+func TestResultMsg_BootstrapsFrameLoop(t *testing.T) {
+	m := newTestModel()
+	staleNow := time.Now().UTC().UnixMilli() - 10_000
+	m.animNowMs = staleNow
+	msg := ui.ResultMsg{
+		Result: metrics.Result{NetWPM: 80, Accuracy: 100, DurationMs: 30000},
+		Mode:   config.ModeTime,
+		Length: 30,
+	}
+
+	model, cmd := m.Update(msg)
+	got := model.(Model)
+	if got.screen != ScreenResult {
+		t.Fatalf("screen=%v want ScreenResult", got.screen)
+	}
+	if cmd == nil {
+		t.Fatal("ResultMsg should bootstrap a frame tick")
+	}
+	if !got.result.HasActiveAnim(time.Now().UTC().UnixMilli()) {
+		t.Fatal("result reveal should start fresh even when the shared clock is stale")
+	}
+
+	got.animNowMs = time.Now().UTC().UnixMilli() - 10_000
+	model, cmd = got.Update(msg)
+	next := model.(Model)
+	if cmd == nil {
+		t.Fatal("second ResultMsg should bootstrap a frame tick")
+	}
+	if !next.result.HasActiveAnim(time.Now().UTC().UnixMilli()) {
+		t.Fatal("second result reveal should restart from the current frame time")
 	}
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -56,31 +56,6 @@ type Model struct {
 	animNowMs int64
 }
 
-// New builds the root model with the given theme, settings, optional code
-// text/hint, and an optional update hint.
-// codeText is the snippet loaded from --text (empty = Code disabled);
-// codeHint is a user-facing load-failure reason (empty = no error);
-// updateHint is non-nil when an opportunistic check found a newer release.
-func New(th theme.Theme, settings config.Settings, codeText, codeHint string, updateHint *update.Result) Model {
-	km := config.DefaultKeymap()
-	home := ui.NewHome(settings, th, km, codeText, codeHint)
-	m := Model{
-		screen:     ScreenHome,
-		theme:      th,
-		keys:       km,
-		settings:   settings,
-		home:       home,
-		codeText:   codeText,
-		codeHint:   codeHint,
-		updateHint: updateHint,
-	}
-	m.sett = ui.NewSettings(settings, th, km)
-	return m
-}
-
-// Init performs no startup command.
-func (m Model) Init() tea.Cmd { return nil }
-
 // Update handles global concerns (resize, quit, navigation) and delegates to
 // the active screen sub-model.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -110,7 +85,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// ResultMsg: test completed → persist record, detect new-best, show result.
 	if rm, ok := msg.(ui.ResultMsg); ok {
 		m = m.handleResultMsg(rm)
-		return m, nil
+		return m, ui.FrameTickCmd()
 	}
 
 	// NavHistoryMsg: navigate to History screen (load fresh from disk).

--- a/internal/app/model_constructor.go
+++ b/internal/app/model_constructor.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/internal/update"
+)
+
+// New builds the root model with the given theme, settings, optional code
+// text/hint, and an optional update hint.
+// codeText is the snippet loaded from --text (empty = Code disabled);
+// codeHint is a user-facing load-failure reason (empty = no error);
+// updateHint is non-nil when an opportunistic check found a newer release.
+func New(th theme.Theme, settings config.Settings, codeText, codeHint string, updateHint *update.Result) Model {
+	km := config.DefaultKeymap()
+	home := ui.NewHome(settings, th, km, codeText, codeHint)
+	m := Model{
+		screen:     ScreenHome,
+		theme:      th,
+		keys:       km,
+		settings:   settings,
+		home:       home,
+		codeText:   codeText,
+		codeHint:   codeHint,
+		updateHint: updateHint,
+	}
+	m.sett = ui.NewSettings(settings, th, km)
+	return m
+}
+
+// Init performs no startup command.
+func (m Model) Init() tea.Cmd { return nil }

--- a/internal/app/model_history.go
+++ b/internal/app/model_history.go
@@ -46,7 +46,11 @@ func (m Model) handleResultMsg(msg ui.ResultMsg) Model {
 		m.persistErr = "Couldn't save result to disk"
 	}
 
-	m.result = ui.NewResult(msg, m.theme, m.keys).WithBest(isBest).WithUpdateHint(m.updateHint).SetSize(m.w, m.h)
+	m.result = ui.NewResult(msg, m.theme, m.keys).
+		WithBest(isBest).
+		WithUpdateHint(m.updateHint).
+		WithRevealStart(nowUTC().UnixMilli()).
+		SetSize(m.w, m.h)
 	m.screen = ScreenResult
 	return m
 }

--- a/internal/ui/screen_result.go
+++ b/internal/ui/screen_result.go
@@ -13,16 +13,13 @@ import (
 // ResultModel is the sub-model for the post-test result screen. It renders
 // big-digit WPM, accuracy/raw/consistency stats, a WPM-over-time sparkline,
 // char counts, and test metadata — all from a completed metrics.Result.
-//
-// isBest is set by Phase 8 (history persistence) and gates the ★ new best
-// badge. It defaults false.
 type ResultModel struct {
 	res      metrics.Result
 	mode     config.Mode
 	length   int
 	quoteLen words.QuoteLen
 	codeText string // ModeCode snippet, so restart-same re-runs it (not "")
-	isBest   bool   // set externally by Phase 8; false = badge hidden
+	isBest   bool   // set by the root after new-best detection; false = hidden
 
 	// updateHint is set when an opportunistic check found a newer release.
 	// Nil means no footer hint. Set via WithUpdateHint after NewResult.
@@ -32,14 +29,14 @@ type ResultModel struct {
 	th   theme.Theme
 	km   config.Keymap
 
-	// nowMs is the shared animation clock, stamped from each FrameTickMsg. The
-	// result reveal derives every animated value purely from it; real reveal
-	// timing is wired in a later phase.
-	nowMs int64
+	// revealStartMs and nowMs drive the Result reveal. A zero revealStartMs
+	// means static/settled rendering, which keeps direct NewResult callers stable.
+	revealStartMs int64
+	nowMs         int64
 }
 
 // NewResult constructs a ResultModel from a completed ResultMsg. The isBest
-// field defaults to false; Phase 8 will set it after a history lookup.
+// field defaults to false; the root sets it after a history lookup.
 func NewResult(msg ResultMsg, th theme.Theme, km config.Keymap) ResultModel {
 	return ResultModel{
 		res:      msg.Result,
@@ -59,7 +56,6 @@ func (m ResultModel) SetSize(w, h int) ResultModel {
 }
 
 // WithBest sets the isBest flag, enabling the ★ new best badge in the View.
-// Called by the root after history persistence (Phase 8).
 func (m ResultModel) WithBest(best bool) ResultModel {
 	m.isBest = best
 	return m
@@ -76,16 +72,15 @@ func (m ResultModel) WithUpdateHint(hint *update.Result) ResultModel {
 	return m
 }
 
-// Update handles key events for the result screen per design §8.4.
+// Update handles key events for the result screen.
 //
 //   - tab / enter  → restart SAME test (same mode, length, quoteLen)
 //   - ctrl+r       → new test (fresh pick via Home)
 //   - esc / 1      → Home
-//   - 3            → History (placeholder until Phase 8)
+//   - 3            → History
 //   - ctrl+c       → quit (handled globally by root; forwarded here for completeness)
 func (m ResultModel) Update(msg tea.Msg) (ResultModel, tea.Cmd) {
 	if ft, ok := msg.(FrameTickMsg); ok {
-		// Animation frame: store the shared clock so the reveal can advance.
 		m.nowMs = ft.T.UnixMilli()
 		return m, nil
 	}
@@ -122,10 +117,10 @@ func (m ResultModel) restartSameCmd() tea.Cmd {
 	}
 }
 
-// HasActiveAnim reports whether the result screen has a live animation at nowMs,
-// so the frame driver knows whether to keep running 33ms frames. Real reveal /
-// celebration timing is wired in later phases; for now it reports idle.
-func (m ResultModel) HasActiveAnim(nowMs int64) bool { return false }
+// HasActiveAnim reports whether the result reveal is still running at nowMs.
+func (m ResultModel) HasActiveAnim(nowMs int64) bool {
+	return !revealDone(m.revealStartMs, nowMs)
+}
 
 // NavHistoryMsg is emitted when the user navigates to the History screen from
 // the Result screen. The root routes it to ScreenHistory.

--- a/internal/ui/screen_result_reveal.go
+++ b/internal/ui/screen_result_reveal.go
@@ -1,0 +1,113 @@
+package ui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/bavanchun/Typeburn/internal/anim"
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+const (
+	countUpMs   int64 = 600
+	drawInMs    int64 = 500
+	staggerMs   int64 = 120
+	cardFadeMs  int64 = 220
+	resultCards       = 3
+)
+
+// WithRevealStart arms the Result entrance reveal at startMs.
+func (m ResultModel) WithRevealStart(startMs int64) ResultModel {
+	m.revealStartMs = startMs
+	m.nowMs = startMs
+	return m
+}
+
+func resultRevealTotalMs() int64 {
+	lastCardEnd := int64(resultCards-1)*staggerMs + cardFadeMs
+	total := countUpMs
+	if drawInMs > total {
+		total = drawInMs
+	}
+	if lastCardEnd > total {
+		total = lastCardEnd
+	}
+	return total
+}
+
+func revealProgress(startMs, nowMs, durMs int64) float64 {
+	if startMs <= 0 {
+		return 1
+	}
+	return anim.Tween{StartMs: startMs, DurMs: durMs}.Progress(nowMs)
+}
+
+func revealDone(startMs, nowMs int64) bool {
+	return startMs <= 0 || nowMs >= startMs+resultRevealTotalMs()
+}
+
+func countUpValue(final int, startMs, nowMs int64) int {
+	p := revealProgress(startMs, nowMs, countUpMs)
+	return anim.LerpInt(0, final, anim.EaseOutQuad(p))
+}
+
+func sparkVisibleBars(total int, startMs, nowMs int64) int {
+	if total <= 0 {
+		return 0
+	}
+	p := revealProgress(startMs, nowMs, drawInMs)
+	n := anim.LerpInt(0, total, anim.EaseOutQuad(p))
+	if n > total {
+		return total
+	}
+	return n
+}
+
+func cardProgress(idx int, startMs, nowMs int64) float64 {
+	if startMs <= 0 {
+		return 1
+	}
+	cardStart := startMs + int64(idx)*staggerMs
+	return revealProgress(cardStart, nowMs, cardFadeMs)
+}
+
+func revealLine(s string, p float64, th theme.Theme) string {
+	if p >= 1 {
+		return s
+	}
+	plain := stripANSI(s)
+	w := lipgloss.Width(plain)
+	if p <= 0 {
+		return strings.Repeat(" ", w)
+	}
+	return th.Style(theme.RoleTextFaint).Render(plain)
+}
+
+// BigDigitsFixed renders n with the same visual width as `final` so the count-up
+// never shifts the Result hero block as the digit count grows (9 → 10 → 100).
+func BigDigitsFixed(n, final int, th theme.Theme) string {
+	out := BigDigits(n, th)
+	finalW := maxLineWidth(BigDigits(final, th))
+	if finalW <= 0 {
+		return out
+	}
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		if lipgloss.Width(line) < finalW {
+			lines[i] = lipgloss.PlaceHorizontal(finalW, lipgloss.Right, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// maxLineWidth returns the widest rendered line width in s.
+func maxLineWidth(s string) int {
+	maxW := 0
+	for _, line := range strings.Split(s, "\n") {
+		if w := lipgloss.Width(line); w > maxW {
+			maxW = w
+		}
+	}
+	return maxW
+}

--- a/internal/ui/screen_result_reveal_test.go
+++ b/internal/ui/screen_result_reveal_test.go
@@ -1,0 +1,147 @@
+package ui
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+func TestCountUpValue_EndpointsAndMonotonic(t *testing.T) {
+	start := int64(1000)
+	final := 94
+
+	if got := countUpValue(final, start, start); got != 0 {
+		t.Fatalf("at start: got %d want 0", got)
+	}
+	if got := countUpValue(final, start, start+countUpMs); got != final {
+		t.Fatalf("at end: got %d want %d", got, final)
+	}
+
+	prev := -1
+	for now := start; now <= start+countUpMs; now += 50 {
+		got := countUpValue(final, start, now)
+		if got < prev {
+			t.Fatalf("count-up regressed at %d: %d < %d", now, got, prev)
+		}
+		prev = got
+	}
+}
+
+func TestSparkVisibleBars_Endpoints(t *testing.T) {
+	start := int64(1000)
+	if got := sparkVisibleBars(5, start, start); got != 0 {
+		t.Fatalf("at start: got %d want 0", got)
+	}
+	if got := sparkVisibleBars(5, start, start+drawInMs); got != 5 {
+		t.Fatalf("at end: got %d want 5", got)
+	}
+}
+
+func TestCardProgress_Stagger(t *testing.T) {
+	start := int64(1000)
+	if got := cardProgress(1, start, start+staggerMs-1); got != 0 {
+		t.Fatalf("card 1 before start: got %.2f want 0", got)
+	}
+	if got := cardProgress(1, start, start+staggerMs+cardFadeMs); got != 1 {
+		t.Fatalf("card 1 after fade: got %.2f want 1", got)
+	}
+}
+
+func TestBigDigitsFixed_ConstantWidth(t *testing.T) {
+	th := theme.Default()
+	final := 104
+	wantW := maxLineWidth(BigDigits(final, th))
+	for _, n := range []int{0, 9, 10, 99, 104} {
+		for _, line := range strings.Split(BigDigitsFixed(n, final, th), "\n") {
+			if got := lipgloss.Width(line); got != wantW {
+				t.Fatalf("BigDigitsFixed(%d) line width=%d want %d", n, got, wantW)
+			}
+		}
+	}
+}
+
+func TestResultReveal_StaticUsesOriginalBigDigits(t *testing.T) {
+	m := newTestResult()
+	final := int(math.Round(m.res.NetWPM))
+	assertHeroBigDigitsPrefix(t, m.renderHero(80), BigDigits(final, m.th))
+
+	revealed := m.WithRevealStart(1000)
+	revealed.nowMs = 1000 + resultRevealTotalMs()
+	assertHeroBigDigitsPrefix(t, revealed.renderHero(80), BigDigits(final, m.th))
+}
+
+func TestResultReveal_SettledMatchesStatic(t *testing.T) {
+	static := newTestResult().View()
+	revealed := newTestResult().WithRevealStart(1000)
+	revealed.nowMs = 1000 + resultRevealTotalMs()
+
+	if got := revealed.View(); got != static {
+		t.Fatalf("settled reveal differs from static frame")
+	}
+}
+
+func TestResultReveal_InProgressKeepsLayout(t *testing.T) {
+	settled := newTestResult().View()
+	revealed := newTestResult().WithRevealStart(1000)
+	revealed.nowMs = 1000
+
+	assertSameLineWidths(t, settled, revealed.View())
+}
+
+func TestResultReveal_NoColorKeepsLayout(t *testing.T) {
+	th := theme.Load("default", true)
+	static := newTestResult()
+	static.th = th
+
+	revealed := static.WithRevealStart(1000)
+	revealed.nowMs = 1120
+
+	assertSameLineWidths(t, static.View(), revealed.View())
+}
+
+func TestResultHasActiveAnim_Window(t *testing.T) {
+	m := newTestResult().WithRevealStart(1000)
+	if !m.HasActiveAnim(1000) {
+		t.Fatal("reveal should be active at start")
+	}
+	if m.HasActiveAnim(1000 + resultRevealTotalMs()) {
+		t.Fatal("reveal should be inactive at total duration")
+	}
+	if newTestResult().HasActiveAnim(1000) {
+		t.Fatal("static result should not report active animation")
+	}
+}
+
+func assertSameLineWidths(t *testing.T, a, b string) {
+	t.Helper()
+	aa := strings.Split(strip(a), "\n")
+	bb := strings.Split(strip(b), "\n")
+	if len(aa) != len(bb) {
+		t.Fatalf("line count: got %d want %d", len(bb), len(aa))
+	}
+	for i := range aa {
+		if len([]rune(aa[i])) != len([]rune(bb[i])) {
+			t.Fatalf("line %d width: got %d want %d\nwant=%q\ngot =%q",
+				i, len([]rune(bb[i])), len([]rune(aa[i])), aa[i], bb[i])
+		}
+	}
+}
+
+func assertHeroBigDigitsPrefix(t *testing.T, hero, big string) {
+	t.Helper()
+	heroLines := strings.Split(hero, "\n")
+	bigLines := strings.Split(big, "\n")
+	if len(heroLines) < len(bigLines) {
+		t.Fatalf("hero line count=%d want at least %d", len(heroLines), len(bigLines))
+	}
+	for i, want := range bigLines {
+		if !strings.HasPrefix(heroLines[i], want) {
+			t.Fatalf("hero line %d should start with original big digit row\nwant prefix=%q\ngot=%q",
+				i, want, heroLines[i])
+		}
+	}
+}

--- a/internal/ui/screen_result_view.go
+++ b/internal/ui/screen_result_view.go
@@ -16,7 +16,7 @@ import (
 // load-time guard in internal/update.
 var validSemverFooter = regexp.MustCompile(`^v?\d+\.\d+\.\d+([-+.][\w.-]+)?$`)
 
-// resultHints returns the footer hint set for the result screen per mockups §3.
+// resultHints returns the footer actions for the result screen.
 func resultHints() []Hint {
 	return []Hint{
 		{Key: "tab", Action: "restart"},
@@ -28,7 +28,6 @@ func resultHints() []Hint {
 
 // View renders the result screen. It places a single rounded-border panel
 // (RoleBorder, surface bg) with title "result" on the top border edge.
-// Layout mirrors mockups §3.
 func (m ResultModel) View() string {
 	footer := RenderFooter(resultHints(), m.w, m.th)
 	updateLine := m.renderUpdateHint()
@@ -109,18 +108,31 @@ func (m ResultModel) renderPanel() string {
 	return injectBorderTitle(panel, titleStyled)
 }
 
-// renderHero renders the big-digit WPM block alongside acc/raw/consistency.
 func (m ResultModel) renderHero(innerW int) string {
-	bigWPM := BigDigits(int(math.Round(m.res.NetWPM)), m.th)
+	finalWPM := int(math.Round(m.res.NetWPM))
+	displayWPM := countUpValue(finalWPM, m.revealStartMs, m.nowMs)
+	bigWPM := BigDigits(finalWPM, m.th)
+	if !revealDone(m.revealStartMs, m.nowMs) {
+		bigWPM = BigDigitsFixed(displayWPM, finalWPM, m.th)
+	}
 
 	wpmLabel := m.th.Style(theme.RoleTextMuted).Render("wpm")
 	if m.isBest {
 		wpmLabel += m.th.Style(theme.RoleSuccess).Render(" ★ new best")
 	}
 
-	accLine := StatCard("acc", fmt.Sprintf("%.0f%%", m.res.Accuracy), accColorRole(m.res.Accuracy), m.th)
-	rawLine := StatCard("raw", fmt.Sprintf("%.0f wpm", m.res.RawWPM), theme.RoleTextPrimary, m.th)
-	consLine := StatCard("consistency", fmt.Sprintf("%.0f%%", m.res.Consistency), theme.RoleTextPrimary, m.th)
+	accLine := revealLine(
+		StatCard("acc", fmt.Sprintf("%.0f%%", m.res.Accuracy), accColorRole(m.res.Accuracy), m.th),
+		cardProgress(0, m.revealStartMs, m.nowMs), m.th,
+	)
+	rawLine := revealLine(
+		StatCard("raw", fmt.Sprintf("%.0f wpm", m.res.RawWPM), theme.RoleTextPrimary, m.th),
+		cardProgress(1, m.revealStartMs, m.nowMs), m.th,
+	)
+	consLine := revealLine(
+		StatCard("consistency", fmt.Sprintf("%.0f%%", m.res.Consistency), theme.RoleTextPrimary, m.th),
+		cardProgress(2, m.revealStartMs, m.nowMs), m.th,
+	)
 	secondaryCol := strings.Join([]string{accLine, rawLine, consLine}, "\n")
 
 	bigLines := strings.Split(bigWPM+"\n"+wpmLabel, "\n")
@@ -140,7 +152,6 @@ func (m ResultModel) renderHero(innerW int) string {
 		}
 		rows[i] = bigLines[i] + "   " + sec
 	}
-	_ = innerW // reserved for future width-aware truncation
 	return strings.Join(rows, "\n")
 }
 
@@ -153,7 +164,8 @@ func (m ResultModel) renderSparkline(innerW int) string {
 		vals[i] = ps.RawWPM
 	}
 
-	graph := Sparkline(vals, innerW, 3, m.th)
+	visible := sparkVisibleBars(len(vals), m.revealStartMs, m.nowMs)
+	graph := sparklineVisible(vals, innerW, 3, visible, m.th)
 	if graph == "" {
 		graph = m.th.Style(theme.RoleTextFaint).Render("(no data)")
 	}

--- a/internal/ui/sparkline.go
+++ b/internal/ui/sparkline.go
@@ -22,11 +22,23 @@ var sparkBars = []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
 //   - len(vals) == 1: renders a single full bar
 //   - all values equal: renders all mid-height bars
 func Sparkline(vals []float64, width, chartH int, th theme.Theme) string {
+	return sparklineVisible(vals, width, chartH, len(vals), th)
+}
+
+// sparklineVisible renders the chart with only the first `visible` bars drawn;
+// positions at/after `visible` are blanked to equal-width spaces so the layout
+// never reflows. The Result reveal animates `visible` from 0 → len(vals); the
+// public Sparkline passes len(vals), so the fully-revealed frame is byte-
+// identical to the static render — one code path, no duplicated layout to drift.
+func sparklineVisible(vals []float64, width, chartH, visible int, th theme.Theme) string {
 	if len(vals) == 0 {
 		return ""
 	}
 	if chartH <= 0 {
 		chartH = 4
+	}
+	if visible < 0 {
+		visible = 0
 	}
 
 	accentStyle := th.Style(theme.RoleAccent)
@@ -42,8 +54,13 @@ func Sparkline(vals []float64, width, chartH int, th theme.Theme) string {
 	}
 
 	// Build the bar string (one char per sample, single-row sparkline style).
+	// Positions at/after `visible` render as a space (not yet drawn in).
 	bars := make([]rune, len(vals))
 	for i, v := range vals {
+		if i >= visible {
+			bars[i] = ' '
+			continue
+		}
 		ratio := (v - minV) / (maxV - minV)
 		idx := int(math.Round(ratio * float64(len(sparkBars)-1)))
 		if idx < 0 {


### PR DESCRIPTION
## Phase 4 — Result reveal

Animates the Result screen entrance, continuing the UI/UX Animation System.
All values derive purely from `(revealStartMs, nowMs)`.

- **WPM count-up** 0→final over 600ms (easeOutQuad), rendered in a **fixed-width
  big-digit slot** so 9→10→100 never shifts the hero block.
- **Sparkline draw-in** left→right. Implemented by adding a `visible` count to the
  existing `Sparkline` (single code path) — no duplicated chart layout, so the
  settled frame is identical and there's no mid-reveal jitter.
- **Stat cards** stagger-fade (120ms offsets): equal-width placeholder → faint → normal.
- Self-stops at `totalRevealMs`; root bootstraps the loop on `ResultMsg` and sets
  `revealStartMs` from the wall clock so a fresh reveal never inherits a stale
  shared-clock value (a second consecutive result animates fresh — tested).

### Invariants (tested)
- Settled frame **byte-identical** to the static Result render.
- **NO_COLOR layout-identical** (line count + rune width).
- Count-up monotonic + lands exactly on final; constant hero width across the count.

### Continuation note
This branch was started by a hand-off. Before shipping I refactored two items to
match project rules: removed a near-duplicate of `Sparkline` (folded into a shared
`visible` param) and removed a `_fixed`-suffixed file (folded `BigDigitsFixed` into
`screen_result_reveal.go`). `New`/`Init` moved to `model_constructor.go` to keep
`model.go` < 200 LOC.

`go test -race`, `go vet`, `gofmt -l` clean; all files < 200 LOC.