### PR TITLE
feat(app): Typing→Result screen transition

### DIFF
--- a/internal/app/anim_driver.go
+++ b/internal/app/anim_driver.go
@@ -53,9 +53,7 @@ func (m Model) handleFrameTick(msg ui.FrameTickMsg) (tea.Model, tea.Cmd) {
 }
 
 // transitionActive reports whether a root-owned screen transition is mid-flight
-// at nowMs. Transitions span two screens, so only the root can track them; the
-// real state lands with the screen-transition feature, which replaces this body
-// with a live check. Until then there is no transition to be live.
+// at nowMs. Transitions span two screens, so only the root can track them.
 func (m Model) transitionActive(nowMs int64) bool {
-	return false
+	return m.transition != nil && nowMs < m.transition.startMs+m.transition.durMs
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -54,6 +54,11 @@ type Model struct {
 	// moment derives purely from time, mirroring metrics.Compute's replay. Zero
 	// until the first frame tick fires.
 	animNowMs int64
+
+	// transition is a root-owned screen transition (currently Typing→Result),
+	// non-nil only while one is mid-flight. View derives its expiry from
+	// animNowMs; it is nil-ed out lazily in Update on the next message.
+	transition *transitionState
 }
 
 // Update handles global concerns (resize, quit, navigation) and delegates to
@@ -64,6 +69,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// lost. Stamps animNowMs, forwards to the active screen, re-arms iff live.
 	if ft, ok := msg.(ui.FrameTickMsg); ok {
 		return m.handleFrameTick(ft)
+	}
+
+	// Lazily clear an expired transition. View stops using it once animNowMs
+	// passes its end (derived expiry); this nil-out reclaims the snapshot on the
+	// next message without any reliance on a trailing cleanup tick.
+	if m.transition != nil && m.animNowMs >= m.transition.startMs+m.transition.durMs {
+		m.transition = nil
 	}
 
 	// StartTestMsg: Home screen requested a test start.
@@ -82,9 +94,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.typing.InitCmd()
 	}
 
-	// ResultMsg: test completed → persist record, detect new-best, show result.
+	// ResultMsg: test completed → persist record, detect new-best, show result,
+	// and (from the typing screen) start the Typing→Result transition.
 	if rm, ok := msg.(ui.ResultMsg); ok {
-		m = m.handleResultMsg(rm)
+		m = m.handleResultWithTransition(rm)
 		return m, ui.FrameTickCmd()
 	}
 
@@ -97,6 +110,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// AbortMsg from typing screen → return to Home.
 	if _, ok := msg.(ui.AbortMsg); ok {
 		m.screen = ScreenHome
+		m.transition = nil // abort cancels any in-flight transition
 		return m, nil
 	}
 
@@ -118,6 +132,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		// A resize invalidates the transition snapshot (taken at the old width),
+		// so snap straight to the target screen instead of bleeding old geometry.
+		m.transition = nil
 		m.w, m.h = msg.Width, msg.Height
 		m.home = m.home.SetSize(msg.Width, msg.Height)
 		m.sett = m.sett.SetSize(msg.Width, msg.Height)

--- a/internal/app/model_view.go
+++ b/internal/app/model_view.go
@@ -6,6 +6,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/bavanchun/Typeburn/internal/anim"
+	"github.com/bavanchun/Typeburn/internal/theme"
 	"github.com/bavanchun/Typeburn/internal/ui"
 )
 
@@ -40,32 +42,18 @@ func (m Model) View() tea.View {
 	}
 
 	// Compute the final frame string in one place (single return) so the
