### PR TITLE
feat(config): add strict_mode setting + config CLI key

### DIFF
--- a/internal/cli/cmd_config.go
+++ b/internal/cli/cmd_config.go
@@ -90,6 +90,7 @@ func configRows(s config.Settings) [][]string {
 		{"default_length", strconv.Itoa(s.DefaultLength)},
 		{"blink_cursor", strconv.FormatBool(s.BlinkCursor)},
 		{"update_check", strconv.FormatBool(s.UpdateCheck)},
+		{"strict_mode", strconv.FormatBool(s.StrictMode)},
 	}
 }
 
@@ -136,6 +137,12 @@ func configSet(s *config.Settings, key, value string) error {
 			return usageError("update_check must be true, false, 1, 0, on, off, yes, or no")
 		}
 		s.UpdateCheck = v
+	case "strict_mode":
+		v, ok := parseBool(value)
+		if !ok {
+			return usageError("strict_mode must be true, false, 1, 0, on, off, yes, or no")
+		}
+		s.StrictMode = v
 	default:
 		return usageError("unknown config key %q", key)
 	}

--- a/internal/cli/strict_mode_config_test.go
+++ b/internal/cli/strict_mode_config_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+)
+
+func TestStrictModeSetGet(t *testing.T) {
+	settings := config.Defaults()
+	var out bytes.Buffer
+
+	execRoot := func(args ...string) error {
+		out.Reset()
+		root := NewRoot(
+			WithWriters(&out, &bytes.Buffer{}),
+			WithHomeRunner(func(context.Context, string, string) error { return nil }),
+			WithSettingsStore(
+				func() config.Settings { return settings },
+				func(s config.Settings) error { settings = s; return nil },
+			),
+		)
+		root.SetArgs(args)
+		return root.Execute()
+	}
+
+	// Default is false.
+	if err := execRoot("config", "get", "strict_mode"); err != nil {
+		t.Fatalf("get strict_mode: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "false" {
+		t.Fatalf("default strict_mode: want false, got %q", out.String())
+	}
+
+	// Set to true and read back.
+	if err := execRoot("config", "set", "strict_mode", "true"); err != nil {
+		t.Fatalf("set strict_mode true: %v", err)
+	}
+	if err := execRoot("config", "get", "strict_mode"); err != nil {
+		t.Fatalf("get strict_mode after set: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "true" {
+		t.Fatalf("after set: want true, got %q", out.String())
+	}
+
+	// Reject invalid values.
+	if err := execRoot("config", "set", "strict_mode", "bogus"); err == nil {
+		t.Fatal("expected error setting invalid strict_mode")
+	}
+}
+
+func TestConfigListIncludesStrictMode(t *testing.T) {
+	var out bytes.Buffer
+	root := NewRoot(
+		WithWriters(&out, &bytes.Buffer{}),
+		WithHomeRunner(func(context.Context, string, string) error { return nil }),
+		WithSettingsStore(func() config.Settings { return config.Defaults() }, nil),
+	)
+	root.SetArgs([]string{"config", "list"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("config list: %v", err)
+	}
+	if !strings.Contains(out.String(), "strict_mode") {
+		t.Errorf("config list output missing strict_mode:\n%s", out.String())
+	}
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -30,6 +30,7 @@ type Settings struct {
 	// UpdateCheck enables an opt-in opportunistic update check on TUI launch.
 	// Default is false to preserve offline-first posture.
 	UpdateCheck bool `json:"update_check"`
+	StrictMode  bool `json:"strict_mode"`
 }
 
 // Defaults returns the baseline configuration used on first run or whenever
@@ -41,6 +42,7 @@ func Defaults() Settings {
 		DefaultLength: 30,
 		BlinkCursor:   false,
 		UpdateCheck:   false,
+		StrictMode:    false,
 	}
 }
 

--- a/internal/config/strict_mode_settings_test.go
+++ b/internal/config/strict_mode_settings_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestDefaults_StrictMode(t *testing.T) {
+	s := Defaults()
+	if s.StrictMode {
+		t.Error("StrictMode: want false by default")
+	}
+}
+
+func TestLoadSettings_MissingStrictModeField(t *testing.T) {
+	// JSON without strict_mode — simulates legacy settings.
+	raw := `{"theme":"default","default_mode":"time","default_length":30,"blink_cursor":false}`
+	var s Settings
+	if err := jsonUnmarshal([]byte(raw), &s); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if s.StrictMode {
+		t.Error("StrictMode: want false when field is absent from JSON")
+	}
+}


### PR DESCRIPTION
Phase 2: add strict_mode settings to config.Settings and expose it in CLI config list/get/set commands. Prepares for wiring in Phase 3.