### PR TITLE
docs(anim): sync shipped animation plan status

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Distraction-free, keyboard-driven, and works on any ANSI terminal.
 - **Four test modes**: Time (15/30/60/120 s), Words (10/25/50/100 words), Quote (short/medium/long/epic), Code (your own text via `--text` or in-app paste)
 - **Live stats**: WPM, raw WPM, accuracy, and consistency updated every keystroke
 - **Result screen**: big-digit WPM, sparkline chart, full char breakdown
-- **Subtle motion**: animated caret (blink + fade), result reveal (WPM count-up, sparkline draw-in), and a new-best celebration — always on, auto-adapts to `NO_COLOR` (layout never shifts)
+- **Subtle motion**: animated caret (blink + fade), result reveal (WPM count-up, sparkline draw-in), new-best celebration, and Typing→Result transition — always on, auto-adapts to `NO_COLOR` (layout never shifts)
 - **History**: scrollable table of all past tests with per-mode best marker (★)
 - **Themes**: `default` (dark, green accent) and `mono` (attribute-only, no color codes)
-- **NO_COLOR support**: set `NO_COLOR=1` for a fully attribute-only render (bold/underline/faint only)
+- **NO_COLOR support**: set `NO_COLOR=1` for a fully attribute-only render (reverse, bold, underline, faint; no color codes)
 - **Minimum terminal**: 60 columns × 20 rows; graceful degraded notice below that
 - **XDG-compliant paths**: settings and history go to `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME`
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -129,11 +129,11 @@ policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
 
 ### `internal/app` — Root Elm Model & Routing
 
-**Purpose:** Bubble Tea root model. Routes global messages (StartTestMsg, ResultMsg, AbortMsg, NavHistoryMsg) to sub-models. Manages screen enum + shared state (theme, keymap, terminal size, quit prompt overlay).
+**Purpose:** Bubble Tea root model. Routes global messages (StartTestMsg, ResultMsg, AbortMsg, NavHistoryMsg, NavCodePasteMsg, CodePastedMsg) to sub-models. Manages screen enum + shared state (theme, keymap, terminal size, quit prompt overlay).
 
 **Key types:**
-- `Model`: root app state (screen enum, five sub-models, theme, keys, settings)
-- `Screen`: enum (Home, Typing, Result, Settings, History)
+- `Model`: root app state (screen enum, six sub-models, theme, keys, settings)
+- `Screen`: enum (Home, Typing, Result, Settings, History, CodePaste)
 - `quitPromptModel`: overlay shown when esc pressed on Home screen
 
 **Entry points:**
