### PR TITLE
chore(release): prep v2.4.1 (UI/UX animation system)

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,13 +1,20 @@
-## [2.4.0] - 2026-05-30
+## [2.4.1] - 2026-06-20
 
-### Changed
+### Added
 
-- The in-app "update available" hint on the result screen now points at
-  `typeburn update` (the self-updater) instead of the check-only
-  `typeburn version --check-update`.
-- `typeburn update` now prints `downloading` / `verifying` / `installing`
-  progress lines during the swap instead of blocking silently, and surfaces the
-  release-notes URL (`Release notes: <url>`) before installing — matching the
-  output of `typeburn version --check-update`.
+- **UI/UX animation system** — a stdlib-only terminal motion layer, always on
+  and auto-adapting under `NO_COLOR`:
+  - Animated typing caret: blink (530ms), freshly-typed cell fade, and a
+    just-vacated trail.
+  - Result screen reveal: WPM count-up (fixed-width slot, no jitter), sparkline
+    draw-in, and staggered stat cards.
+  - One-shot sparkle burst when a result beats the per-mode personal best.
+  - A short Typing→Result transition (dim-curtain crossfade in color, a
+    row-wipe under `NO_COLOR`).
+  - Driven by a self-stopping ~33ms frame loop that schedules zero ticks when
+    idle, independent of the existing 100ms timer. Motion never shifts layout
+    (line count + rune width preserved) and every settled frame matches the
+    prior static render; the typing hot path is kept cheap by a prefix-token
+    cache.
 
-[2.4.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.4.0
+[2.4.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-06-20
+
 ### Added
 
 - **UI/UX animation system** — a stdlib-only terminal motion layer, always on
@@ -307,7 +309,8 @@ terminal typing test built with Go and Bubble Tea v2.
   HTTPS transport and the pipeline-generated `checksums.txt`. See
   [SECURITY.md](./SECURITY.md).
 
-[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v2.4.1...HEAD
+[2.4.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.4.1
 [2.0.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.0.0
 [1.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.5.0
 [1.4.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.4.0


### PR DESCRIPTION
Release-prep for **v2.4.1**.

## What
- `CHANGELOG.md`: move the curated `[Unreleased]` animation-system block to `## [2.4.1] - 2026-06-20`; reset `[Unreleased]` compare link to `v2.4.1...HEAD`; add `[2.4.1]` release link.
- `.github/release-notes.md`: replace 2.4.0 notes with the verbatim 2.4.1 section (consumed by GoReleaser `--release-notes`).

## Version note
Per-maintainer request this is tagged **v2.4.1** (patch). Content is the UI/UX animation system (PRs #40–#48), a feature add — SemVer would normally call this a minor (v2.5.0). Cutting as requested.

No source/behavior change. Docs only.

After squash-merge: disposable-tag dry-run via `release.yml`, verify 7 assets + checksums + notes, delete dry-run, then annotate `v2.4.1` on the merged SHA and push.