### PR TITLE
feat(ui): new-best celebration sparkle burst

### DIFF
--- a/internal/ui/celebration.go
+++ b/internal/ui/celebration.go
@@ -1,0 +1,146 @@
+package ui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+// New-best celebration timing/shape. The burst rides the same frame loop as the
+// result reveal and is one-shot. celebrateMs bounds the active window; particles
+// twinkle on a short sub-cycle within their individual lifetimes.
+const (
+	celebrateMs    int64 = 1000
+	particleCount        = 6
+	particleLifeMs int64 = 300
+	bandRadius           = 3 // a blank row counts if within this many rows of content
+)
+
+// celebrationGlyphs are display-width-1 sparkle runes (asserted in tests). They
+// are spliced onto blank padding cells, so width must stay 1 to preserve layout.
+var celebrationGlyphs = []rune{'*', '+', '·', '.'}
+
+// overlayCell is a styled width-1 glyph to splat at (row, col) in the frame.
+type overlayCell struct {
+	row, col int
+	glyph    string
+}
+
+// applyCelebration overlays a sparkle burst onto blank margin rows of an already
+// composed, placed frame when the burst is active. It only ever rewrites
+// all-blank rows (never styled content), and rebuilds each touched row to the
+// exact same rune width — so the overlay is layout-identical (line count + width
+// preserved; only blank cells gain a glyph). Returns the frame unchanged when no
+// particle is live.
+func applyCelebration(frame string, startMs, nowMs int64, th theme.Theme) string {
+	if startMs <= 0 || nowMs < startMs || nowMs >= startMs+celebrateMs {
+		return frame
+	}
+	lines := strings.Split(frame, "\n")
+	band := blankBand(lines)
+	if len(band) == 0 {
+		return frame
+	}
+	w := len([]rune(lines[band[0]])) // blank rows are pure spaces → rune count = width
+	cells := celebrationCells(startMs, nowMs, band, w, th)
+	if len(cells) == 0 {
+		return frame
+	}
+
+	byRow := make(map[int]map[int]string, len(cells))
+	for _, c := range cells {
+		if byRow[c.row] == nil {
+			byRow[c.row] = make(map[int]string)
+		}
+		byRow[c.row][c.col] = c.glyph
+	}
+	for row, cols := range byRow {
+		lines[row] = overlayBlankRow(len([]rune(lines[row])), cols)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// celebrationCells places up to particleCount sparkles deterministically from
+// (index, startMs) — no math/rand global — so renders are reproducible for
+// goldens. Each particle has a staggered birth and a short life; it twinkles
+// through the glyph set while alive. Columns cluster in the centre band so the
+// burst reads as celebrating the result card rather than scattering edge-to-edge.
+func celebrationCells(startMs, nowMs int64, band []int, w int, th theme.Theme) []overlayCell {
+	style := celebrationStyle(th)
+	colLo := w / 4
+	colSpan := w / 2
+	if colSpan < 1 {
+		colSpan = 1
+	}
+
+	cells := make([]overlayCell, 0, particleCount)
+	for i := 0; i < particleCount; i++ {
+		h := particleHash(i, startMs)
+		born := int64(h % 200) // 0–200ms stagger
+		age := nowMs - startMs - born
+		if age < 0 || age >= particleLifeMs {
+			continue
+		}
+		row := band[int(h>>8)%len(band)]
+		col := colLo + int(h>>16)%colSpan
+		gi := int((nowMs/80 + int64(i)) % int64(len(celebrationGlyphs)))
+		cells = append(cells, overlayCell{row: row, col: col, glyph: style.Render(string(celebrationGlyphs[gi]))})
+	}
+	return cells
+}
+
+// celebrationStyle is the sparkle style: success color, or an attribute-only
+// twinkle (bold + reverse) under NO_COLOR so the burst stays layout-identical.
+func celebrationStyle(th theme.Theme) lipgloss.Style {
+	if th.Color(theme.RoleSuccess) == nil {
+		return lipgloss.NewStyle().Bold(true).Reverse(true)
+	}
+	return th.Style(theme.RoleSuccess)
+}
+
+// particleHash is a small deterministic mixer over (index, startMs).
+func particleHash(i int, startMs int64) uint64 {
+	h := uint64(startMs)*1099511628211 ^ uint64(i+1)*2654435761
+	h ^= h >> 17
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	return h
+}
+
+// blankBand returns indices of all-blank rows that sit within bandRadius of a
+// content row — i.e. the padding hugging the result card, not far-flung edges.
+func blankBand(lines []string) []int {
+	blank := make([]bool, len(lines))
+	for i, ln := range lines {
+		blank[i] = ln != "" && strings.Trim(ln, " ") == ""
+	}
+	var band []int
+	for i := range lines {
+		if !blank[i] {
+			continue
+		}
+		for d := 1; d <= bandRadius; d++ {
+			if (i-d >= 0 && !blank[i-d]) || (i+d < len(lines) && !blank[i+d]) {
+				band = append(band, i)
+				break
+			}
+		}
+	}
+	return band
+}
+
+// overlayBlankRow rebuilds a blank row of the given rune width with styled glyphs
+// at the requested columns and spaces elsewhere — exact width, no reflow.
+func overlayBlankRow(width int, cols map[int]string) string {
+	var b strings.Builder
+	for col := 0; col < width; col++ {
+		if g, ok := cols[col]; ok {
+			b.WriteString(g)
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	return b.String()
+}

--- a/internal/ui/celebration_test.go
+++ b/internal/ui/celebration_test.go
@@ -1,0 +1,159 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+func TestCelebrationGlyphs_Width1(t *testing.T) {
+	for _, g := range celebrationGlyphs {
+		if w := lipgloss.Width(string(g)); w != 1 {
+			t.Errorf("glyph %q display width=%d want 1", string(g), w)
+		}
+	}
+}
+
+// celebrationCells must be empty outside the active window and non-empty inside.
+func TestCelebrationCells_Lifetime(t *testing.T) {
+	th := theme.Default()
+	band := []int{2, 3, 4}
+	start := int64(1000)
+
+	// Mid-window (after staggered births, before deaths) particles are live.
+	if got := celebrationCells(start, start+150, band, 40, th); len(got) == 0 {
+		t.Error("expected live particles mid-window")
+	}
+	// Past the longest particle life (stagger ≤200 + life 300 = 500ms), none remain.
+	if got := celebrationCells(start, start+600, band, 40, th); len(got) != 0 {
+		t.Errorf("expected no particles after all lifetimes, got %d", len(got))
+	}
+}
+
+// Deterministic jitter: identical (i, startMs) → identical placement, so goldens
+// are stable.
+func TestCelebrationCells_Deterministic(t *testing.T) {
+	th := theme.Default()
+	band := []int{2, 3, 4}
+	a := celebrationCells(1000, 1050, band, 40, th)
+	b := celebrationCells(1000, 1050, band, 40, th)
+	if len(a) != len(b) {
+		t.Fatalf("nondeterministic count: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].row != b[i].row || a[i].col != b[i].col {
+			t.Errorf("particle %d moved between calls: %v vs %v", i, a[i], b[i])
+		}
+	}
+}
+
+// blankBand selects only blank rows adjacent to content, never far-flung edges.
+func TestBlankBand_AdjacentToContent(t *testing.T) {
+	lines := []string{
+		"          ", // 0 blank, far from content (edge)
+		"          ", // 1 blank
+		"          ", // 2 blank
+		"          ", // 3 blank (within 3 of content at 4? 4 is content) → included
+		"panel here", // 4 content
+		"          ", // 5 blank, adjacent → included
+		"          ", // 6 blank, within 3 → included
+	}
+	band := blankBand(lines)
+	got := map[int]bool{}
+	for _, i := range band {
+		got[i] = true
+	}
+	if got[0] {
+		t.Error("row 0 (far edge) should not be in band")
+	}
+	if !got[3] || !got[5] {
+		t.Error("rows adjacent to content should be in band")
+	}
+}
+
+// applyCelebration must preserve line count and per-line rune width, and only
+// touch blank rows.
+func TestApplyCelebration_PreservesLayout(t *testing.T) {
+	th := theme.Default()
+	content := strings.Join([]string{
+		strings.Repeat(" ", 40),
+		"  +----------------------------------+  ",
+		strings.Repeat(" ", 40),
+		strings.Repeat(" ", 40),
+	}, "\n")
+
+	out := applyCelebration(content, 1000, 1050, th)
+	in := strings.Split(content, "\n")
+	got := strings.Split(out, "\n")
+	if len(in) != len(got) {
+		t.Fatalf("line count changed: %d → %d", len(in), len(got))
+	}
+	for i := range in {
+		iw := len([]rune(stripANSI(in[i])))
+		gw := len([]rune(stripANSI(got[i])))
+		if iw != gw {
+			t.Errorf("line %d width changed: %d → %d", i, iw, gw)
+		}
+	}
+	// The content (panel) row must be untouched.
+	if got[1] != in[1] {
+		t.Error("celebration touched a content row")
+	}
+}
+
+// Outside the active window applyCelebration is a no-op (settled == input).
+func TestApplyCelebration_InactiveNoop(t *testing.T) {
+	content := strings.Repeat(" ", 20) + "\nx\n" + strings.Repeat(" ", 20)
+	if got := applyCelebration(content, 0, 50, theme.Default()); got != content {
+		t.Error("startMs<=0 should be a no-op")
+	}
+	if got := applyCelebration(content, 1000, 1000+celebrateMs, theme.Default()); got != content {
+		t.Error("after celebrateMs should be a no-op")
+	}
+}
+
+// An isBest result keeps the loop alive through the celebration window; an
+// ordinary result self-stops with the reveal.
+func TestResultCelebration_ExtendsActiveWindow(t *testing.T) {
+	best := newTestResult().WithBest(true).WithRevealStart(1000)
+	afterReveal := int64(1000) + resultRevealTotalMs()
+	if !best.HasActiveAnim(afterReveal) {
+		t.Error("new-best result should stay active through the celebration window")
+	}
+	if best.HasActiveAnim(1000 + celebrateMs) {
+		t.Error("celebration should self-stop after celebrateMs")
+	}
+
+	ordinary := newTestResult().WithBest(false).WithRevealStart(1000)
+	if ordinary.HasActiveAnim(afterReveal) {
+		t.Error("ordinary result should self-stop when the reveal finishes")
+	}
+}
+
+// An ordinary (non-best) result never sparkles: well past every window it
+// renders exactly the static frame.
+func TestResultView_OrdinaryNoCelebration(t *testing.T) {
+	static := newTestResult().View() // best=false, no reveal
+	ordinary := newTestResult().WithBest(false).WithRevealStart(1000)
+	ordinary.nowMs = 1000 + celebrateMs + 100 // past reveal + any burst
+	if ordinary.View() != static {
+		t.Error("ordinary result must render the static frame (zero sparkle)")
+	}
+}
+
+// A new-best frame mid-burst differs from its settled self (sparkle present)
+// but keeps identical line count + width; after celebrateMs the burst is gone.
+func TestResultView_BestBurstThenSettles(t *testing.T) {
+	mid := newTestResult().WithBest(true).WithRevealStart(1000)
+	mid.nowMs = 1150 // particles reliably alive
+	settled := newTestResult().WithBest(true).WithRevealStart(1000)
+	settled.nowMs = 1000 + celebrateMs + 100
+
+	if mid.View() == settled.View() {
+		t.Error("mid-celebration frame should differ from settled (sparkle present)")
+	}
+	assertSameLineWidths(t, settled.View(), mid.View())
+}

--- a/internal/ui/screen_result.go
+++ b/internal/ui/screen_result.go
@@ -117,9 +117,15 @@ func (m ResultModel) restartSameCmd() tea.Cmd {
 	}
 }
 
-// HasActiveAnim reports whether the result reveal is still running at nowMs.
+// HasActiveAnim reports whether the result reveal OR a new-best celebration is
+// still running at nowMs. The celebration window (celebrateMs) is longer than
+// the reveal, so an isBest result keeps the frame loop alive until the burst
+// settles; an ordinary result self-stops when the reveal finishes.
 func (m ResultModel) HasActiveAnim(nowMs int64) bool {
-	return !revealDone(m.revealStartMs, nowMs)
+	if !revealDone(m.revealStartMs, nowMs) {
+		return true
+	}
+	return m.isBest && m.revealStartMs > 0 && nowMs < m.revealStartMs+celebrateMs
 }
 
 // NavHistoryMsg is emitted when the user navigates to the History screen from

--- a/internal/ui/screen_result_hero.go
+++ b/internal/ui/screen_result_hero.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+// renderHero renders the big-digit WPM block beside the acc/raw/consistency stat
+// cards. During the reveal the WPM counts up in a fixed-width digit slot (no
+// jitter) and each stat card stagger-fades in; once settled it is byte-identical
+// to the static hero.
+func (m ResultModel) renderHero(innerW int) string {
+	finalWPM := int(math.Round(m.res.NetWPM))
+	displayWPM := countUpValue(finalWPM, m.revealStartMs, m.nowMs)
+	bigWPM := BigDigits(finalWPM, m.th)
+	if !revealDone(m.revealStartMs, m.nowMs) {
+		bigWPM = BigDigitsFixed(displayWPM, finalWPM, m.th)
+	}
+
+	wpmLabel := m.th.Style(theme.RoleTextMuted).Render("wpm")
+	if m.isBest {
+		wpmLabel += m.th.Style(theme.RoleSuccess).Render(" ★ new best")
+	}
+
+	accLine := revealLine(
+		StatCard("acc", fmt.Sprintf("%.0f%%", m.res.Accuracy), accColorRole(m.res.Accuracy), m.th),
+		cardProgress(0, m.revealStartMs, m.nowMs), m.th,
+	)
+	rawLine := revealLine(
+		StatCard("raw", fmt.Sprintf("%.0f wpm", m.res.RawWPM), theme.RoleTextPrimary, m.th),
+		cardProgress(1, m.revealStartMs, m.nowMs), m.th,
+	)
+	consLine := revealLine(
+		StatCard("consistency", fmt.Sprintf("%.0f%%", m.res.Consistency), theme.RoleTextPrimary, m.th),
+		cardProgress(2, m.revealStartMs, m.nowMs), m.th,
+	)
+	secondaryCol := strings.Join([]string{accLine, rawLine, consLine}, "\n")
+
+	bigLines := strings.Split(bigWPM+"\n"+wpmLabel, "\n")
+	secLines := strings.Split(secondaryCol, "\n")
+	for len(bigLines) < len(secLines) {
+		bigLines = append(bigLines, "")
+	}
+	for len(secLines) < len(bigLines) {
+		secLines = append(secLines, "")
+	}
+
+	rows := make([]string, len(bigLines))
+	for i := range bigLines {
+		sec := ""
+		if i < len(secLines) {
+			sec = secLines[i]
+		}
+		rows[i] = bigLines[i] + "   " + sec
+	}
+	return strings.Join(rows, "\n")
+}

--- a/internal/ui/screen_result_view.go
+++ b/internal/ui/screen_result_view.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"math"
 	"regexp"
 	"strings"
 
@@ -55,10 +54,17 @@ func (m ResultModel) View() string {
 	}
 	b.WriteString(footer)
 
+	frame := b.String()
 	if m.w > 0 && m.h > 0 {
-		return lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, b.String())
+		frame = lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, frame)
 	}
-	return b.String()
+	// New-best celebration: one-shot sparkle burst overlaid onto blank margin
+	// rows of the placed frame. Triggers only on a new best, never on ordinary
+	// results, and only while the burst window is open.
+	if m.isBest {
+		frame = applyCelebration(frame, m.revealStartMs, m.nowMs, m.th)
+	}
+	return frame
 }
 
 // renderUpdateHint returns the update-available footer line, or "" if no hint