-	// persistence notice can be overlaid uniformly. Home/Result/Settings/
-	// History self-place to w×h inside their own View(); Typing and the
-	// placeholder are placed here. With no notice this yields byte-identical
-	// output to the previous per-branch returns.
-	var out string
-	switch m.screen {
-	case ScreenHome:
-		out = m.home.View() // self-placed
-	case ScreenResult:
-		out = m.result.View() // self-placed
-	case ScreenSettings:
-		out = m.sett.View() // self-placed
-	case ScreenHistory:
-		out = m.hist.View() // self-placed
-	case ScreenCodePaste:
-		out = m.codePaste.View() // self-placed
-	case ScreenTyping:
-		out = m.typing.View()
-		if m.w > 0 && m.h > 0 {
-			out = lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, out)
-		}
-	default:
-		out = placeholderView(m.screen, m.theme)
-		if m.w > 0 && m.h > 0 {
-			out = lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, out)
-		}
+	// persistence notice can be overlaid uniformly. With no transition and no
+	// notice this yields byte-identical output to the previous per-branch returns.
+	out := m.composeScreen(m.screen)
+
+	// Screen transition: while a root-owned transition is mid-flight, blend the
+	// snapshotted outgoing frame with the live incoming frame (out). Expiry is
+	// derived here (View is a value receiver and must not mutate); the actual
+	// nil-out happens lazily in Update on the next message.
+	if m.transitionActive(m.animNowMs) {
+		p := anim.EaseInOutQuad(m.transition.progress(m.animNowMs))
+		noColor := m.theme.Color(theme.RoleBg) == nil
+		out = renderTransition(m.transition.fromFrame, out, p, noColor)
 	}
 
 	// Transient persistence-failure toast: overlay onto the frame's last row
@@ -81,4 +69,35 @@ func (m Model) View() tea.View {
 	}
 
 	return altView(out)
+}
+
+// composeScreen renders a single screen to its final placed frame. Home/Result/
+// Settings/History/CodePaste self-place to w×h inside their own View(); Typing
+// and the placeholder are placed here. Used both for the live View and to
+// snapshot the outgoing frame when starting a transition.
+func (m Model) composeScreen(screen Screen) string {
+	switch screen {
+	case ScreenHome:
+		return m.home.View()
+	case ScreenResult:
+		return m.result.View()
+	case ScreenSettings:
+		return m.sett.View()
+	case ScreenHistory:
+		return m.hist.View()
+	case ScreenCodePaste:
+		return m.codePaste.View()
+	case ScreenTyping:
+		out := m.typing.View()
+		if m.w > 0 && m.h > 0 {
+			out = lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, out)
+		}
+		return out
+	default:
+		out := placeholderView(screen, m.theme)
+		if m.w > 0 && m.h > 0 {
+			out = lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, out)
+		}
+		return out
+	}
 }

