### PR TITLE
build: silence echoed go build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SIZE_LIMIT ?= 10485760
 .PHONY: build run test test-race lint fmt clean version snapshot release size-check notui-noexit-check
 
 build:
-	go build -trimpath -ldflags '$(LDFLAGS)' -o $(BIN_DIR)/$(BINARY) .
+	@go build -trimpath -ldflags '$(LDFLAGS)' -o $(BIN_DIR)/$(BINARY) .
 
 run:
 	go run .


### PR DESCRIPTION
Re-applies the one useful change from the obsolete quiet-make-recipe-echo branch onto current main: prefix the build recipe with @ so 'make build' does not echo the full go build invocation. No behavior change beyond output verbosity. Supersedes quiet-make-recipe-echo (to be deleted).