@@ -106,53 +112,6 @@ func (m ResultModel) renderPanel() string {
 	panel := borderStyle.Render(inner.String())
 	titleStyled := m.th.Style(theme.RoleTextMuted).Render(" result ")
 	return injectBorderTitle(panel, titleStyled)
-}
-
-func (m ResultModel) renderHero(innerW int) string {
-	finalWPM := int(math.Round(m.res.NetWPM))
-	displayWPM := countUpValue(finalWPM, m.revealStartMs, m.nowMs)
-	bigWPM := BigDigits(finalWPM, m.th)
-	if !revealDone(m.revealStartMs, m.nowMs) {
-		bigWPM = BigDigitsFixed(displayWPM, finalWPM, m.th)
-	}
-
-	wpmLabel := m.th.Style(theme.RoleTextMuted).Render("wpm")
-	if m.isBest {
-		wpmLabel += m.th.Style(theme.RoleSuccess).Render(" ★ new best")
-	}
-
-	accLine := revealLine(
-		StatCard("acc", fmt.Sprintf("%.0f%%", m.res.Accuracy), accColorRole(m.res.Accuracy), m.th),
-		cardProgress(0, m.revealStartMs, m.nowMs), m.th,
-	)
-	rawLine := revealLine(
-		StatCard("raw", fmt.Sprintf("%.0f wpm", m.res.RawWPM), theme.RoleTextPrimary, m.th),
-		cardProgress(1, m.revealStartMs, m.nowMs), m.th,
-	)
-	consLine := revealLine(
-		StatCard("consistency", fmt.Sprintf("%.0f%%", m.res.Consistency), theme.RoleTextPrimary, m.th),
-		cardProgress(2, m.revealStartMs, m.nowMs), m.th,
-	)
-	secondaryCol := strings.Join([]string{accLine, rawLine, consLine}, "\n")
-
-	bigLines := strings.Split(bigWPM+"\n"+wpmLabel, "\n")
-	secLines := strings.Split(secondaryCol, "\n")
-	for len(bigLines) < len(secLines) {
-		bigLines = append(bigLines, "")
-	}
-	for len(secLines) < len(bigLines) {
-		secLines = append(secLines, "")
-	}
-
-	rows := make([]string, len(bigLines))
-	for i := range bigLines {
-		sec := ""
-		if i < len(secLines) {
-			sec = secLines[i]
-		}
-		rows[i] = bigLines[i] + "   " + sec
-	}
-	return strings.Join(rows, "\n")
 }
 
 // renderSparkline renders the "wpm over time" sparkline section.