--- a/internal/app/transition.go
+++ b/internal/app/transition.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/bavanchun/Typeburn/internal/ui"
+)
+
+// transitionDurMs is the Typing→Result transition length. Short enough to feel
+// like a soft cut, not a wait.
+const transitionDurMs int64 = 250
+
+// transitionState holds a root-owned screen transition. It spans two screens, so
+// only app.Model can compose it (sub-models can't see each other). fromFrame is
+// the already-placed outgoing frame snapshot; toScreen is rendered live each
+// frame. nil on app.Model means no transition.
+type transitionState struct {
+	fromFrame string
+	toScreen  Screen
+	startMs   int64
+	durMs     int64
+}
+
+// handleResultWithTransition persists the result and switches to ScreenResult,
+// and — only when coming from the typing screen at a non-degraded size — starts
+// a Typing→Result transition by snapshotting the outgoing placed frame BEFORE
+// the screen flips. A result arriving from elsewhere (e.g. tests) just routes.
+func (m Model) handleResultWithTransition(rm ui.ResultMsg) Model {
+	transitionable := m.screen == ScreenTyping && m.w >= 60 && m.h >= 20
+	var fromFrame string
+	if transitionable {
+		fromFrame = m.composeScreen(ScreenTyping)
+	}
+	m = m.handleResultMsg(rm)
+	if transitionable {
+		m.transition = &transitionState{
+			fromFrame: fromFrame,
+			toScreen:  ScreenResult,
+			startMs:   nowUTC().UnixMilli(),
+			durMs:     transitionDurMs,
+		}
+	}
+	return m
+}
+
+// progress returns linear progress in [0,1] at nowMs; the caller applies easing.
+func (t *transitionState) progress(nowMs int64) float64 {
+	if t == nil || t.durMs <= 0 {
+		return 1
+	}
+	p := float64(nowMs-t.startMs) / float64(t.durMs)
+	if p < 0 {
+		return 0
+	}
+	if p > 1 {
+		return 1
+	}
+	return p
+}
+
+// renderTransition composes the outgoing and incoming frames at eased progress p.
+//
+//   - Color: a dim-curtain crossfade — the outgoing frame is faint for the first
+//     half, the incoming frame faint for the second half. True per-cell alpha is
+//     not possible in a terminal; faint is the equivalent. (Layout is untouched:
+//     only SGR is added, so runes/line-count/width are preserved.)
+//   - NO_COLOR: a top-down wipe — the first floor(rows*p) lines come from the
+//     incoming frame, the rest from the outgoing one. Pure line slicing, so width
+//     and line count are identical in both frames.
+func renderTransition(from, to string, p float64, noColor bool) string {
+	fromLines := strings.Split(from, "\n")
+	toLines := strings.Split(to, "\n")
+	n := len(fromLines)
+	if len(toLines) > n {
+		n = len(toLines)
+	}
+	fromLines = padLines(fromLines, n)
+	toLines = padLines(toLines, n)
+
+	if noColor {
+		visible := int(float64(n) * p)
+		if visible < 0 {
+			visible = 0
+		}
+		if visible > n {
+			visible = n
+		}
+		out := make([]string, n)
+		for i := 0; i < n; i++ {
+			if i < visible {
+				out[i] = toLines[i]
+			} else {
+				out[i] = fromLines[i]
+			}
+		}
+		return strings.Join(out, "\n")
+	}
+
+	faint := lipgloss.NewStyle().Faint(true)
+	if p < 0.5 {
+		return faint.Render(strings.Join(fromLines, "\n"))
+	}
+	return faint.Render(strings.Join(toLines, "\n"))
+}
+
+// padLines pads a line slice up to n entries with empty lines so the wipe can
+// mix two frames index-by-index without bounds risk. Placed frames already share
+// the same height, so this is defensive only.
+func padLines(lines []string, n int) []string {
+	for len(lines) < n {
+		lines = append(lines, "")
+	}
+	return lines
+}