@@ -143,13 +143,13 @@ policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
 
 **Animation driver:** `anim_driver.go` owns the self-stopping 33ms frame loop (`ui.FrameTickCmd`/`FrameInterval`, distinct from the 100ms timer tick). `handleFrameTick` stamps the shared clock `animNowMs`, forwards to the active screen, and re-arms only while `animActive` (active screen's `HasActiveAnim` OR a live transition) — an idle app schedules zero frame ticks. `transition.go` holds the root-owned Typing→Result transition (crossfade/wipe); expiry is derived in View and nil-ed out lazily in Update.
 
-**Files:** model.go (root + Update/routing), model_constructor.go (New/Init), anim_driver.go (frame loop), transition.go (screen transition), model_history.go (result persistence + transition start), model_settings.go, model_view.go (compose + degraded guard + transition blend), routing.go, quit_prompt.go, model_key_handler.go, model_time_helpers.go, smoke_test.go, model_test.go.
+**Files:** model.go (root + Update/routing), model_constructor.go (New/Init), anim_driver.go (frame loop), transition.go (screen transition), model_code_paste.go, model_history.go (result persistence + transition start), model_settings.go, model_view.go (compose + degraded guard + transition blend), routing.go, quit_prompt.go, model_key_handler.go, model_time_helpers.go, smoke_test.go, model_test.go.
 
 ---
 
 ### `internal/ui` — Screen Sub-Models & Components
 
-**Purpose:** Bubble Tea sub-models for Home, Typing, Result, Settings, History screens. Emits domain messages (StartTestMsg, ResultMsg, AbortMsg, NavHistoryMsg). Implements rendering via Lip Gloss.
+**Purpose:** Bubble Tea sub-models for Home, Typing, Result, Settings, History, and CodePaste screens. Emits domain messages (StartTestMsg, ResultMsg, AbortMsg, NavHistoryMsg, NavCodePasteMsg, CodePastedMsg). Implements rendering via Lip Gloss.
 
 **Key types per screen:**
 - `HomeModel`: mode/length picker, defaults display, best-result badge. Emits StartTestMsg.
@@ -157,6 +157,7 @@ policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
 - `ResultModel`: big-digit WPM display, sparkline chart, stat cards, footer navigation.
 - `SettingsModel`: four setting rows (Theme/DefaultMode/DefaultLength/BlinkCursor), arrow navigation, auto-persist.
 - `HistoryModel`: scrollable table of all records, per-mode ★ badge, vim-style navigation.
+- `CodePasteModel`: paste-only Code-mode entry screen; normalizes bracketed paste via `codetext.Normalize`.
 
 **Components (reusable):**
 - `statCard`: displays WPM/Accuracy/Consistency with labels and big-digit rendering
@@ -166,7 +167,7 @@ policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
 - `timer`: displays elapsed time formatted as MM:SS
 - `footer`: renders keybinds with terminal-width-aware collapse (full → short forms)
 
-**Messages:** StartTestMsg, ResultMsg, AbortMsg, NavHistoryMsg, FrameTickMsg (in messages.go); FrameTickCmd/FrameInterval in frame_tick.go.
+**Messages:** StartTestMsg, ResultMsg, AbortMsg, NavHistoryMsg, NavCodePasteMsg, CodePastedMsg, FrameTickMsg (in messages.go); FrameTickCmd/FrameInterval in frame_tick.go.
 
 **Animation (always-on, NO_COLOR auto-adapting):**
 - **Caret** (caret_anim.go, word_stream_anim.go, screen_typing_caret.go, screen_typing_input.go): blink (530ms, rides the 100ms tick), new-cell fade + just-vacated trail (150ms, ride the 33ms loop). A prefix-token cache re-Renders only the ≤3 animated cells per frame (≈70 allocs/op vs ≈3500 static — benchmarked).
@@ -174,7 +175,7 @@ policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
 - **New-best celebration** (celebration.go): deterministic one-shot sparkle burst on blank margin rows; new-best only; ASCII width-1 glyphs.
 - All settle byte-identical to the static frame; under NO_COLOR each is layout-identical (line count + rune width preserved) via attribute-only variants.
 
-**Files (by screen):** screen_home.go, screen_home_view.go, screen_home_test.go; screen_typing.go, screen_typing_view.go, screen_typing_actions.go, screen_typing_test.go; screen_result.go, screen_result_view.go, screen_result_test.go; screen_settings.go, screen_settings_view.go, screen_settings_test.go; screen_history.go, screen_history_view.go, screen_history_test.go. Plus: footer.go, timer.go, stat_card.go, sparkline.go, word_stream_renderer.go, ascii_big_digits.go, ascii_logo.go, degraded_notice.go, selectable_list.go, settings_rows.go, width_tier.go, history_table.go, result_render_helpers.go, typing_log_helpers.go, test_helpers_test.go, phase09_polish_test.go, ui.go.
+**Files (by screen):** screen_home.go, screen_home_view.go, screen_home_test.go; screen_typing.go, screen_typing_view.go, screen_typing_actions.go, screen_typing_test.go; screen_result.go, screen_result_view.go, screen_result_test.go; screen_settings.go, screen_settings_view.go, screen_settings_test.go; screen_history.go, screen_history_view.go, screen_history_test.go; screen_code_paste.go, screen_code_paste_view.go, screen_code_paste_test.go. Plus: footer.go, timer.go, stat_card.go, sparkline.go, word_stream_renderer.go, ascii_big_digits.go, ascii_logo.go, degraded_notice.go, selectable_list.go, settings_rows.go, width_tier.go, history_table.go, result_render_helpers.go, typing_log_helpers.go, test_helpers_test.go, phase09_polish_test.go, ui.go.
 
 ---
 

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -197,14 +197,16 @@ Selection moves with `↑/↓` or `j/k`. The `▎` bar in `accent` is the focus 
 | Mode tab (Time/Words/Quote) | `text-muted` | `accent` + `Bold` + `▎` | selected mode persists `accent` |
 | Mode option (15/30/…) | `text-faint` | `accent` `Bold` | chosen option `accent`, others `text-muted` |
 | Settings row | `text-muted` | `surface-alt` bg + `▎` accent | value cycles inline on `←/→`/`enter` |
-| Cursor | block, steady | — | advances per keystroke (no easing) |
+| Cursor | block caret | — | animates per motion policy below |
 
-**Motion policy:** the TUI is intentionally near-static for perceived speed.
-- **Restart:** instant clear + repaint. **No flash by default.** Optional `restart flash` setting → single 1-frame `accent`-tinted blank then new text (off by default — flashes feel slow).
-- **Counter (WPM in header):** updates on a ~250ms tick, no tween (tweening numbers reads as laggy).
-- **Screen transitions:** hard cut. No slide/fade — terminals can't do it cleanly and it harms the "fast" feel.
+**Motion policy:** the TUI uses subtle, non-blocking motion for polish without changing layout.
+- **Restart:** instant clear + repaint. No flash by default.
+- **Counter (WPM in header):** updates on the existing timer path, no tween (tweening live numbers reads as laggy).
+- **Caret:** always-on blink plus brief new-cell fade/trail; under `NO_COLOR` this is attribute-only.
+- **Result reveal:** WPM count-up, sparkline draw-in, and staggered stat cards; settled frame equals the static render.
+- **Screen transitions:** Typing→Result gets a short transition. Color themes use a dim-curtain crossfade; `NO_COLOR`/mono uses a row wipe. Other navigation stays instant.
 - **Code paste screen (`ScreenCodePaste`):** instruction + single status line (waiting, or the validation reason on a failed paste). Role-only styling; the line structure is identical in every state and under `NO_COLOR`. Pasted text is validated by the same `codetext.Normalize` core as `--text` (no rule divergence), so the rejection reasons match the CLI path.
-- Respect a future `reduce-motion` notion by simply having no motion to reduce (design is already static).
+- **Reduced motion:** no user-facing setting yet; motion always auto-adapts to `NO_COLOR`/mono by preserving line count and rune width.
 
 ---
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -128,7 +128,7 @@
 #### UI/UX Animation System — ✅ SHIPPED
 - **Description:** A stdlib-only terminal motion layer: animated caret (blink + new-cell fade + trail), result reveal (WPM count-up, sparkline draw-in, staggered stat cards), one-shot new-best celebration, and a Typing→Result transition (crossfade / NO_COLOR wipe).
 - **Design:** Two independent tick loops — the 100ms timer (untouched) and a self-stopping ~33ms frame loop in `internal/app/anim_driver.go`; all motion is a pure function of time built on the UI-free `internal/anim` package. Always-on, auto-adapts under `NO_COLOR` to attribute-only variants; every frame is layout-identical and every settled frame is byte-identical to the prior static render. A prefix-token cache keeps the typing hot path bounded (~70 vs ~3500 allocs/op, benchmarked).
-- **Status:** Shipped across PRs #40–#46 (anim core → frame driver → caret → reveal → celebration → transition → hardening/docs).
+- **Status:** Shipped across PRs #40–#47 (anim core → frame driver → caret → reveal → celebration → transition → hardening/docs).
 
 #### Multiplayer / Online Sync
 - **Description:** Race against other users, leaderboard integration

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -63,6 +63,7 @@ Model (app)
 ├─ ResultModel (ui)
 ├─ SettingsModel (ui)
 ├─ HistoryModel (ui)
+├─ CodePasteModel (ui)
 └─ quitPromptModel (app) — overlay on Home
 ```
 
@@ -77,11 +78,10 @@ Each sub-model has `SetSize(w, h)` to handle WindowSizeMsg; root calls it on res
 2. **Root receives StartTestMsg:**
    - Creates new `TypingModel` with mode/length/generated target words
    - Switches `screen = ScreenTyping`
-   - TypingModel.Init() returns no cmd (tick is armed on first keystroke)
+   - Returns `TypingModel.InitCmd()` to arm the 100ms timer tick so the caret blinks before the first keystroke
 3. **Typing screen:**
    - User types; each keystroke → `tea.KeyPressMsg`
    - TypingModel.Update() → `typing.Engine.Apply(rune)` logs keystroke
-   - On first key, TypingModel returns `tickCmd()` to arm 100ms timer loop
    - Every ~100ms, tickMsg → recalculate live WPM/accuracy/consistency from keystroke log
    - Test completes on: (Time mode: timer expires) OR (Words mode: word count reached) OR (Quote mode: all runes typed)
    - Emits `ResultMsg` with final `metrics.Result`

--- a/plans/260618-1454-ui-ux-animation-system/handover-phases-04-07-cook-continuation.md
+++ b/plans/260618-1454-ui-ux-animation-system/handover-phases-04-07-cook-continuation.md
@@ -1,8 +1,9 @@
 # Handover — UI/UX Animation System, phases 4–7
 
-Continuation brief for whoever cooks the rest. Phases **1–3 are merged to `main`**;
-**4–7 remain**. Read this before touching the phase files — it records deviations
-from the original plan that the remaining phases depend on.
+Historical continuation brief. This was written after PR #43, when phases 1–3
+were merged and phases 4–7 were still pending. It is now **superseded**:
+phases 4–7 shipped on `main` through PRs #44–#47. Keep this file as build
+history and implementation context, not current work guidance.
 
 ## Status
 
@@ -11,12 +12,12 @@ from the original plan that the remaining phases depend on.
 | 1 Anim core (`internal/anim`) | merged | #40 |
 | 2 Frame driver | merged | #41 |
 | 3 Caret animation | merged | #42 |
-| 4 Result reveal | TODO | — |
-| 5 New-best celebration | TODO | — |
-| 6 Screen transitions | TODO | — |
-| 7 Hardening + docs | TODO | — |
+| 4 Result reveal | merged | #44 |
+| 5 New-best celebration | merged | #45 |
+| 6 Screen transitions | merged | #46 |
+| 7 Hardening + docs | merged | #47 |
 
-Branch base for the next phase: latest `main` (already contains 1–3).
+Final branch base was latest `main` after each squash merge.
 
 ## Required workflow (per user instruction)
 
@@ -38,33 +39,30 @@ Branch base for the next phase: latest `main` (already contains 1–3).
 
 Note: `prc`'s `git add -A` stages **everything** in the tree — keep the working tree limited to the current phase's files (the pre-existing plan/`docs/mdocs` artifacts already merged in #40, so the tree is clean now).
 
-## Deviations from the original plan (IMPORTANT — build on these)
+## Deviations from the original plan (applied)
 
 1. **Frame-tick command lives in `ui`, not `app`.** Phase 2's plan text put
    `frameTickCmd`/`frameInterval` in `app/anim_driver.go`, but Phase 3 needs a
    screen sub-model (package `ui`) to bootstrap the loop — impossible across
    packages. So it's **`ui.FrameTickCmd()` + `ui.FrameInterval` (33ms)** in
-   `internal/ui/frame_tick.go`. **Phases 4/5/6 must call `ui.FrameTickCmd()`** to
+   `internal/ui/frame_tick.go`. Phases 4/5/6 call `ui.FrameTickCmd()` to
    bootstrap the loop (not an app-local helper). The app re-arms via
    `Model.maybeFrameCmd()` (in `app/anim_driver.go`).
 
-2. **`transitionActive` is a stub.** `app/anim_driver.go` has
-   `func (m Model) transitionActive(nowMs int64) bool { return false }` and
-   `animActive` already ORs it in. **Phase 6 must**: add a `transition *transitionState`
-   field to `app.Model` (in `model.go`) and replace the stub body with
-   `m.transition != nil && nowMs < m.transition.startMs+m.transition.durMs`.
+2. **`transitionActive` was filled in during Phase 6.** `app.Model` now owns
+   `transition *transitionState`, and `transitionActive` returns true while the
+   root-owned Typing→Result transition is inside its duration window.
 
 3. **`ResultModel` already has the frame plumbing.** From Phase 2 it has a
    `nowMs int64` field, a `FrameTickMsg` case storing `nowMs`, and
-   `HasActiveAnim(nowMs) bool` returning `false`. **Phase 4 fills in** the real
-   reveal state (`revealStartMs`, etc.) and the real `HasActiveAnim` window; do
-   not re-add the field/case.
+   `HasActiveAnim(nowMs) bool`. Phase 4 filled in the reveal state
+   (`revealStartMs`, etc.) and the real active window.
 
 4. **`app.Model.animNowMs`** is the shared clock, stamped in `handleFrameTick`
    (`app/anim_driver.go`). The Result reveal/celebration and transitions read it.
    The root forwards `FrameTickMsg` to the active screen's `Update` (typing/result)
-   already; `handleResultMsg` (in `app/model_history.go`) is where Phase 4 sets
-   `revealStartMs = m.animNowMs` and returns `ui.FrameTickCmd()` to start the loop.
+   already; `handleResultMsg` (in `app/model_history.go`) sets
+   `revealStartMs` and returns `ui.FrameTickCmd()` to start the loop.
 
 5. **Pre-start typing tick.** Root `StartTestMsg` now returns `m.typing.InitCmd()`
    (bootstraps the 100ms tick so the caret blinks pre-keystroke). Unrelated to 4–7
@@ -114,11 +112,11 @@ Note: `prc`'s `git add -A` stages **everything** in the tree — keep the workin
   moments. Update docs (`codebase-summary.md`, `system-architecture.md`,
   `project-roadmap.md`, `README.md`). No plan-artifact refs in code comments.
 
-## Open decision still needing the user (raise in P5/P7)
+## Resolved decision
 
 The brainstorm said "byte-identical layout". Resolved in the plan as
 **layout-identical** (line count + rune width preserved), NOT literal byte
 identity — the celebration overlays glyphs onto blank margin cells, changing
-those cells' rune *content* while preserving width. **Confirm this reading is
-acceptable before shipping P5.** (Phases 1–3 are strictly layout-identical AND
-settle byte-identical, so this only bites at P5.)
+those cells' rune *content* while preserving width. This is the shipped behavior
+documented in `docs/system-architecture.md`: mid-animation frames are
+layout-identical; settled frames are byte-identical to the static render.

--- a/plans/260618-1454-ui-ux-animation-system/phase-01-anim-core-package.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-01-anim-core-package.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Anim core package"
-status: pending
+status: completed
 priority: P1
 effort: "4h"
 dependencies: []
@@ -58,10 +58,10 @@ UI boundary. `LerpColor(from, to, t)` returns `color.RGBA`; if either input is
    math + `nil` passthrough, `LerpInt` endpoints, `Done`/`Active` transitions.
 
 ## Success Criteria
-- [ ] `go test ./internal/anim/ -race -count=1` green; table-driven, no mocks.
-- [ ] `go list -deps ./internal/anim` shows **no** `charm.land`/`charmbracelet` imports.
-- [ ] Every file < 200 LOC; `gofmt -l` empty; `go vet ./internal/anim/` clean.
-- [ ] `LerpColor(nil, x, t)` and `LerpColor(x, nil, t)` both return `nil`.
+- [x] `go test ./internal/anim/ -race -count=1` green; table-driven, no mocks.
+- [x] `go list -deps ./internal/anim` shows **no** `charm.land`/`charmbracelet` imports.
+- [x] Every file < 200 LOC; `gofmt -l` empty; `go vet ./internal/anim/` clean.
+- [x] `LerpColor(nil, x, t)` and `LerpColor(x, nil, t)` both return `nil`.
 
 ## Risk Assessment
 - RGBA `/257` rounding: acceptable (research-confirmed); assert exact endpoints in tests.

--- a/plans/260618-1454-ui-ux-animation-system/phase-02-frame-driver.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-02-frame-driver.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Frame driver"
-status: pending
+status: completed
 priority: P1
 effort: "5h"
 dependencies: [1]
@@ -78,13 +78,13 @@ type Animatable interface{ HasActiveAnim(nowMs int64) bool }
    reporting idle returns no frame cmd. Assert `FrameTickMsg` never advances WPM/completion.
 
 ## Success Criteria
-- [ ] With all screens reporting idle, `FrameTickMsg` handling returns no frame re-arm (loop stops).
-- [ ] When a screen reports active, handling returns `tea.Batch(subCmd, frameTickCmd())` (non-nil frame cmd).
-- [ ] `FrameTickMsg` is handled by an explicit root case, not the generic delegation block.
-- [ ] `TypingModel`/`ResultModel.Update` each have a `FrameTickMsg` case that stores `nowMs`.
-- [ ] `Init()` still returns `nil`; launching the app schedules no frame tick until an animation starts.
-- [ ] Existing `timer.go` tick + WPM/completion tests unchanged and green.
-- [ ] `go test ./... -race`, `go vet`, `gofmt -l` all clean; files < 200 LOC.
+- [x] With all screens reporting idle, `FrameTickMsg` handling returns no frame re-arm (loop stops).
+- [x] When a screen reports active, handling returns `tea.Batch(subCmd, frameTickCmd())` (non-nil frame cmd).
+- [x] `FrameTickMsg` is handled by an explicit root case, not the generic delegation block.
+- [x] `TypingModel`/`ResultModel.Update` each have a `FrameTickMsg` case that stores `nowMs`.
+- [x] `Init()` still returns `nil`; launching the app schedules no frame tick until an animation starts.
+- [x] Existing `timer.go` tick + WPM/completion tests unchanged and green.
+- [x] `go test ./... -race`, `go vet`, `gofmt -l` all clean; files < 200 LOC.
 
 ## Risk Assessment
 - **Double-tick coupling:** during typing both the 100ms timer tick and 33ms frame tick run.

--- a/plans/260618-1454-ui-ux-animation-system/phase-03-caret-animation.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-03-caret-animation.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "Caret animation"
-status: pending
+status: completed
 priority: P2
 effort: "6h"
 dependencies: [2]
@@ -99,15 +99,15 @@ independent of the blink toggle). Document this so the toggle's contract is clea
    endpoints; blink phase; prefix cache reused across frames (alloc count bounded).
 
 ## Success Criteria
-- [ ] Caret blinks at 530ms; fresh cell visibly fades; vacated cell trails — in a color theme.
-- [ ] Under `NO_COLOR=1`, caret uses reverse/faint/bold only; **layout-identical** (same runes, line count, rune width) to static.
-- [ ] Typing a 100-word test: WPM/accuracy/consistency identical to pre-change (no hot-path semantic drift).
-- [ ] Frame loop self-stops within ~150ms of the last keystroke (paused typing → no 33ms ticks).
-- [ ] Sustained fast typing keeps exactly ONE frame loop live (no multiplying `tea.Tick` timers).
-- [ ] Caret blinks on the typing screen BEFORE the first keystroke.
-- [ ] `restartSame`/`newTest` clear caret state — no stale fade on the fresh test's first frame.
-- [ ] Caret goldens are deterministic via injected `nowFn` (no wall-clock read in the tested path).
-- [ ] `make test-race`, `go vet`, `gofmt -l` clean; new files < 200 LOC.
+- [x] Caret blinks at 530ms; fresh cell visibly fades; vacated cell trails — in a color theme.
+- [x] Under `NO_COLOR=1`, caret uses reverse/faint/bold only; **layout-identical** (same runes, line count, rune width) to static.
+- [x] Typing a 100-word test: WPM/accuracy/consistency identical to pre-change (no hot-path semantic drift).
+- [x] Frame loop self-stops within ~150ms of the last keystroke (paused typing → no 33ms ticks).
+- [x] Sustained fast typing keeps exactly ONE frame loop live (no multiplying `tea.Tick` timers).
+- [x] Caret blinks on the typing screen BEFORE the first keystroke.
+- [x] `restartSame`/`newTest` clear caret state — no stale fade on the fresh test's first frame.
+- [x] Caret goldens are deterministic via injected `nowFn` (no wall-clock read in the tested path).
+- [x] `make test-race`, `go vet`, `gofmt -l` clean; new files < 200 LOC.
 
 ## Risk Assessment
 - **Trail legibility (UX researcher flag):** dim trail may read as noise at high speed. Mitigation:

--- a/plans/260618-1454-ui-ux-animation-system/phase-04-result-reveal.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-04-result-reveal.md
@@ -1,7 +1,7 @@
 ---
 phase: 4
 title: "Result reveal"
-status: pending
+status: completed
 priority: P2
 effort: "5h"
 dependencies: [2]
@@ -68,13 +68,13 @@ appearance time is exposed so P5 can hang the celebration off it.
 6. Tests pin `nowMs`; assert final frame equals the pre-animation static render exactly.
 
 ## Success Criteria
-- [ ] WPM counts 0→final over ~600ms with easeOut; lands exactly on final (no off-by-one blur).
-- [ ] Sparkline fills left→right; stat cards appear staggered; no horizontal jitter at any frame.
-- [ ] Final settled frame is **byte-identical** to the current static Result render (golden test).
-- [ ] Under `NO_COLOR`, reveal uses faint→normal only; layout-identical (line count + rune width).
-- [ ] `HasActiveAnim` false after `totalRevealMs`; loop self-stops.
-- [ ] A second consecutive result animates fresh (no inherited elapsed window from the prior result).
-- [ ] `make test-race`, `go vet`, `gofmt -l` clean; files < 200 LOC.
+- [x] WPM counts 0→final over ~600ms with easeOut; lands exactly on final (no off-by-one blur).
+- [x] Sparkline fills left→right; stat cards appear staggered; no horizontal jitter at any frame.
+- [x] Final settled frame is **byte-identical** to the current static Result render (golden test).
+- [x] Under `NO_COLOR`, reveal uses faint→normal only; layout-identical (line count + rune width).
+- [x] `HasActiveAnim` false after `totalRevealMs`; loop self-stops.
+- [x] A second consecutive result animates fresh (no inherited elapsed window from the prior result).
+- [x] `make test-race`, `go vet`, `gofmt -l` clean; files < 200 LOC.
 
 ## Risk Assessment
 - **Width jitter on digit growth (UX flag):** mitigated by reserved fixed-width digit slot; test asserts

--- a/plans/260618-1454-ui-ux-animation-system/phase-05-new-best-celebration.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-05-new-best-celebration.md
@@ -1,7 +1,7 @@
 ---
 phase: 5
 title: "New-best celebration"
-status: pending
+status: completed
 priority: P3
 effort: "4h"
 dependencies: [2, 4]
@@ -67,13 +67,13 @@ Cell count and rune width unchanged → layout-identical (glyph content differs 
    non-new-best result emits zero particles.
 
 ## Success Criteria
-- [ ] New best → visible ~1s sparkle in the card’s blank margin rows; ordinary result → nothing.
-- [ ] A non-new-best result immediately following a new-best emits ZERO particles (no residue).
-- [ ] All glyphs are ASCII display-width 1 (asserted); overlay only touches blank margin rows.
-- [ ] Overlay never changes line count or any line’s rune width (asserted).
-- [ ] Under `NO_COLOR`, sparkle is attribute-only; layout-identical (line count + rune width).
-- [ ] Burst is one-shot; `HasActiveAnim` false after `celebrateMs`; loop self-stops.
-- [ ] `make test-race`, `go vet`, `gofmt -l` clean; files < 200 LOC.
+- [x] New best → visible ~1s sparkle in the card’s blank margin rows; ordinary result → nothing.
+- [x] A non-new-best result immediately following a new-best emits ZERO particles (no residue).
+- [x] All glyphs are ASCII display-width 1 (asserted); overlay only touches blank margin rows.
+- [x] Overlay never changes line count or any line’s rune width (asserted).
+- [x] Under `NO_COLOR`, sparkle is attribute-only; layout-identical (line count + rune width).
+- [x] Burst is one-shot; `HasActiveAnim` false after `celebrateMs`; loop self-stops.
+- [x] `make test-race`, `go vet`, `gofmt -l` clean; files < 200 LOC.
 
 ## Risk Assessment
 - **Annoyance / overuse:** restricted to new-best only and one-shot — matches research guidance.

--- a/plans/260618-1454-ui-ux-animation-system/phase-06-screen-transitions.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-06-screen-transitions.md
@@ -1,7 +1,7 @@
 ---
 phase: 6
 title: "Screen transitions"
-status: pending
+status: completed
 priority: P2
 effort: "5h"
 dependencies: [2]
@@ -82,12 +82,12 @@ pressed enter; immediacy is correct). Other navs stay instant unless the user la
    ignored by View even if not yet nil-ed; resize/abort cancel cleanly.
 
 ## Success Criteria
-- [ ] Typing→Result shows a ~250ms crossfade (color) / wipe (NO_COLOR), then the live Result reveal.
-- [ ] Transition never changes total line count or any line’s rune width (asserted both modes).
-- [ ] `model_view.go` remains the single return chokepoint (all paths via `altView`).
-- [ ] Transition expiry is derived in View (no value-receiver mutation); no stale-frame stall.
-- [ ] Resize during a transition snaps to `toScreen` (no old-width bleed); abort clears it.
-- [ ] `make test-race`, `go vet`, `gofmt -l` clean; files < 200 LOC.
+- [x] Typing→Result shows a ~250ms crossfade (color) / wipe (NO_COLOR), then the live Result reveal.
+- [x] Transition never changes total line count or any line’s rune width (asserted both modes).
+- [x] `model_view.go` remains the single return chokepoint (all paths via `altView`).
+- [x] Transition expiry is derived in View (no value-receiver mutation); no stale-frame stall.
+- [x] Resize during a transition snaps to `toScreen` (no old-width bleed); abort clears it.
+- [x] `make test-race`, `go vet`, `gofmt -l` clean; files < 200 LOC.
 
 ## Risk Assessment
 - **Faint-nesting reliability:** wrapping an already-styled frame in `Faint(true)` may not override

--- a/plans/260618-1454-ui-ux-animation-system/phase-07-hardening-and-docs.md
+++ b/plans/260618-1454-ui-ux-animation-system/phase-07-hardening-and-docs.md
@@ -1,7 +1,7 @@
 ---
 phase: 7
 title: "Hardening and docs"
-status: pending
+status: completed
 priority: P1
 effort: "4h"
 dependencies: [3, 4, 5, 6]
@@ -63,14 +63,14 @@ The plan/docs use "layout-identical" wording accordingly.
    `celebrateMs`, transition `durMs`) are consistent across phases and docs.
 
 ## Success Criteria
-- [ ] `go test ./... -race -count=1` green; `go vet` clean; `gofmt -l .` empty; `make size-check` passes.
-- [ ] Settled frame of every animated screen is byte-identical to its pre-animation static render
+- [x] `go test ./... -race -count=1` green; `go vet` clean; `gofmt -l .` empty; `make size-check` passes.
+- [x] Settled frame of every animated screen is byte-identical to its pre-animation static render
       (the *settled* end state IS byte-identical; only mid-animation differs, and celebration only by content).
-- [ ] NO_COLOR layout-invariant test (rune width + line count) passes for typing, result, celebration, transition.
-- [ ] Edge-case tests pass: resize/abort/ctrl+r/double-result/min-terminal.
-- [ ] Typing hot-path benchmark confirms the P3 prefix-cache engages (animated allocs/op ≈ static).
-- [ ] Chosen `frameInterval` recorded with rationale; idle app schedules zero frame ticks.
-- [ ] Docs (`codebase-summary`, `system-architecture`, `roadmap`, `README`) updated; no plan refs in code.
+- [x] NO_COLOR layout-invariant test (rune width + line count) passes for typing, result, celebration, transition.
+- [x] Edge-case tests pass: resize/abort/ctrl+r/double-result/min-terminal.
+- [x] Typing hot-path benchmark confirms the P3 prefix-cache engages (animated allocs/op ≈ static).
+- [x] Chosen `frameInterval` recorded with rationale; idle app schedules zero frame ticks.
+- [x] Docs (`codebase-summary`, `system-architecture`, `roadmap`, `README`) updated; no plan refs in code.
 
 ## Risk Assessment
 - **Golden flakiness:** any non-pinned timestamp reintroduces flakiness — assert all animated goldens

--- a/plans/260618-1454-ui-ux-animation-system/plan.md
+++ b/plans/260618-1454-ui-ux-animation-system/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "UI/UX Animation System"
 description: "Stdlib-only terminal motion system for Typeburn: pure anim package, self-stopping frame driver, animated caret, result reveal, new-best celebration, and screen transitions — always-on, NO_COLOR auto-adapting."
-status: pending
+status: completed
 priority: P2
 branch: "main"
 tags: [ui, animation, motion, tui]
@@ -29,7 +29,7 @@ draw-in + stat stagger), a new-best celebration burst, and screen transitions
   (line count + rune width preserved)**. NOTE: this is *layout*-identical, not
   literally *byte*-identical — the celebration (P5) overlays glyphs onto blank
   padding cells, changing rune *content* of those cells while preserving width.
-  Flagged for user confirmation (see Open decisions).
+  This wording is now the shipped invariant documented in `docs/system-architecture.md`.
 - **Pure-logic layering preserved** — new `internal/anim` package is UI-free
   (joins `typing`/`metrics`/`words`); UI deps stay in `ui`/`app`/`theme`.
 - **<200 LOC per file**, allowed deps unchanged (stdlib + charm.land/* + cobra + x/*).
@@ -90,13 +90,14 @@ P1 (anim pkg) ──► P2 (frame driver) ──┬─► P3 (caret)
 4. **No layout mutation, ever.** Count-up reserves max digit width; confetti
    overlays existing blank cells; transitions never reflow. Guarded by golden tests.
 
-## Open decisions deferred to validation/red-team
+## Decisions resolved during implementation
 
-- Frame cadence: 33ms (30fps) default vs 50ms (20Hz) SSH-safer. Benchmark gate in P7.
-- Caret trail jitter risk (UX researcher flagged) — verify legibility at speed in P3.
+- Frame cadence stayed at 33ms (30fps). P7 benchmark confirmed the prefix cache
+  keeps animated word-stream work bounded.
+- Caret trail shipped as a subtle 150ms effect with deterministic tests.
 - **"byte-identical" wording**: the brainstorm constraint said "byte-identical layout".
-  Resolved as **layout-identical** (line count + rune width). Celebration glyphs change
-  rune content of blank cells but not layout — confirm this reading is acceptable to user.
+  Shipped as **layout-identical** for mid-animation frames (line count + rune
+  width); settled frames stay byte-identical to the static render.
 
 ## Red-team resolutions (applied to phases)
 

--- a/plans/260619-1422-animation-plan-doc-sync/phase-01-sync-animation-plan-artifacts.md
+++ b/plans/260619-1422-animation-plan-doc-sync/phase-01-sync-animation-plan-artifacts.md
@@ -1,0 +1,75 @@
+---
+phase: 1
+title: Sync Animation Plan Artifacts
+status: completed
+priority: P1
+effort: 1h
+dependencies: []
+---
+
+# Phase 1: Sync Animation Plan Artifacts
+
+## Overview
+
+Reconcile `plans/260618-1454-ui-ux-animation-system/` with shipped reality. The
+top-level phase table says done, but frontmatter and phase checklists still say
+pending/TODO.
+
+## Requirements
+
+- Functional: old animation plan reads as completed and traceable to PRs #40-#47.
+- Non-functional: preserve historical context; do not rewrite implementation
+  decisions or invent new scope.
+
+## Architecture
+
+Use the existing plan directory as the source-of-truth artifact for the shipped
+animation work. Keep the new cleanup plan separate so future readers can see why
+metadata changed after the implementation PRs.
+
+Prefer `ck plan check` for CLI-managed phase status if it works cleanly in the
+old plan directory. Manually patch only fields/checklists that the CLI cannot
+sync.
+
+## Related Code Files
+
+- Modify: `plans/260618-1454-ui-ux-animation-system/plan.md`
+- Modify: `plans/260618-1454-ui-ux-animation-system/phase-01-anim-core-package.md`
+- Modify: `plans/260618-1454-ui-ux-animation-system/phase-02-frame-driver.md`
+- Modify: `plans/260618-1454-ui-ux-animation-system/phase-03-caret-animation.md`
+- Modify: `plans/260618-1454-ui-ux-animation-system/phase-04-result-reveal.md`
+- Modify: `plans/260618-1454-ui-ux-animation-system/phase-05-new-best-celebration.md`
+- Modify: `plans/260618-1454-ui-ux-animation-system/phase-06-screen-transitions.md`
+- Modify: `plans/260618-1454-ui-ux-animation-system/phase-07-hardening-and-docs.md`
+- Modify: `plans/260618-1454-ui-ux-animation-system/handover-phases-04-07-cook-continuation.md`
+
+## Implementation Steps
+
+1. Update old plan frontmatter `status: completed`.
+2. Confirm phase table already lists all phases done with PR references.
+3. Update each phase file frontmatter `status: completed`.
+4. Change success criteria checkboxes from `[ ]` to `[x]` only where verified by
+   merged code/tests/docs. If any item is ambiguous, leave unchecked and note why.
+5. Update handover file:
+   - Mark it as superseded by PRs #44-#47; or
+   - Rewrite status table to shipped, preserving useful deviations/gotchas as
+     historical notes.
+6. Remove stale "remain", "TODO", or "needs user confirmation" text only when
+   the current code/docs prove it is resolved.
+7. Run `rg -n "status: pending|\\[ \\]|TODO|remain"` inside the animation plan
+   directory and review remaining hits.
+
+## Success Criteria
+
+- [x] `plan.md` frontmatter says `status: completed`.
+- [x] Phase 1-7 files say `status: completed`.
+- [x] No stale unchecked success criteria remain for completed shipped work.
+- [x] Handover file cannot be misread as current TODO work.
+- [x] Remaining search hits are intentional and documented.
+
+## Risk Assessment
+
+- Risk: marking an unverified item complete because implementation exists nearby.
+  Mitigation: cite merged PRs/tests or leave item unchecked with note.
+- Risk: losing useful historical context in the handover. Mitigation: mark
+  superseded instead of deleting unless content is misleading/noisy.

--- a/plans/260619-1422-animation-plan-doc-sync/phase-02-sync-evergreen-documentation.md
+++ b/plans/260619-1422-animation-plan-doc-sync/phase-02-sync-evergreen-documentation.md
@@ -1,0 +1,69 @@
+---
+phase: 2
+title: Sync Evergreen Documentation
+status: completed
+priority: P1
+effort: 1h
+dependencies:
+  - 1
+---
+
+# Phase 2: Sync Evergreen Documentation
+
+## Overview
+
+Fix project docs that still describe pre-animation behavior or incomplete PR
+ranges. Keep docs concise and consistent with the shipped implementation.
+
+## Requirements
+
+- Functional: docs describe current motion behavior accurately.
+- Non-functional: no code comments or docs should refer to volatile phase/finding
+  labels as the reason for behavior; explain stable behavior/invariants instead.
+
+## Architecture
+
+Evergreen docs are the source of truth for future contributors. Update the small
+set of files that directly mention motion, NO_COLOR behavior, or animation PR
+status. Avoid broad documentation rewrites.
+
+## Related Code Files
+
+- Modify: `docs/design-guidelines.md`
+- Modify: `README.md`
+- Modify: `docs/project-roadmap.md`
+- Inspect/modify if needed: `docs/system-architecture.md`
+- Inspect/modify if needed: `docs/codebase-summary.md`
+
+## Implementation Steps
+
+1. Update `docs/design-guidelines.md` motion policy:
+   - Replace "screen transitions: hard cut" with shipped policy.
+   - Mention Typing->Result gets a short transition.
+   - Mention NO_COLOR uses row wipe / attribute-only behavior.
+   - Remove stale "already static" reduced-motion wording if it contradicts
+     always-on animation.
+2. Update `README.md` feature bullet if needed so it includes the Typing->Result
+   transition, not only caret/reveal/celebration.
+3. Update `docs/project-roadmap.md` PR range from `#40-#46` to `#40-#47`.
+4. Inspect `docs/system-architecture.md` and `docs/codebase-summary.md`; patch
+   only if they conflict with current code or this cleanup.
+5. Search docs for stale motion statements:
+   `rg -n "hard cut|no motion|near-static|#40.*#46|TODO|remain" docs README.md`.
+
+## Success Criteria
+
+- [x] `docs/design-guidelines.md` matches shipped animation behavior.
+- [x] README feature list mentions transition or deliberately omits it with no
+      contradiction.
+- [x] Roadmap status references PRs #40-#47.
+- [x] `docs/system-architecture.md` and `docs/codebase-summary.md` remain
+      consistent after inspection.
+- [x] No stale motion-policy contradictions remain in docs.
+
+## Risk Assessment
+
+- Risk: over-editing design docs beyond the requested drift. Mitigation: patch
+  only paragraphs that contradict shipped behavior.
+- Risk: docs claim more than code supports. Mitigation: verify against
+  `internal/app/transition.go`, `internal/ui/frame_tick.go`, and existing tests.

--- a/plans/260619-1422-animation-plan-doc-sync/phase-03-verify-and-prepare-pr.md
+++ b/plans/260619-1422-animation-plan-doc-sync/phase-03-verify-and-prepare-pr.md
@@ -1,0 +1,69 @@
+---
+phase: 3
+title: Verify And Prepare PR
+status: completed
+priority: P2
+effort: 1h
+dependencies:
+  - 1
+  - 2
+---
+
+# Phase 3: Verify And Prepare PR
+
+## Overview
+
+Run the lightweight verification gate and prepare the branch/PR for a docs/plans
+cleanup. This protects against accidental source churn and keeps protected-main
+workflow intact.
+
+## Requirements
+
+- Functional: branch contains only intended docs/plans changes.
+- Non-functional: verification output is captured in PR notes; no direct commit
+  or push to `main`.
+
+## Architecture
+
+Use the repo's normal PR flow. Since this should be docs/plans-only, the Go gates
+should be unchanged from the current clean baseline. Still run them unless time
+or environment blocks execution.
+
+## Related Code Files
+
+- No source files expected.
+- Inspect: `git diff --stat`
+- Inspect: `git diff -- plans/260618-1454-ui-ux-animation-system docs README.md`
+
+## Implementation Steps
+
+1. Create branch: `git checkout -b fix/anim-plan-doc-sync`.
+2. Verify changed files are limited to:
+   - `plans/260618-1454-ui-ux-animation-system/**`
+   - `plans/260619-1422-animation-plan-doc-sync/**`
+   - selected evergreen docs (`README.md`, `docs/*.md`)
+3. Run verification:
+   - `go test ./... -race -count=1`
+   - `go vet ./...`
+   - `gofmt -l .`
+   - `make size-check`
+4. Optional quick check: `ck plan status plans/260618-1454-ui-ux-animation-system/plan.md`.
+5. Commit with conventional message. Suggested:
+   `docs(anim): sync shipped animation plan status`
+6. Push branch and open PR to `main`.
+
+## Success Criteria
+
+- [x] Git diff contains only docs/plans cleanup.
+- [x] Verification commands pass, or skipped/failed commands are explained.
+- [x] Commit message uses `docs(anim): ...` or another accurate conventional type.
+- [x] PR summary states: code already shipped; this syncs plan/docs drift.
+- [x] No unresolved questions remain.
+
+## Risk Assessment
+
+- Risk: CI wasted on docs-only change. Mitigation: acceptable; protected main
+  requires PR checks and the local baseline is known clean.
+- Risk: plan sync modifies old artifacts in a way future tools dislike.
+  Mitigation: prefer `ck plan` commands for phase status where possible; keep
+  markdown structure intact.

--- a/plans/260619-1422-animation-plan-doc-sync/plan.md
+++ b/plans/260619-1422-animation-plan-doc-sync/plan.md
@@ -1,0 +1,70 @@
+---
+title: Animation Plan Documentation Sync
+description: >-
+  Sync shipped animation plan metadata and evergreen docs after PRs #40-#47
+  landed.
+status: completed
+priority: P2
+effort: 3h
+branch: fix/anim-plan-doc-sync
+tags:
+  - docs
+  - plans
+  - tech-debt
+blockedBy: []
+blocks: []
+created: '2026-06-19T07:22:14.238Z'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Animation Plan Documentation Sync
+
+## Overview
+
+The UI/UX Animation System is implemented and merged on `main`, verified by
+merged PRs #40-#47 and a clean local gate. The remaining work is documentation
+and plan-state hygiene: reconcile stale `pending` metadata/checklists in the
+animation plan, remove or mark stale handover text, and align evergreen docs
+with shipped motion behavior.
+
+No source behavior change expected. Treat this as a docs/plans cleanup with a
+normal PR, because `main` is protected.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Sync Animation Plan Artifacts](./phase-01-sync-animation-plan-artifacts.md) | Completed |
+| 2 | [Sync Evergreen Documentation](./phase-02-sync-evergreen-documentation.md) | Completed |
+| 3 | [Verify And Prepare PR](./phase-03-verify-and-prepare-pr.md) | Completed |
+
+## Dependencies
+
+- Target plan to sync: `plans/260618-1454-ui-ux-animation-system/`.
+- Implementation evidence: merged PRs #40, #41, #42, #44, #45, #46, #47 on `main`.
+- No blocking plan dependencies. The old animation plan is the artifact being
+  corrected, not a prerequisite for this cleanup.
+
+## Scope
+
+In scope:
+- Update animation plan frontmatter/status and phase success checklists.
+- Mark the stale handover file superseded or rewrite it as historical handoff.
+- Update evergreen docs that contradict shipped motion behavior.
+- Re-run gates and prepare a small PR.
+
+Out of scope:
+- No animation code changes.
+- No new tests unless a doc-only change unexpectedly exposes an existing failure.
+- No release/tag work.
+
+## Success Criteria
+
+- Animation plan and each phase file no longer show stale `pending` state.
+- Stale TODO language in the handover is removed or explicitly superseded.
+- `docs/design-guidelines.md` no longer says transitions are hard cuts.
+- `README.md`, `docs/project-roadmap.md`, and architecture/codebase docs are
+  internally consistent about caret, reveal, celebration, transition, NO_COLOR,
+  and PR range #40-#47.
+- Verification commands pass or any skipped command is explained in the PR notes.