### PR DESCRIPTION
## Phase 5 — New-best celebration

A short, one-shot sparkle burst when a result beats the per-mode personal best.
Rides the same frame loop as the Phase 4 reveal, then settles.

- **New-best only** — reuses the existing `isBest` flag (set per `ResultMsg`).
  Ordinary results never sparkle; a fresh `ResultModel` per result means no residue
  (tested: ordinary result renders the static frame exactly).
- **Deterministic** — particles derived from `(index, revealStartMs)`, no
  `math/rand`; staggered births + short lives, twinkling through display-width-1
  glyphs `* + · .` (width asserted).
- **Layout-safe** — overlaid only onto blank margin rows of the placed frame,
  each touched row rebuilt to the exact same rune width. Never splices styled
  content. NO_COLOR → attribute-only twinkle (bold+reverse), identical cell count.
- `HasActiveAnim` extends to `celebrateMs` (1000ms) so the loop stays live through
  the burst then self-stops; settled frame is byte-identical to static.

### Decision note (please confirm)
Per the plan's resolution, the burst is **layout-identical** (line count + rune
width preserved) but **not literally byte-identical** mid-burst — sparkle glyphs
occupy otherwise-blank cells. This matches the plan's "layout-identical" reading;
flagging since the original brainstorm said "byte-identical".

`renderHero` moved to `screen_result_hero.go` to keep files < 200 LOC.
`go test -race`, `go vet`, `gofmt -l` clean.