--- a/internal/app/transition_test.go
+++ b/internal/app/transition_test.go
@@ -1,0 +1,121 @@
+package app
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var transAnsiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func transStrip(s string) string { return transAnsiRE.ReplaceAllString(s, "") }
+
+// frame builds a 4-line test frame with the given marker rune filling each line.
+func transFrame(marker string, lines, width int) string {
+	row := strings.Repeat(marker, width)
+	out := make([]string, lines)
+	for i := range out {
+		out[i] = row
+	}
+	return strings.Join(out, "\n")
+}
+
+// NO_COLOR wipe reveals exactly floor(rows*p) incoming rows from the top.
+func TestRenderTransition_WipeRowMath(t *testing.T) {
+	from := transFrame("F", 4, 6)
+	to := transFrame("T", 4, 6)
+
+	cases := []struct {
+		p       float64
+		topIsTo int // number of leading rows that should be the incoming frame
+	}{
+		{0.0, 0}, {0.25, 1}, {0.5, 2}, {0.75, 3}, {1.0, 4},
+	}
+	for _, c := range cases {
+		out := renderTransition(from, to, c.p, true)
+		lines := strings.Split(out, "\n")
+		if len(lines) != 4 {
+			t.Fatalf("p=%v line count=%d want 4", c.p, len(lines))
+		}
+		for i, ln := range lines {
+			wantTo := i < c.topIsTo
+			isTo := strings.Contains(ln, "T")
+			if wantTo != isTo {
+				t.Errorf("p=%v line %d: isTo=%v want %v", c.p, i, isTo, wantTo)
+			}
+		}
+	}
+}
+
+// Both wipe and crossfade preserve line count and per-line rune width.
+func TestRenderTransition_PreservesLayout(t *testing.T) {
+	from := transFrame("F", 5, 8)
+	to := transFrame("T", 5, 8)
+
+	for _, noColor := range []bool{true, false} {
+		for _, p := range []float64{0, 0.3, 0.5, 0.7, 1} {
+			out := renderTransition(from, to, p, noColor)
+			lines := strings.Split(transStrip(out), "\n")
+			if len(lines) != 5 {
+				t.Fatalf("noColor=%v p=%v line count=%d want 5", noColor, p, len(lines))
+			}
+			for i, ln := range lines {
+				if w := len([]rune(ln)); w != 8 {
+					t.Errorf("noColor=%v p=%v line %d width=%d want 8", noColor, p, i, w)
+				}
+			}
+		}
+	}
+}
+
+// The color crossfade swaps which frame shows at the midpoint.
+func TestRenderTransition_CrossfadeSwapsAtMidpoint(t *testing.T) {
+	from := transFrame("F", 3, 5)
+	to := transFrame("T", 3, 5)
+
+	if got := transStrip(renderTransition(from, to, 0.49, false)); !strings.Contains(got, "F") {
+		t.Error("p<0.5 should show the outgoing frame")
+	}
+	if got := transStrip(renderTransition(from, to, 0.51, false)); !strings.Contains(got, "T") {
+		t.Error("p>=0.5 should show the incoming frame")
+	}
+}
+
+// transitionActive is the frame-loop liveness signal: true only within the window.
+func TestTransitionActive_Window(t *testing.T) {
+	m := newTestModel()
+	if m.transitionActive(0) {
+		t.Error("nil transition should be inactive")
+	}
+	m.transition = &transitionState{startMs: 1000, durMs: transitionDurMs}
+	if !m.transitionActive(1000) {
+		t.Error("at start should be active")
+	}
+	if !m.transitionActive(1000 + transitionDurMs - 1) {
+		t.Error("inside window should be active")
+	}
+	if m.transitionActive(1000 + transitionDurMs) {
+		t.Error("at end should be inactive (self-stop)")
+	}
+}
+
+// An expired transition is ignored by View (derived expiry) and nil-ed out on
+// the next message in Update.
+func TestTransition_ExpiresCleanly(t *testing.T) {
+	m := newTestModel()
+	m.w, m.h = 80, 24
+	m.transition = &transitionState{
+		fromFrame: "stale", toScreen: ScreenResult, startMs: 1000, durMs: transitionDurMs,
+	}
+	m.animNowMs = 1000 + transitionDurMs + 5 // past the window
+
+	// View must not surface the stale frame.
+	if strings.Contains(transStrip(m.View().Content), "stale") {
+		t.Error("expired transition should be ignored by View")
+	}
+	// Next non-frame message nil-outs it.
+	next, _ := m.Update(press('1', 0))
+	if next.(Model).transition != nil {
+		t.Error("expired transition should be nil-ed out on the next message")
+	}
+}


### PR DESCRIPTION
## Phase 6 — Screen transitions

Softens the hard cut into the Result screen with a ~250ms root-owned transition
(root-owned because it spans two screens that sub-models can't compose).

- **Color**: dim-curtain crossfade (outgoing faint first half, incoming faint
  second half). **NO_COLOR**: top-down row wipe (first `floor(rows*p)` lines from
  the incoming frame). Both preserve line count + per-line rune width.
- **Capture-then-animate**: the outgoing *placed* typing frame is snapshotted
  before the screen flips, then blended with the live incoming frame each tick.
- **Derived expiry**: View treats the transition active only while
  `animNowMs < startMs+durMs` (View is a value receiver — must not mutate); the
  nil-out happens lazily in `Update` on the next message. No trailing-tick reliance.
- **Cancellation**: resize (stale geometry) and abort clear it; degraded (<60×20)
  skips entirely; scope is **Typing→Result only**.
- `transitionActive` feeds the driver's `animActive`, so the loop stays live
  through the transition then self-stops.

`composeScreen` extracted so the live View and the snapshot share one render path.

### Tests
Wipe row math, crossfade midpoint swap, line-count/width invariants (both modes),
active-window self-stop, and derived-expiry + lazy nil-out. `go test -race`,
`go vet`, `gofmt -l` clean; files < 200 LOC.