--- a/plans/260619-1422-animation-plan-doc-sync/reports/pm-260619-1535-animation-plan-doc-sync-complete.md
+++ b/plans/260619-1422-animation-plan-doc-sync/reports/pm-260619-1535-animation-plan-doc-sync-complete.md
@@ -1,0 +1,48 @@
+# Plan Complete: Animation Plan Documentation Sync
+
+## Summary
+
+| Item | Result |
+|---|---|
+| Plan | `plans/260619-1422-animation-plan-doc-sync/plan.md` |
+| Status | completed |
+| Phases | 3/3 complete |
+| Scope | docs/plans only |
+| Source behavior | unchanged |
+
+## Completed
+
+- [x] Synced `plans/260618-1454-ui-ux-animation-system` frontmatter and phase criteria to shipped state.
+- [x] Marked phases 4-7 handover as historical/superseded, with PRs #44-#47 recorded.
+- [x] Updated README/design/roadmap docs for Typing->Result transition, NO_COLOR attributes, and PR range #40-#47.
+- [x] Fixed stale architecture/codebase summaries for CodePaste and pre-start caret tick wiring.
+- [x] Created cleanup plan and synced its phase status/checklists.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| `go test ./... -race -count=1` | pass |
+| `go vet ./...` | pass |
+| `gofmt -l .` | empty |
+| `make size-check` | pass |
+| `git diff --check` | pass |
+| Code review | 10/10, no warnings |
+
+## Changed Areas
+
+- `README.md`
+- `docs/codebase-summary.md`
+- `docs/design-guidelines.md`
+- `docs/project-roadmap.md`
+- `docs/system-architecture.md`
+- `plans/260618-1454-ui-ux-animation-system/**`
+- `plans/260619-1422-animation-plan-doc-sync/**`
+
+## Risks
+
+- None open. Docs/plans-only change; no runtime contract touched.
+
+## Unresolved Questions
+
+None.


### PR DESCRIPTION
## Summary
- sync shipped animation plan metadata/checklists
- mark handover historical
- align README/design/roadmap/architecture/codebase docs with shipped animation behavior

## Tests
- `git diff --check`: PASS
- `gofmt -l .`: empty
- `go vet ./...`: PASS
- `go test ./... -race -count=1`: PASS
- `make size-check`: PASS
- code-reviewer final score 10/10, no warnings

## Note
Docs/plans-only, no runtime behavior changes.
