### PR TITLE
feat: consolidate upcoming v2.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
-## [2.5.0] - 2026-06-26
-
 ### Added
 
 - **Strict typing mode** — an optional letter-strict typing mode:
@@ -21,6 +19,16 @@ release section is extracted verbatim and passed to GoReleaser via
   - Keystroke-level accuracy metric: strict runs compute and save `KeystrokeAccuracy` (based on total non-backspace forward keystrokes) rather than final-state accuracy.
   - Excluded from bests: strict runs are saved in history but excluded from personal best (★) records.
   - Settings TUI toggle and CLI config key (`typeburn config set strict_mode on|off`) persisted in `settings.json` (backward-compatible).
+- **Punctuation and numbers toggles** — optional persisted Settings controls that
+  add commas, periods, capitalization, and numeric tokens to Words/Time target
+  generation; Quote and Code targets remain unchanged.
+
+### Fixed
+
+- Code records now use the `code` label rather than being displayed as Quote
+  records in History and Result metadata.
+- Code and Strict records consistently remain ineligible for personal-best (★)
+  markers across result detection and History display.
 
 ## [2.4.1] - 2026-06-20
 
@@ -320,8 +328,7 @@ terminal typing test built with Go and Bubble Tea v2.
   HTTPS transport and the pipeline-generated `checksums.txt`. See
   [SECURITY.md](./SECURITY.md).
 
-[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v2.5.0...HEAD
-[2.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.5.0
+[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v2.4.1...HEAD
 [2.4.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.4.1
 [2.0.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.0.0
 [1.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.5.0

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Distraction-free, keyboard-driven, and works on any ANSI terminal.
 - **History**: scrollable table of all past tests with per-mode best marker (★)
 - **Themes**: `default` (dark, green accent) and `mono` (attribute-only, no color codes)
 - **Strict mode**: optional letter-strict mode that blocks wrong keypresses at the cursor, logging errors for keystroke-level accuracy, and excluding strict runs from personal best (★) records.
+- **Punctuation & numbers**: optional Settings toggles that mix commas/periods/capitalization and random numbers into Words/Time mode tests.
 - **NO_COLOR support**: set `NO_COLOR=1` for a fully attribute-only render (reverse, bold, underline, faint; no color codes)
 - **Minimum terminal**: 60 columns × 20 rows; graceful degraded notice below that
 - **XDG-compliant paths**: settings and history go to `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME`

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Distraction-free, keyboard-driven, and works on any ANSI terminal.
 - **Live stats**: WPM, raw WPM, accuracy, and consistency updated every keystroke
 - **Result screen**: big-digit WPM, sparkline chart, full char breakdown
 - **Subtle motion**: animated caret (blink + fade), result reveal (WPM count-up, sparkline draw-in), new-best celebration, and Typing→Result transition — always on, auto-adapts to `NO_COLOR` (layout never shifts)
-- **History**: scrollable table of all past tests with per-mode best marker (★)
-- **Themes**: `default` (dark, green accent) and `mono` (attribute-only, no color codes)
+- **History**: scrollable table of all past tests with personal-best markers (★) for eligible runs: Time/Words by mode + length and Quote by mode; Code and Strict runs never qualify
+- **Themes**: `default`, `mono`, `solarized-dark`, `solarized-light`, `dracula`, `nord`, `gruvbox-dark`, `gruvbox-light`; `mono` is a grayscale color palette
 - **Strict mode**: optional letter-strict mode that blocks wrong keypresses at the cursor, logging errors for keystroke-level accuracy, and excluding strict runs from personal best (★) records.
 - **Punctuation & numbers**: optional Settings toggles that mix commas/periods/capitalization and random numbers into Words/Time mode tests.
-- **NO_COLOR support**: set `NO_COLOR=1` for a fully attribute-only render (reverse, bold, underline, faint; no color codes)
+- **NO_COLOR support**: any non-empty `NO_COLOR` value forces a fully attribute-only render (reverse, bold, underline, faint; no color codes), regardless of the selected theme
 - **Minimum terminal**: 60 columns × 20 rows; graceful degraded notice below that
 - **XDG-compliant paths**: settings and history go to `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,13 +44,14 @@ Flags:
 | `--duration N` | time | Positive seconds |
 | `--words N` | words | Positive word count |
 | `--quote-len short|medium|long` | quote | Defaults to medium |
-| `--theme NAME` | TUI | Initial-only override; Settings changes inside the TUI win |
+| `--theme NAME` | TUI | Initial-only override; one of `default`, `mono`, `solarized-dark`, `solarized-light`, `dracula`, `nord`, `gruvbox-dark`, `gruvbox-light`; Settings changes inside the TUI win |
 | `--text PATH|-` | code | Required for CLI Code mode |
 | `--no-tui` | all | Raw stdin/stdout runner; stdin must be a terminal |
 | `--json` | `--no-tui` only | Emits final metrics JSON |
 
-Code mode from the CLI never opens the in-app paste screen. Use bare `typeburn`
-and choose Code to paste interactively.
+Code mode from the CLI never opens the in-app paste screen. A persisted
+`default_mode=code` is honored by `run`, but `--text` is still required; use
+bare `typeburn` and choose Code to paste interactively.
 
 Raw mode limitation: if a `--no-tui` process is killed by SIGKILL or the parent
 terminal disappears, Typeburn cannot restore the terminal. Run `reset` or
@@ -76,17 +77,24 @@ typeburn config set theme nord
 typeburn config set update_check on
 ```
 
-Keys: `theme`, `default_mode`, `default_length`, `blink_cursor`, `update_check`.
+Keys: `theme`, `default_mode`, `default_length`, `blink_cursor`, `update_check`,
+`strict_mode`, `punctuation`, `numbers`.
 
 | Key | Values | Default | Notes |
 |---|---|---|---|
-| `theme` | name string | `default` | Built-in theme name |
-| `default_mode` | `time\|words\|quote\|code` | `time` | |
-| `default_length` | positive int | `30` | Seconds or word count |
-| `blink_cursor` | `true\|false` | `false` | |
-| `update_check` | `on\|off` (also `true\|false\|yes\|no\|1\|0`) | `off` | Opt-in opportunistic check |
+| `theme` | `default\|mono\|solarized-dark\|solarized-light\|dracula\|nord\|gruvbox-dark\|gruvbox-light` | `default` | Built-in theme name |
+| `default_mode` | `time\|words\|quote\|code` | `time` | The TUI Settings row cycles only Time/Words/Quote |
+| `default_length` | non-negative integer | `30` | Constrained to the selected Time/Words options; Quote/Code have no numeric selector |
+| `blink_cursor` | Boolean | `false` | Typing-screen cursor blink |
+| `update_check` | Boolean | `false` | Opt-in opportunistic check; persisted/CLI-only, not a Settings TUI row |
+| `strict_mode` | Boolean | `false` | Blocks wrong forward keystrokes |
+| `punctuation` | Boolean | `false` | Applies only to Words/Time targets |
+| `numbers` | Boolean | `false` | Applies only to Words/Time targets |
 
-`config set` is strict: invalid values exit 1 before writing `settings.json`.
+Boolean values are trimmed and case-insensitive: `true`, `1`, `on`, or `yes`;
+and `false`, `0`, `off`, or `no`. `config set` is strict: invalid values exit 1
+before writing `settings.json`. Punctuation and numbers do not transform Quote
+targets; Code uses its supplied text unchanged.
 
 ### update_check
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -83,7 +83,7 @@ Keys: `theme`, `default_mode`, `default_length`, `blink_cursor`, `update_check`,
 | Key | Values | Default | Notes |
 |---|---|---|---|
 | `theme` | `default\|mono\|solarized-dark\|solarized-light\|dracula\|nord\|gruvbox-dark\|gruvbox-light` | `default` | Built-in theme name |
-| `default_mode` | `time\|words\|quote\|code` | `time` | The TUI Settings row cycles only Time/Words/Quote |
+| `default_mode` | `time\|words\|quote\|code` | `time` | The TUI cycles Time/Words/Quote; it displays a persisted `code` value until changed |
 | `default_length` | non-negative integer | `30` | Constrained to the selected Time/Words options; Quote/Code have no numeric selector |
 | `blink_cursor` | Boolean | `false` | Typing-screen cursor blink |
 | `update_check` | Boolean | `false` | Opt-in opportunistic check; persisted/CLI-only, not a Settings TUI row |

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -105,9 +105,9 @@ executes it, and maps returned errors to process exit codes.
 and `wordTarget` math shared by TUI and CLI.
 
 **Entry points:**
-- `NewSession(mode, length, quoteLen, seed, strict bool) Session`
-- `NewCodeSession(snippet string, strict bool) Session`
-- `RebuildEngine(target string, mode config.Mode, length int, strict bool) *typing.Engine`
+- `NewSession(mode, length, quoteLen, seed, strict, punctuation, numbers) Session`
+- `NewCodeSession(snippet, strict) Session`
+- `RebuildEngine(target string, mode mode.Mode, length int, strict bool) *typing.Engine`
 
 ---
 
@@ -155,8 +155,14 @@ policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
 - `HomeModel`: mode/length picker, defaults display, best-result badge. Emits StartTestMsg.
 - `TypingModel`: live typing test UI. Arms 100ms tick, delegates to typing.Engine, emits ResultMsg on completion.
 - `ResultModel`: big-digit WPM display, sparkline chart, stat cards, footer navigation.
-- `SettingsModel`: four setting rows (Theme/DefaultMode/DefaultLength/BlinkCursor), arrow navigation, auto-persist.
-- `HistoryModel`: scrollable table of all records, per-mode ★ badge, vim-style navigation.
+- `SettingsModel`: seven rows (Theme, Default mode, Default length, Blink
+  cursor, Strict mode, Punctuation, Numbers), arrow navigation, auto-persist.
+  `update_check` is the eighth persisted/CLI key and has no TUI row; the TUI
+  Default mode row cycles Time/Words/Quote, although persisted/CLI values also
+  accept Code.
+- `HistoryModel`: scrollable table of all records; ★ marks eligible bucket
+  leaders (Time/Words by mode+length, Quote by mode); Code/Strict never
+  qualify. Supports vim-style navigation.
 - `CodePasteModel`: paste-only Code-mode entry screen; normalizes bracketed paste via `codetext.Normalize`.
 
 **Components (reusable):**
@@ -244,10 +250,12 @@ policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
 - `quotePack`: {short, medium, long, epic []string} — embedded quotes for each bucket
 
 **Entry points:**
-- `ForMode(generator, mode, length, quoteLen)`: return target string (Time: time buffer; Words: exact N words; Quote: random from bucket)
+- `ForMode(generator, mode, length, quoteLen, punctuation, numbers)`: return
+  target string (Time: time buffer; Words: exact N words; Quote: random from
+  bucket). Punctuation and numbers transform only Time/Words targets.
 - `Word(n)`: return n-th word from wordlist (deterministic, seeded)
 - `Quote(len QuoteLen)`: return random quote from bucket (seeded)
-- `TimeBuffer(seconds)`: generate words for Time mode (~5 chars/word avg)
+- `TimeBuffer()`: generate the oversized Words/Time buffer (~5 chars/word avg)
 
 **Files:** generator.go, for_mode.go, quotes.go, generator_test.go, for_mode_test.go, quotes_test.go.
 
@@ -255,18 +263,21 @@ policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
 
 ### `internal/config` — Settings, Keymap, XDG Paths
 
-**Purpose:** User-facing configuration (theme, mode, length, cursor blink, strict mode) +
+**Purpose:** User-facing configuration (theme, mode, length, cursor blink,
+update check, strict mode, punctuation, numbers) +
 centralized keybindings + XDG directory resolution. Settings and XDG helpers
 stay storage-agnostic; keymap intentionally centralizes Bubble Tea key bindings.
 
 **Key types:**
 - `Mode`: alias of `mode.Mode` for persisted settings compatibility
-- `Settings`: {Theme, DefaultMode, DefaultLength, BlinkCursor, StrictMode} — loaded from disk or defaults
+- `Settings`: {Theme, DefaultMode, DefaultLength, BlinkCursor, UpdateCheck,
+  StrictMode, Punctuation, Numbers} — loaded from disk or defaults
 - `Keymap`: keybinds per screen (Home/Typing/Result/Settings/History) — maps Bubble Tea key codes to actions
 - `QuoteLen`: enum for quote bucket selection
 
 **Entry points:**
-- `Defaults()`: baseline settings (theme="default", mode="time", length=30, blink=false, strict=false)
+- `Defaults()`: baseline settings (theme="default", mode="time", length=30;
+  BlinkCursor, UpdateCheck, StrictMode, Punctuation, and Numbers all false)
 - `(s *Settings) Normalize()`: repair out-of-range values in place
 - `DefaultKeymap()`: centralized keybindings
 - `ConfigDir(), DataDir()`: resolve XDG paths (fallback to ~/.config, ~/.local/share)
@@ -292,7 +303,10 @@ stay storage-agnostic; keymap intentionally centralizes Bubble Tea key bindings.
 - `EffectiveWPM(r Record)`: precise NetWPM comparison with legacy WPM fallback
 - `BestBucketKey(mode, length)`: shared leaderboard bucket key
 - `BestWPMPerBucket(records)`: shared per-bucket bests for UI badges
-- `IsNewBest(history, r)`: check if WPM is highest for that (mode, length) pair (excludes strict runs)
+- `EligibleForBest(r)`: excludes Code and Strict records from personal-best
+  eligibility
+- `IsNewBest(history, r)`: checks eligible records only; Time/Words use
+  mode+length buckets and Quote uses one mode bucket
 
 **Data flow:**
 - Settings loaded at startup in `app.NewFromDisk()`
@@ -307,21 +321,31 @@ history_record.go, history_store_test.go, new_best_test.go, settings_store_test.
 
 ### `internal/theme` — Color Mapping via Roles
 
-**Purpose:** Semantic color system. Decouple UI code from concrete hex colors. Support NO_COLOR + mono (attribute-only) themes without layout changes.
+**Purpose:** Semantic color system. Decouple UI code from concrete hex colors.
+Support grayscale `mono` and attribute-only `NO_COLOR` rendering without layout
+changes.
 
 **Key types:**
-- `Role`: enum {RoleTextPrimary, RoleAccent, RoleError, RoleCursor, ...} — semantic role (12 total)
+- `Role`: enum {RoleTextPrimary, RoleAccent, RoleError, RoleCursorBg,
+  RoleCursorFg, ...} — semantic role (16 total)
 - `Theme`: {name, colors map[Role]color.Color, noColor bool} — theme instance
 - Default theme: dark + green accent + red error
-- Mono theme: greyscale attributes (bold, underline, faint)
+- Mono theme: grayscale colors with a white accent
 
 **Entry points:**
 - `Load(name, noColor)`: return theme by name; respect NO_COLOR env
 - `(t Theme) Style(r Role)`: return lipgloss.Style for role (color + attributes)
 - `(t Theme) Color(r Role)`: return raw color.Color (nil under NO_COLOR)
-- `Available()`: list selectable themes (["default", "mono"])
+- `Available()`: list selectable themes in display order: `default`, `mono`,
+  `solarized-dark`, `solarized-light`, `dracula`, `nord`, `gruvbox-dark`,
+  `gruvbox-light`
 
-**Files:** theme.go, roles.go, default_theme.go, mono_theme.go, theme_test.go.
+Any non-empty `NO_COLOR` value overrides the selected theme and renders by
+attributes only; `mono` remains a color palette.
+
+**Files:** theme.go, roles.go, default-theme.go, mono-theme.go,
+solarized-dark-theme.go, solarized-light-theme.go, dracula-theme.go,
+nord-theme.go, gruvbox-dark-theme.go, gruvbox-light-theme.go, theme_test.go.
 
 ---
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -159,7 +159,7 @@ policy. Pure package used by `typing`, `metrics`, `words`, `runner`, and
   cursor, Strict mode, Punctuation, Numbers), arrow navigation, auto-persist.
   `update_check` is the eighth persisted/CLI key and has no TUI row; the TUI
   Default mode row cycles Time/Words/Quote, although persisted/CLI values also
-  accept Code.
+  accept Code and the row displays a persisted Code value until it is changed.
 - `HistoryModel`: scrollable table of all records; ★ marks eligible bucket
   leaders (Time/Words by mode+length, Quote by mode); Code/Strict never
   qualify. Supports vim-style navigation.

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -32,6 +32,7 @@ contract, including changes being prepared for that release.
   persisted/CLI-only.
 - **Mode and target settings:** persisted/CLI `default_mode` accepts Time,
   Words, Quote, or Code; the TUI Settings row cycles only Time/Words/Quote.
+  It displays a persisted Code value until the user changes the mode.
   `default_length` is non-negative and constrained for Time/Words; Quote and
   Code have no numeric selector. Punctuation and numbers apply only to
   Words/Time targets.

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -15,14 +15,40 @@ and a scriptable v2 CLI.
 
 ---
 
-## v1 Feature Scope (Shipped)
+## Current Product State
+
+**Public stable release:** `v2.4.1`. **Upcoming release:** one consolidated
+`v2.5.0`, which is unreleased. The following describes the current runtime
+contract, including changes being prepared for that release.
+
+- **Themes:** `default`, `mono`, `solarized-dark`, `solarized-light`,
+  `dracula`, `nord`, `gruvbox-dark`, `gruvbox-light`. `mono` is a grayscale
+  color palette. Any non-empty `NO_COLOR` value forces attribute-only rendering
+  regardless of the selected theme.
+- **Persisted/CLI settings:** `theme`, `default_mode`, `default_length`,
+  `blink_cursor`, `update_check`, `strict_mode`, `punctuation`, `numbers`.
+  The Settings TUI exposes seven rows: Theme, Default mode, Default length,
+  Blink cursor, Strict mode, Punctuation, Numbers. `update_check` is
+  persisted/CLI-only.
+- **Mode and target settings:** persisted/CLI `default_mode` accepts Time,
+  Words, Quote, or Code; the TUI Settings row cycles only Time/Words/Quote.
+  `default_length` is non-negative and constrained for Time/Words; Quote and
+  Code have no numeric selector. Punctuation and numbers apply only to
+  Words/Time targets.
+- **Strict and best markers:** Strict blocks wrong forward keystrokes. Code and
+  Strict records never qualify for ★ markers; Time/Words use mode+length
+  buckets and Quote uses one mode bucket.
+
+---
+
+## v1 Feature Scope and Later Additions (Historical)
 
 ### Modes & Durations
 - **Time:** 15, 30, 60, 120 seconds (timer counts down; test ends when time expires)
 - **Words:** 10, 25, 50, 100 words (test ends when word count typed)
 - **Quote:** Short/Medium/Long/Epic from embedded pack (test ends when quote complete)
-- **Code:** User text via `--text`, in-app paste, or `run --mode code --text`
-  (exact whitespace match)
+- **Later addition — Code:** User text via `--text`, in-app paste, or
+  `run --mode code --text` (exact whitespace match)
 
 ### Test Metrics
 - **Net WPM:** correct characters / 5 / seconds × 60
@@ -48,7 +74,8 @@ and a scriptable v2 CLI.
 - `NO_COLOR` env: Switches to attribute-only rendering (no color codes, same layout)
 
 ### Input & UX
-- **Typing mode:** Printable chars + backspace; allow-continue default, with optional letter-strict (stop-on-error) mode
+- **Typing mode:** Printable chars + backspace; allow-continue default.
+  **Later addition — Strict:** optional letter-strict (stop-on-error) mode.
 - **Keybindings:** Centralized, per design spec (Home/Typing/Result/Settings/History each have distinct binds)
 - **Resize handling:** Graceful degradation notice if <60 cols or <20 rows; auto-resume when resized
 - **Paste support:** Ctrl+V pastes entire clipboard into typing; each char logged
@@ -108,5 +135,6 @@ and a scriptable v2 CLI.
 
 ## Development Status
 
-**v2.0 CLI implementation complete in working tree.** CI gates must pass before
-release.
+`v2.4.1` is the publicly released stable version. The consolidated `v2.5.0`
+release remains upcoming/unreleased; its integration work must pass CI and
+release gates before publication.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -180,7 +180,7 @@
 | Constraint | Rationale | Impact |
 |------------|-----------|--------|
 | ASCII wordlist only | CJK width handling deferred; simple word length ~5 chars | No CJK quotes in v1 |
-| 4 settings only | Minimize surface area; avoid scope creep | No sound, smooth scroll, etc. |
+| 4 settings only (v1 scope; superseded — 7 settings as of v2.6.0) | Minimize surface area; avoid scope creep | No sound, smooth scroll, etc. |
 | Per-mode best only | Simpler history; full leaderboard deferred | ★ badge scoped to mode+length |
 | 200-record history cap | Storage simplicity; no pagination | Oldest tests auto-rotated |
 | No backend | Local-only; no sync | Multiplayer/leaderboard future |
@@ -248,6 +248,7 @@
 - ✅ **v2.4.0 (Update UX):** In-app hint directs to self-updater; download progress reporting. Ship date: 2026-05-30.
 - ✅ **v2.4.1 (UI Animations):** stdlib-only terminal motion layer (blink/fade caret, stats reveal count-up, sparkle personal best celebration, Typing→Result transition) with NO_COLOR adaptation and hot-path token cache. Ship date: 2026-06-20.
 - ✅ **v2.5.0 (Strict Mode):** Letter-strict typing mode blocking wrong keypresses at cursor, logging error keystrokes for keystroke-level accuracy, and settings TUI toggle + CLI config, with runs excluded from personal bests. Ship date: 2026-06-26.
+- ✅ **v2.6.0 (Punctuation & Numbers):** Monkeytype-parity Settings toggles mixing commas/periods/capitalization and random numeric tokens into Words/Time mode word generation, settings-only control surface (no new CLI run flags), preserved across ctrl+r restart. Quote/Code modes and typing/metrics engine untouched. Ship date: 2026-07-02.
 
 
 ### Next (Optional)
@@ -283,6 +284,6 @@
 
 ## Conclusion
 
-**Typeburn v2.5.0 is the current stable release.** The codebase is clean, tested, and well-documented. Post-1.0 work has been additive or corrective: v2.0.0 added a professional scriptable CLI, v2.1.x added opt-in update checks plus audited defect cleanup, v2.2.0 added per-key error heatmaps, v2.3.0 added the self-update command, v2.4.0/v2.4.1 added animations and update UX, and v2.5.0 added strict stop-on-error typing mode.
+**Typeburn v2.6.0 is the current stable release.** The codebase is clean, tested, and well-documented. Post-1.0 work has been additive or corrective: v2.0.0 added a professional scriptable CLI, v2.1.x added opt-in update checks plus audited defect cleanup, v2.2.0 added per-key error heatmaps, v2.3.0 added the self-update command, v2.4.0/v2.4.1 added animations and update UX, v2.5.0 added strict stop-on-error typing mode, and v2.6.0 added punctuation/numbers toggles for Words/Time mode.
 
 M1 (timer re-arm) and M2 (new-best precision) — the identified correctness bugs — were fixed in v1.0 (d6369de) and v1.0.1 respectively. v1.4.0 fixed a Settings live-apply bug (changes were persisted but not applied in-session) and improved the wide-terminal typing layout. Remaining backlog is additive or cosmetic.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -2,6 +2,15 @@
 
 ---
 
+## Current Release State
+
+**Public stable:** `v2.4.1` (2026-06-20). **Upcoming:** one consolidated
+`v2.5.0`, currently unreleased. Strict typing and punctuation/numbers are
+integration work for that release, not separate shipped `v2.5.0` or `v2.6.0`
+releases.
+
+---
+
 ## v1.0 — Complete (2026-05-18)
 
 **Status:** SHIPPED. All 10 phases implemented, tested, shipped.
@@ -180,8 +189,8 @@
 | Constraint | Rationale | Impact |
 |------------|-----------|--------|
 | ASCII wordlist only | CJK width handling deferred; simple word length ~5 chars | No CJK quotes in v1 |
-| 4 settings only (v1 scope; superseded — 7 settings as of v2.6.0) | Minimize surface area; avoid scope creep | No sound, smooth scroll, etc. |
-| Per-mode best only | Simpler history; full leaderboard deferred | ★ badge scoped to mode+length |
+| 4 settings only (historical v1 scope; current product has 7 TUI rows and 8 persisted keys) | Minimize surface area; avoid scope creep | No sound, smooth scroll, etc. |
+| Scoped best buckets | Simpler history; full leaderboard deferred | ★ badge uses mode+length for Time/Words and one bucket for Quote |
 | 200-record history cap | Storage simplicity; no pagination | Oldest tests auto-rotated |
 | No backend | Local-only; no sync | Multiplayer/leaderboard future |
 
@@ -208,7 +217,7 @@
 - ✅ README + design-guidelines + system-architecture docs complete
 - ✅ Code review SHIP verdict; M1 fixed in v1.0 (d6369de), M2 accepted as documented v1 decision
 
-### Shipped Post-1.0
+### Post-1.0 Release History and Upcoming Work
 - ✅ **v1.0.1:** M2 new-best sub-WPM precision fixed; always-zero `missed` stat removed.
 - ✅ **v1.1.0:** Six theme packs (Solarized D/L, Dracula, Nord, Gruvbox D/L);
   non-blocking persistence-failure notice; post-1.0 doc corrections.
@@ -231,7 +240,7 @@
 - ✅ **v2.0.0 (Pro CLI):** cobra/fang subcommands (`run`, `history`,
   `version`, `config`, `replay`), JSON outputs, schema-versioned replay logs,
   and raw `run --no-tui`; v1 root aliases remain compatible. Ship date:
-  2026-05-20.
+  2026-05-21.
 - ✅ **v2.1.0 (Update Check):** opt-in `update_check` config key, opportunistic
   TUI launch check (800 ms timeout, 24 h cache), Result-screen footer hint, and
   `typeburn version --check-update` explicit flag with `--json` support. Ship date: 2026-05-21.
@@ -247,8 +256,12 @@
 - ✅ **v2.3.0 (Self-Update):** stdlib-only atomic self-updater via `typeburn update`, preflight managed-install check, redirect allowlist, O_EXCL locks, archive path-traversal safety, Windows move-aside rollback. Ship date: 2026-05-30.
 - ✅ **v2.4.0 (Update UX):** In-app hint directs to self-updater; download progress reporting. Ship date: 2026-05-30.
 - ✅ **v2.4.1 (UI Animations):** stdlib-only terminal motion layer (blink/fade caret, stats reveal count-up, sparkle personal best celebration, Typing→Result transition) with NO_COLOR adaptation and hot-path token cache. Ship date: 2026-06-20.
-- ✅ **v2.5.0 (Strict Mode):** Letter-strict typing mode blocking wrong keypresses at cursor, logging error keystrokes for keystroke-level accuracy, and settings TUI toggle + CLI config, with runs excluded from personal bests. Ship date: 2026-06-26.
-- ✅ **v2.6.0 (Punctuation & Numbers):** Monkeytype-parity Settings toggles mixing commas/periods/capitalization and random numeric tokens into Words/Time mode word generation, settings-only control surface (no new CLI run flags), preserved across ctrl+r restart. Quote/Code modes and typing/metrics engine untouched. Ship date: 2026-07-02.
+- ⏳ **v2.5.0 (Upcoming consolidated release):** Letter-strict typing blocks
+  wrong forward keypresses and records them for keystroke-level accuracy;
+  Strict runs are excluded from personal bests. Punctuation and Numbers
+  Settings toggles add punctuation/capitalization and numeric tokens to
+  Words/Time generation while leaving Quote and Code unchanged. This release
+  has not shipped.
 
 
 ### Next (Optional)
@@ -256,10 +269,11 @@
 2. **Shell completions + man pages in archives** (cobra/fang can generate them;
    packaging is deferred).
 
-### v2.0 Planning (Future)
+### v2.0 Planning (Historical)
+This pre-v2.0 backlog is retained for context. Code mode was delivered later;
+the remaining entries are historical planning ideas, not the current roadmap.
 - M4: Add target delivery mechanism; remove MissedChars 0-stub or make it meaningful
 - m5: CJK width support (if quotes added)
-- Code mode (custom text input)
 - Backend sync / multiplayer (major feature)
 - Plugin system (if ecosystem demand exists)
 
@@ -284,6 +298,11 @@
 
 ## Conclusion
 
-**Typeburn v2.6.0 is the current stable release.** The codebase is clean, tested, and well-documented. Post-1.0 work has been additive or corrective: v2.0.0 added a professional scriptable CLI, v2.1.x added opt-in update checks plus audited defect cleanup, v2.2.0 added per-key error heatmaps, v2.3.0 added the self-update command, v2.4.0/v2.4.1 added animations and update UX, v2.5.0 added strict stop-on-error typing mode, and v2.6.0 added punctuation/numbers toggles for Words/Time mode.
+**Typeburn v2.4.1 is the current public stable release.** Post-1.0 work has
+been additive or corrective: v2.0.0 added a professional scriptable CLI,
+v2.1.x added opt-in update checks plus audited defect cleanup, v2.2.0 added
+per-key error heatmaps, v2.3.0 added the self-update command, and v2.4.0/v2.4.1
+added update UX and animations. The consolidated v2.5.0 work—Strict typing and
+punctuation/numbers—is upcoming and unreleased.
 
 M1 (timer re-arm) and M2 (new-best precision) — the identified correctness bugs — were fixed in v1.0 (d6369de) and v1.0.1 respectively. v1.4.0 fixed a Settings live-apply bug (changes were persisted but not applied in-session) and improved the wide-terminal typing layout. Remaining backlog is additive or cosmetic.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -216,8 +216,9 @@ The eight persisted and CLI-configurable keys are `theme`, `default_mode`,
 and `numbers`. The seven TUI Settings rows are Theme, Default mode, Default
 length, Blink cursor, Strict mode, Punctuation, and Numbers; `update_check` is
 persisted/CLI-only. The TUI Default mode row cycles Time/Words/Quote, while
-persisted and CLI values also accept Code. Quote and Code have no numeric
-length selector; punctuation and numbers affect only Words/Time targets.
+persisted and CLI values also accept Code; it displays a persisted Code value
+until the user changes the mode. Quote and Code have no numeric length selector;
+punctuation and numbers affect only Words/Time targets.
 
 Loaded from XDG_CONFIG_HOME at startup; auto-persisted on settings change.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -73,21 +73,28 @@ Each sub-model has `SetSize(w, h)` to handle WindowSizeMsg; root calls it on res
 
 ## Full Test Flow (Home → Typing → Result → History)
 
-1. **Home screen:** User selects mode (Time/Words/Quote) + length; presses Enter
-   - Emits `StartTestMsg{Mode, Length, QuoteLen}`
+1. **Home screen:** User selects mode (Time/Words/Quote/Code) + its available
+   option; presses Enter. Code starts from supplied text or opens CodePaste when
+   no text is present.
+   - Emits `StartTestMsg{Mode, Length, QuoteLen}` for generated targets, or
+     `StartTestMsg{Mode: Code, CodeText}` for a supplied Code snippet
 2. **Root receives StartTestMsg:**
-   - Creates new `TypingModel` with mode/length/generated target words
+   - Creates a new `TypingModel` with the generated target or supplied Code
+     snippet
    - Switches `screen = ScreenTyping`
    - Returns `TypingModel.InitCmd()` to arm the 100ms timer tick so the caret blinks before the first keystroke
 3. **Typing screen:**
    - User types; each keystroke → `tea.KeyPressMsg`
    - TypingModel.Update() → `typing.Engine.Apply(rune)` logs keystroke
    - Every ~100ms, tickMsg → recalculate live WPM/accuracy/consistency from keystroke log
-   - Test completes on: (Time mode: timer expires) OR (Words mode: word count reached) OR (Quote mode: all runes typed)
+   - Test completes on: Time timer expiry, Words word-count target, or an exact
+     full-target match for Quote and Code
    - Emits `ResultMsg` with final `metrics.Result`
 4. **Root receives ResultMsg:**
    - Calls `storage.AppendHistory()` to persist record (atomic write, cap 200)
-   - Calls `storage.IsNewBest()` to detect if this is a new personal best for that mode+length
+   - Calls `storage.IsNewBest()` for eligible records: Time/Words use
+     mode+length buckets, Quote uses one mode bucket, and Code/Strict never
+     qualify
    - Creates ResultModel with record + new-best flag
    - Switches `screen = ScreenResult`
 5. **Result screen:**
@@ -95,7 +102,8 @@ Each sub-model has `SetSize(w, h)` to handle WindowSizeMsg; root calls it on res
    - User can: Tab/Enter to restart same test, Ctrl+R for new test, 3 to view History, Esc to home
 6. **History screen:**
    - Scrollable table of all records; reverse-sorted (newest first)
-   - ★ badge on per-mode best; grey out records from other modes/lengths
+   - ★ badge on eligible bucket leaders: Time/Words use mode+length, Quote
+     uses one mode bucket, and Code/Strict records never qualify
 
 ---
 
@@ -107,6 +115,9 @@ Each sub-model has `SetSize(w, h)` to handle WindowSizeMsg; root calls it on res
 - **`internal/typing`:** Engine state machine + keystroke logging. No UI/Bubble Tea.
 - **`internal/metrics`:** WPM/accuracy/consistency computation. No UI/Bubble Tea.
 - **`internal/words`:** Word generator + quote pack. No UI/Bubble Tea.
+- **`internal/runner`:** Shared session factory. `NewSession(mode, length,
+  quoteLen, seed, strict, punctuation, numbers)` builds non-Code sessions;
+  `NewCodeSession(snippet, strict)` builds supplied-snippet sessions.
 - **`internal/anim`:** Easing, color/value interpolation, tween, clock. Pure functions of time; no UI/Bubble Tea.
 - **`internal/storage`:** JSON persistence (atomic write, XDG paths). No UI/Bubble Tea.
 - **`internal/theme`:** Role-based color mapping. No UI/Bubble Tea.
@@ -122,7 +133,8 @@ Each sub-model has `SetSize(w, h)` to handle WindowSizeMsg; root calls it on res
 
 ### UI Package
 
-- **`internal/ui`:** Screen models (Home/Typing/Result/Settings/History) + components (word-stream, stat-card, table, timer).
+- **`internal/ui`:** Screen models (Home/Typing/Result/Settings/History/CodePaste)
+  + components (word-stream, stat-card, table, timer).
 - **`internal/app`:** Root Elm model + routing logic.
 
 This separation allows metrics to be tested without running the terminal, and reused in future CLI/server projects.
@@ -170,14 +182,14 @@ Computed from keystroke log post-hoc (no live state). Passed to ResultMsg.
 ```go
 type Record struct {
   WPM         int           // rounded for display
-  NetWPM      float64       // v2: add this for precise new-best comparison
+  NetWPM      float64       // unrounded value for precise new-best comparison
   RawWPM      float64
   Accuracy    float64
   Consistency float64
-  Mode        mode.Mode
+  Mode        string        // "time" | "words" | "quote" | "code"
   Length      int
   Time        time.Time
-  Strict      bool          // v2.5: strict typing run
+  Strict      bool          // strict typing run
   // ... other fields
 }
 ```
@@ -188,13 +200,24 @@ Persisted to history.json; compared via storage's exported best-bucket helpers.
 
 ```go
 type Settings struct {
-  Theme         string        // "default" | "mono"
-  DefaultMode   config.Mode   // "time" | "words" | "quote"
-  DefaultLength int           // 15, 30, 60, 120 (time) or 10, 25, 50, 100 (words)
+  Theme         string        // one of the eight selectable theme names
+  DefaultMode   config.Mode   // "time" | "words" | "quote" | "code"
+  DefaultLength int           // non-negative; constrained for Time/Words
   BlinkCursor   bool
+  UpdateCheck   bool
   StrictMode    bool
+  Punctuation   bool
+  Numbers       bool
 }
 ```
+
+The eight persisted and CLI-configurable keys are `theme`, `default_mode`,
+`default_length`, `blink_cursor`, `update_check`, `strict_mode`, `punctuation`,
+and `numbers`. The seven TUI Settings rows are Theme, Default mode, Default
+length, Blink cursor, Strict mode, Punctuation, and Numbers; `update_check` is
+persisted/CLI-only. The TUI Default mode row cycles Time/Words/Quote, while
+persisted and CLI values also accept Code. Quote and Code have no numeric
+length selector; punctuation and numbers affect only Words/Time targets.
 
 Loaded from XDG_CONFIG_HOME at startup; auto-persisted on settings change.
 
@@ -245,24 +268,25 @@ Two independent tick loops run by design — the existing timer is never coupled
 **Never hardcode color.** Screen code references semantic roles:
 
 ```go
-type Role string
+type Role int
 const (
   RoleTextPrimary
   RoleTextMuted
   RoleAccent
   RoleError
-  RoleCursor
-  // ... 12 roles total
+  RoleCursorBg
+  RoleCursorFg
+  // ... 16 roles total
 )
 ```
 
-Theme maps each role to a color (or attribute-only under NO_COLOR):
+Theme maps each role to a color (or attributes only under `NO_COLOR`):
 
 ```go
 type Theme struct {
   name    string
   colors  map[Role]color.Color
-  noColor bool // true if NO_COLOR env set or mono theme chosen
+  noColor bool // true when a non-empty NO_COLOR env value is set
 }
 
 func (t Theme) Style(r Role) lipgloss.Style {
@@ -270,9 +294,15 @@ func (t Theme) Style(r Role) lipgloss.Style {
 }
 ```
 
-### NO_COLOR Behavior
+### Theme Selection and `NO_COLOR`
 
-If `NO_COLOR=1` set or theme="mono", the theme switches to attribute-only:
+The selectable themes, in display order, are `default`, `mono`,
+`solarized-dark`, `solarized-light`, `dracula`, `nord`, `gruvbox-dark`,
+`gruvbox-light`. `mono` is a grayscale color palette; it does not select the
+attribute-only path.
+
+Any non-empty `NO_COLOR` value switches rendering to attribute-only regardless
+of the selected theme:
 - Accent → bold
 - Error → underline
 - Muted → normal + slightly dimmer attribute

--- a/internal/app/anim_driver_test.go
+++ b/internal/app/anim_driver_test.go
@@ -57,7 +57,7 @@ func TestMaybeFrameCmd_NilWhenIdle(t *testing.T) {
 func TestFrameTick_DoesNotStartTest(t *testing.T) {
 	m := newTestModel()
 	m.screen = ScreenTyping
-	m.typing = ui.NewTyping(config.ModeTime, 30, 0, m.theme, m.keys, false, false).SetSize(80, 24)
+	m.typing = ui.NewTyping(config.ModeTime, 30, 0, m.theme, m.keys, false, false, false, false).SetSize(80, 24)
 
 	model, _ := m.handleFrameTick(ui.FrameTickMsg{T: time.UnixMilli(1234)})
 	got := model.(Model)

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -86,7 +86,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			t = ui.NewTypingCode(sm.CodeText, m.theme, m.keys, m.settings.BlinkCursor, m.settings.StrictMode)
 		} else {
 			t = ui.NewTyping(sm.Mode, sm.Length, sm.QuoteLen,
-				m.theme, m.keys, m.settings.BlinkCursor, m.settings.StrictMode)
+				m.theme, m.keys, m.settings.BlinkCursor, m.settings.StrictMode,
+				m.settings.Punctuation, m.settings.Numbers)
 		}
 		m.typing = t.SetSize(m.w, m.h)
 		m.screen = ScreenTyping

--- a/internal/cli/cmd_config.go
+++ b/internal/cli/cmd_config.go
@@ -91,6 +91,8 @@ func configRows(s config.Settings) [][]string {
 		{"blink_cursor", strconv.FormatBool(s.BlinkCursor)},
 		{"update_check", strconv.FormatBool(s.UpdateCheck)},
 		{"strict_mode", strconv.FormatBool(s.StrictMode)},
+		{"punctuation", strconv.FormatBool(s.Punctuation)},
+		{"numbers", strconv.FormatBool(s.Numbers)},
 	}
 }
 
@@ -143,6 +145,18 @@ func configSet(s *config.Settings, key, value string) error {
 			return usageError("strict_mode must be true, false, 1, 0, on, off, yes, or no")
 		}
 		s.StrictMode = v
+	case "punctuation":
+		v, ok := parseBool(value)
+		if !ok {
+			return usageError("punctuation must be true, false, 1, 0, on, off, yes, or no")
+		}
+		s.Punctuation = v
+	case "numbers":
+		v, ok := parseBool(value)
+		if !ok {
+			return usageError("numbers must be true, false, 1, 0, on, off, yes, or no")
+		}
+		s.Numbers = v
 	default:
 		return usageError("unknown config key %q", key)
 	}

--- a/internal/cli/cmd_run_notui.go
+++ b/internal/cli/cmd_run_notui.go
@@ -51,5 +51,5 @@ func runSession(e env, req runRequest) (runner.Session, error) {
 		}
 		return runner.NewCodeSession(text, settings.StrictMode), nil
 	}
-	return runner.NewSession(req.mode, req.length, req.quoteLen, 0, settings.StrictMode), nil
+	return runner.NewSession(req.mode, req.length, req.quoteLen, 0, settings.StrictMode, settings.Punctuation, settings.Numbers), nil
 }

--- a/internal/cli/punctuation_numbers_config_test.go
+++ b/internal/cli/punctuation_numbers_config_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+)
+
+func TestPunctuationNumbersSetGet(t *testing.T) {
+	settings := config.Defaults()
+	var out bytes.Buffer
+
+	execRoot := func(args ...string) error {
+		out.Reset()
+		root := NewRoot(
+			WithWriters(&out, &bytes.Buffer{}),
+			WithHomeRunner(func(context.Context, string, string) error { return nil }),
+			WithSettingsStore(
+				func() config.Settings { return settings },
+				func(s config.Settings) error { settings = s; return nil },
+			),
+		)
+		root.SetArgs(args)
+		return root.Execute()
+	}
+
+	for _, key := range []string{"punctuation", "numbers"} {
+		// Default is false.
+		if err := execRoot("config", "get", key); err != nil {
+			t.Fatalf("get %s: %v", key, err)
+		}
+		if strings.TrimSpace(out.String()) != "false" {
+			t.Fatalf("default %s: want false, got %q", key, out.String())
+		}
+
+		// Set to true and read back.
+		if err := execRoot("config", "set", key, "true"); err != nil {
+			t.Fatalf("set %s true: %v", key, err)
+		}
+		if err := execRoot("config", "get", key); err != nil {
+			t.Fatalf("get %s after set: %v", key, err)
+		}
+		if strings.TrimSpace(out.String()) != "true" {
+			t.Fatalf("after set: want true, got %q", out.String())
+		}
+
+		// Reject invalid values.
+		if err := execRoot("config", "set", key, "bogus"); err == nil {
+			t.Fatalf("expected error setting invalid %s", key)
+		}
+	}
+}
+
+func TestConfigListIncludesPunctuationAndNumbers(t *testing.T) {
+	var out bytes.Buffer
+	root := NewRoot(
+		WithWriters(&out, &bytes.Buffer{}),
+		WithHomeRunner(func(context.Context, string, string) error { return nil }),
+		WithSettingsStore(func() config.Settings { return config.Defaults() }, nil),
+	)
+	root.SetArgs([]string{"config", "list"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("config list: %v", err)
+	}
+	if !strings.Contains(out.String(), "punctuation") {
+		t.Errorf("config list output missing punctuation:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "numbers") {
+		t.Errorf("config list output missing numbers:\n%s", out.String())
+	}
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -31,6 +31,8 @@ type Settings struct {
 	// Default is false to preserve offline-first posture.
 	UpdateCheck bool `json:"update_check"`
 	StrictMode  bool `json:"strict_mode"`
+	Punctuation bool `json:"punctuation"`
+	Numbers     bool `json:"numbers"`
 }
 
 // Defaults returns the baseline configuration used on first run or whenever
@@ -43,6 +45,8 @@ func Defaults() Settings {
 		BlinkCursor:   false,
 		UpdateCheck:   false,
 		StrictMode:    false,
+		Punctuation:   false,
+		Numbers:       false,
 	}
 }
 

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -20,9 +20,9 @@ type Session struct {
 
 // NewSession builds a fresh non-code typing session.
 // seed==0 uses the words package's time-based random seed.
-func NewSession(m mode.Mode, length int, ql words.QuoteLen, seed int64, strict bool) Session {
+func NewSession(m mode.Mode, length int, ql words.QuoteLen, seed int64, strict, punctuation, numbers bool) Session {
 	g := words.NewGenerator(seed)
-	target := words.ForMode(g, m, length, ql)
+	target := words.ForMode(g, m, length, ql, punctuation, numbers)
 	return Session{
 		Engine:   RebuildEngine(target, m, length, strict),
 		Target:   target,

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -22,27 +22,27 @@ func TestNewSession_DeterministicTargets(t *testing.T) {
 			mode:   config.ModeWords,
 			length: 5,
 			seed:   42,
-			want:   words.ForMode(words.NewGenerator(42), config.ModeWords, 5, words.QuoteMedium),
+			want:   words.ForMode(words.NewGenerator(42), config.ModeWords, 5, words.QuoteMedium, false, false),
 		},
 		{
 			name: "quote",
 			mode: config.ModeQuote,
 			ql:   words.QuoteShort,
 			seed: 7,
-			want: words.ForMode(words.NewGenerator(7), config.ModeQuote, 0, words.QuoteShort),
+			want: words.ForMode(words.NewGenerator(7), config.ModeQuote, 0, words.QuoteShort, false, false),
 		},
 		{
 			name:   "time",
 			mode:   config.ModeTime,
 			length: 15,
 			seed:   99,
-			want:   words.ForMode(words.NewGenerator(99), config.ModeTime, 15, words.QuoteMedium),
+			want:   words.ForMode(words.NewGenerator(99), config.ModeTime, 15, words.QuoteMedium, false, false),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewSession(tt.mode, tt.length, tt.ql, tt.seed, false)
+			got := NewSession(tt.mode, tt.length, tt.ql, tt.seed, false, false, false)
 			if got.Target != tt.want {
 				t.Fatalf("target drift:\nwant %q\ngot  %q", tt.want, got.Target)
 			}
@@ -50,6 +50,14 @@ func TestNewSession_DeterministicTargets(t *testing.T) {
 				t.Fatalf("metadata drift: %#v", got)
 			}
 		})
+	}
+}
+
+func TestNewSession_PunctuationAndNumbersThreaded(t *testing.T) {
+	plain := NewSession(config.ModeWords, 60, words.QuoteShort, 33, false, false, false)
+	got := NewSession(config.ModeWords, 60, words.QuoteShort, 33, false, true, true)
+	if got.Target == plain.Target {
+		t.Error("NewSession(punctuation=true, numbers=true): target unchanged, flags not threaded to words.ForMode")
 	}
 }
 
@@ -90,7 +98,7 @@ func TestRebuildEngine_WordsUsesWordCount(t *testing.T) {
 }
 
 func TestNewSession_StrictBlocksWrongKeys(t *testing.T) {
-	s := NewSession(config.ModeWords, 5, words.QuoteShort, 42, true)
+	s := NewSession(config.ModeWords, 5, words.QuoteShort, 42, true, false, false)
 	if s.Engine == nil {
 		t.Fatal("expected non-nil engine")
 	}

--- a/internal/storage/best_eligibility_test.go
+++ b/internal/storage/best_eligibility_test.go
@@ -1,0 +1,50 @@
+package storage
+
+import "testing"
+
+func TestEligibleForBest(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  Record
+		want bool
+	}{
+		{name: "normal time", rec: Record{Mode: "time"}, want: true},
+		{name: "strict time", rec: Record{Mode: "time", Strict: true}, want: false},
+		{name: "code", rec: Record{Mode: "code"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EligibleForBest(tt.rec); got != tt.want {
+				t.Fatalf("EligibleForBest(%+v) = %t, want %t", tt.rec, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBestWPMPerBucket_IgnoresIneligibleRuns(t *testing.T) {
+	rows := []Record{
+		{Mode: "time", Length: 30, WPM: 80, NetWPM: 80},
+		{Mode: "time", Length: 30, WPM: 120, NetWPM: 120, Strict: true},
+		{Mode: "code", Length: 142, WPM: 140, NetWPM: 140},
+	}
+
+	bests := BestWPMPerBucket(rows)
+	if got := bests["time/30"]; got != 80 {
+		t.Fatalf("time best = %v, want eligible run 80", got)
+	}
+	if _, ok := bests["code"]; ok {
+		t.Fatalf("code must not have a best bucket: %#v", bests)
+	}
+}
+
+func TestIsNewBest_IgnoresIneligibleHistory(t *testing.T) {
+	hist := []Record{
+		{Mode: "time", Length: 30, WPM: 120, NetWPM: 120, Strict: true},
+		{Mode: "code", Length: 142, WPM: 140, NetWPM: 140},
+	}
+	candidate := Record{Mode: "time", Length: 30, WPM: 80, NetWPM: 80}
+	if !IsNewBest(hist, candidate) {
+		t.Fatal("eligible candidate must ignore strict and code history")
+	}
+}

--- a/internal/storage/new_best.go
+++ b/internal/storage/new_best.go
@@ -2,6 +2,11 @@ package storage
 
 import "strconv"
 
+// EligibleForBest reports whether a record may participate in personal bests.
+func EligibleForBest(r Record) bool {
+	return r.Mode != "code" && !r.Strict
+}
+
 // BestBucketKey returns the comparison key for new-best scoping.
 // For time and words modes the key includes the length parameter so that, e.g.,
 // a 60s best does not suppress a 30s best. Quote mode has no numeric length
@@ -35,6 +40,9 @@ func EffectiveWPM(r Record) float64 {
 func BestWPMPerBucket(records []Record) map[string]float64 {
 	bests := make(map[string]float64)
 	for _, r := range records {
+		if !EligibleForBest(r) {
+			continue
+		}
 		key := BestBucketKey(r.Mode, r.Length)
 		eff := EffectiveWPM(r)
 		if prev, ok := bests[key]; !ok || eff > prev {
@@ -59,13 +67,15 @@ func BestWPMPerBucket(records []Record) map[string]float64 {
 // hist must NOT already contain r; call IsNewBest before AppendHistory.
 // This function is pure and does not mutate hist.
 func IsNewBest(hist []Record, r Record) bool {
-	// Code-mode runs and strict runs are never personal bests (display-only, no leaderboard).
-	if r.Mode == "code" || r.Strict {
+	if !EligibleForBest(r) {
 		return false
 	}
 	key := BestBucketKey(r.Mode, r.Length)
 	best := -1.0
 	for _, h := range hist {
+		if !EligibleForBest(h) {
+			continue
+		}
 		if BestBucketKey(h.Mode, h.Length) == key {
 			if eff := EffectiveWPM(h); eff > best {
 				best = eff

--- a/internal/ui/history_table.go
+++ b/internal/ui/history_table.go
@@ -41,7 +41,7 @@ func renderHistoryHeader(th theme.Theme) string {
 func renderHistoryRow(r storage.Record, selected bool, isBestRow bool, th theme.Theme) string {
 	// Format each column value.
 	date := r.Time.Format("2006-01-02 15:04")
-	modeLabel := modeLabel(r.Mode, r.Length)
+	label := displayModeLabel(r.Mode, r.Length)
 	wpm := fmt.Sprintf("%d", r.WPM)
 	acc := fmt.Sprintf("%.0f%%", r.Accuracy)
 	cons := fmt.Sprintf("%.0f%%", r.Consistency)
@@ -64,7 +64,7 @@ func renderHistoryRow(r storage.Record, selected bool, isBestRow bool, th theme.
 		accStyled := bgStyle.Render(th.Style(accRole).Render(fmt.Sprintf("%-*s", colAccW, acc)))
 		consStyled := bgStyle.Render(th.Style(theme.RoleTextPrimary).Render(fmt.Sprintf("%-*s", colConsW, cons)))
 		dateStyled := bgStyle.Render(th.Style(theme.RoleTextPrimary).Render(fmt.Sprintf("%-*s", colDateW, date)))
-		modeStyled := bgStyle.Render(th.Style(theme.RoleTextPrimary).Render(fmt.Sprintf("%-*s", colModeW, modeLabel)))
+		modeStyled := bgStyle.Render(th.Style(theme.RoleTextPrimary).Render(fmt.Sprintf("%-*s", colModeW, label)))
 		return bar + " " + dateStyled + " " + modeStyled + " " + wpmStyled + " " + accStyled + " " + consStyled + star
 	}
 
@@ -73,20 +73,8 @@ func renderHistoryRow(r storage.Record, selected bool, isBestRow bool, th theme.
 	accStyled := th.Style(accRole).Render(fmt.Sprintf("%-*s", colAccW, acc))
 	consStyled := th.Style(theme.RoleTextPrimary).Render(fmt.Sprintf("%-*s", colConsW, cons))
 	dateStyled := th.Style(theme.RoleTextMuted).Render(fmt.Sprintf("%-*s", colDateW, date))
-	modeStyled := th.Style(theme.RoleTextMuted).Render(fmt.Sprintf("%-*s", colModeW, modeLabel))
+	modeStyled := th.Style(theme.RoleTextMuted).Render(fmt.Sprintf("%-*s", colModeW, label))
 	return "   " + dateStyled + " " + modeStyled + " " + wpmStyled + " " + accStyled + " " + consStyled + star
-}
-
-// modeLabel formats a mode+length label for display (e.g. "time 30", "words 50", "quote").
-func modeLabel(mode string, length int) string {
-	switch mode {
-	case "time":
-		return fmt.Sprintf("time %d", length)
-	case "words":
-		return fmt.Sprintf("words %d", length)
-	default:
-		return "quote"
-	}
 }
 
 // renderHistoryMeta renders the "showing X–Y of N" meta line in RoleTextFaint.

--- a/internal/ui/mode_label.go
+++ b/internal/ui/mode_label.go
@@ -1,0 +1,17 @@
+package ui
+
+import "fmt"
+
+// displayModeLabel formats a persisted mode identifier for History and Result.
+func displayModeLabel(mode string, length int) string {
+	switch mode {
+	case "time", "words":
+		return fmt.Sprintf("%s %d", mode, length)
+	case "quote", "code":
+		return mode
+	case "":
+		return "unknown"
+	default:
+		return mode
+	}
+}

--- a/internal/ui/mode_label_test.go
+++ b/internal/ui/mode_label_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/internal/storage"
+	"github.com/bavanchun/Typeburn/internal/theme"
+)
+
+func TestDisplayModeLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		mode   string
+		length int
+		want   string
+	}{
+		{name: "time", mode: "time", length: 30, want: "time 30"},
+		{name: "words", mode: "words", length: 50, want: "words 50"},
+		{name: "quote ignores length", mode: "quote", length: 42, want: "quote"},
+		{name: "code ignores length", mode: "code", length: 142, want: "code"},
+		{name: "unknown keeps identifier", mode: "custom", length: 10, want: "custom"},
+		{name: "empty is unknown", mode: "", length: 10, want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := displayModeLabel(tt.mode, tt.length); got != tt.want {
+				t.Fatalf("displayModeLabel(%q, %d) = %q, want %q", tt.mode, tt.length, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHistoryView_CodeAndStrictRunsDoNotShowBestMarker(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  storage.Record
+	}{
+		{name: "code", rec: storage.Record{Mode: "code", Length: 142, WPM: 120, NetWPM: 120}},
+		{name: "strict", rec: storage.Record{Mode: "time", Length: 30, WPM: 120, NetWPM: 120, Strict: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := NewHistory([]storage.Record{tt.rec}, theme.Default(), config.DefaultKeymap()).SetSize(80, 24).View()
+			if strings.Contains(view, "★") {
+				t.Fatalf("ineligible %s run rendered a best marker:\n%s", tt.name, view)
+			}
+		})
+	}
+}
+
+func TestHistoryView_CodeLabelIsNotQuote(t *testing.T) {
+	rec := storage.Record{Mode: "code", Length: 142, WPM: 94, NetWPM: 94}
+	view := NewHistory([]storage.Record{rec}, theme.Default(), config.DefaultKeymap()).SetSize(80, 24).View()
+	if !strings.Contains(view, "code") {
+		t.Fatalf("history did not render code label:\n%s", view)
+	}
+	if strings.Contains(view, "quote") {
+		t.Fatalf("history mislabeled code as quote:\n%s", view)
+	}
+}
+
+func TestHistoryView_EligibleTiesShowBestMarkers(t *testing.T) {
+	rows := []storage.Record{
+		{Mode: "time", Length: 30, WPM: 94, NetWPM: 94},
+		{Mode: "time", Length: 30, WPM: 94, NetWPM: 94},
+	}
+	view := NewHistory(rows, theme.Default(), config.DefaultKeymap()).SetSize(80, 24).View()
+	if got := strings.Count(view, "★"); got != 2 {
+		t.Fatalf("eligible tied runs rendered %d best markers, want 2:\n%s", got, view)
+	}
+}
+
+func TestResultView_CodeMetaIsNotQuote(t *testing.T) {
+	msg := ResultMsg{Result: makeTestMetricsResult(), Mode: config.ModeCode, CodeText: "func main() {}"}
+	view := NewResult(msg, theme.Default(), config.DefaultKeymap()).SetSize(80, 24).View()
+	if !strings.Contains(view, "· code · english") {
+		t.Fatalf("result did not render code metadata:\n%s", view)
+	}
+	if strings.Contains(view, "· quote · english") {
+		t.Fatalf("result mislabeled code as quote:\n%s", view)
+	}
+}

--- a/internal/ui/phase09_polish_test.go
+++ b/internal/ui/phase09_polish_test.go
@@ -336,7 +336,7 @@ func TestAFK_TimeMode_LongIdleTrimmedInTypingEngine(t *testing.T) {
 	// via the typing log, verifying the duration reflects AFK trim.
 	m := newTypingWithSeed(
 		config.ModeTime, 30, 0,
-		theme.Default(), config.DefaultKeymap(), false, false, 42,
+		theme.Default(), config.DefaultKeymap(), false, false, false, false, 42,
 	).SetSize(80, 24)
 
 	// Type a character at t=1000ms.
@@ -360,7 +360,7 @@ func TestAFK_WordsMode_NotTrimmed(t *testing.T) {
 	// side-effects that would accidentally trigger trimming.
 	m := newTypingWithSeed(
 		config.ModeWords, 5, 0,
-		theme.Default(), config.DefaultKeymap(), false, false, 42,
+		theme.Default(), config.DefaultKeymap(), false, false, false, false, 42,
 	).SetSize(80, 24)
 
 	m, _ = m.Update(pressText(string([]rune(m.target)[0])))

--- a/internal/ui/result_render_helpers.go
+++ b/internal/ui/result_render_helpers.go
@@ -6,7 +6,6 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
 	"github.com/bavanchun/Typeburn/internal/theme"
 )
 
@@ -72,19 +71,6 @@ func accColorRole(acc float64) theme.Role {
 		return theme.RoleWarning
 	default:
 		return theme.RoleTextPrimary
-	}
-}
-
-// modeMetaLabel formats the mode+length string for the result meta line.
-// Quote mode has no numeric length so it returns "quote".
-func modeMetaLabel(mode config.Mode, length int) string {
-	switch mode {
-	case config.ModeTime:
-		return fmt.Sprintf("time %d", length)
-	case config.ModeWords:
-		return fmt.Sprintf("words %d", length)
-	default:
-		return "quote"
 	}
 }
 

--- a/internal/ui/screen_history_view.go
+++ b/internal/ui/screen_history_view.go
@@ -60,7 +60,7 @@ func (m HistoryModel) View() string {
 			// Float equality is safe here: we compare the same stored value
 			// (EffectiveWPM(r)) against what BestWPMPerBucket already derived from
 			// the same records — no recomputation drift possible.
-			isBestRow := storage.EffectiveWPM(r) == bests[key]
+			isBestRow := storage.EligibleForBest(r) && storage.EffectiveWPM(r) == bests[key]
 			body.WriteString(renderHistoryRow(r, i == m.sel, isBestRow, m.th))
 			body.WriteString("\n")
 		}

--- a/internal/ui/screen_result_view.go
+++ b/internal/ui/screen_result_view.go
@@ -154,5 +154,5 @@ func (m ResultModel) renderCharStats() string {
 func (m ResultModel) renderMeta() string {
 	style := m.th.Style(theme.RoleTextFaint)
 	dur := fmt.Sprintf("%.0fs", float64(m.res.DurationMs)/1000.0)
-	return style.Render(dur + " · " + modeMetaLabel(m.mode, m.length) + " · english")
+	return style.Render(dur + " · " + displayModeLabel(string(m.mode), m.length) + " · english")
 }

--- a/internal/ui/screen_settings.go
+++ b/internal/ui/screen_settings.go
@@ -8,7 +8,8 @@ import (
 )
 
 // SettingsModel is the sub-model for the Settings screen. It owns exactly
-// 5 rows (Theme, Default mode, Default length, Blink cursor, Strict mode) and nothing else.
+// 7 rows (Theme, Default mode, Default length, Blink cursor, Strict mode,
+// Punctuation, Numbers) and nothing else.
 // It holds its settings BY VALUE; every value change emits a
 // SettingsChangedMsg so the root can persist and apply it to the live model.
 // (A callback/pointer bound in app.New() would target a copied-out struct the
@@ -131,5 +132,9 @@ func (m *SettingsModel) applyRow(rowIdx, valIdx int) {
 		m.s.BlinkCursor = (val == "on")
 	case rowStrictMode:
 		m.s.StrictMode = (val == "on")
+	case rowPunctuation:
+		m.s.Punctuation = (val == "on")
+	case rowNumbers:
+		m.s.Numbers = (val == "on")
 	}
 }

--- a/internal/ui/screen_settings.go
+++ b/internal/ui/screen_settings.go
@@ -92,8 +92,17 @@ func (m SettingsModel) changedCmd() tea.Cmd {
 // and writes it into the local settings value.
 func (m SettingsModel) cycleSelected(delta int) SettingsModel {
 	row := &m.rows[m.sel]
-	n := len(row.values)
-	row.idx = ((row.idx+delta)%n + n) % n
+	if m.sel == rowDefaultMode && m.s.DefaultMode == config.ModeCode {
+		row.values = append([]string(nil), selectableDefaultModes...)
+		if delta < 0 {
+			row.idx = len(row.values) - 1
+		} else {
+			row.idx = 0
+		}
+	} else {
+		n := len(row.values)
+		row.idx = ((row.idx+delta)%n + n) % n
+	}
 
 	m.applyRow(m.sel, row.idx)
 
@@ -122,6 +131,9 @@ func (m *SettingsModel) applyRow(rowIdx, valIdx int) {
 		if m.s.DefaultMode == config.ModeQuote {
 			// Quote uses bucket labels ("short"/"medium"/"long"); no int to store.
 			m.s.DefaultLength = 0
+		} else if m.s.DefaultMode == config.ModeCode {
+			// Code has no length setting.
+			return
 		} else {
 			lens := config.LengthsFor(m.s.DefaultMode)
 			if valIdx < len(lens) {

--- a/internal/ui/screen_settings.go
+++ b/internal/ui/screen_settings.go
@@ -16,7 +16,7 @@ import (
 // program never renders.) Row types/helpers live in settings_rows.go.
 type SettingsModel struct {
 	rows []settingRow
-	sel  int // currently-selected row index (0-4)
+	sel  int // currently-selected row index (0-6)
 	s    config.Settings
 	th   theme.Theme
 	km   config.Keymap

--- a/internal/ui/screen_settings_test.go
+++ b/internal/ui/screen_settings_test.go
@@ -45,6 +45,56 @@ func TestNewSettingsExactly7Rows(t *testing.T) {
 	}
 }
 
+func TestCodeDefaultRendersSettings(t *testing.T) {
+	s := config.Defaults()
+	s.DefaultMode = config.ModeCode
+	m := NewSettings(s, theme.Default(), config.DefaultKeymap()).SetSize(100, 40)
+
+	if got := m.rows[rowDefaultMode].values[m.rows[rowDefaultMode].idx]; got != "code" {
+		t.Fatalf("persisted Code default should render as code, got %q", got)
+	}
+	if got := m.View(); !strings.Contains(got, "n/a") {
+		t.Fatalf("Code default length row should render n/a, got %q", got)
+	}
+
+	for range rowDefaultLength {
+		m, _ = m.Update(pressSettKey(tea.KeyDown))
+	}
+	m, _ = m.Update(pressSettKey(tea.KeyRight))
+	if m.s.DefaultLength != s.DefaultLength {
+		t.Fatalf("Code default should leave length unchanged: want %d, got %d", s.DefaultLength, m.s.DefaultLength)
+	}
+}
+
+func TestCyclingPersistedCodeDefaultUsesTUIChoices(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  rune
+		want config.Mode
+	}{
+		{name: "right selects time", key: tea.KeyRight, want: config.ModeTime},
+		{name: "left selects quote", key: tea.KeyLeft, want: config.ModeQuote},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := config.Defaults()
+			s.DefaultMode = config.ModeCode
+			m := NewSettings(s, theme.Default(), config.DefaultKeymap())
+			m, _ = m.Update(pressSettKey(tea.KeyDown))
+			m, cmd := m.Update(pressSettKey(tc.key))
+
+			if m.s.DefaultMode != tc.want {
+				t.Fatalf("selected default mode = %q, want %q", m.s.DefaultMode, tc.want)
+			}
+			if got := m.rows[rowDefaultMode].values; strings.Join(got, ",") != "time,words,quote" {
+				t.Fatalf("TUI default-mode choices = %v, want time/words/quote", got)
+			}
+			if sc := settChangedFrom(t, cmd); sc.Settings.DefaultMode != tc.want {
+				t.Fatalf("emitted default mode = %q, want %q", sc.Settings.DefaultMode, tc.want)
+			}
+		})
+	}
+}
+
 // TestDownMovesSelection verifies ↓ increments selection.
 func TestDownMovesSelection(t *testing.T) {
 	m := newTestSettings()

--- a/internal/ui/screen_settings_test.go
+++ b/internal/ui/screen_settings_test.go
@@ -36,11 +36,12 @@ func settChangedFrom(t *testing.T, cmd tea.Cmd) SettingsChangedMsg {
 	return sc
 }
 
-// TestNewSettingsExactly5Rows verifies the constructor yields exactly 5 rows.
-func TestNewSettingsExactly5Rows(t *testing.T) {
+// TestNewSettingsExactly7Rows verifies the constructor yields exactly 7 rows
+// (5 original + Punctuation + Numbers).
+func TestNewSettingsExactly7Rows(t *testing.T) {
 	m := newTestSettings()
-	if len(m.rows) != 5 {
-		t.Fatalf("want 5 rows, got %d", len(m.rows))
+	if len(m.rows) != 7 {
+		t.Fatalf("want 7 rows, got %d", len(m.rows))
 	}
 }
 
@@ -68,8 +69,8 @@ func TestDownClampsAtLastRow(t *testing.T) {
 	for range 10 {
 		m, _ = m.Update(pressSettKey(tea.KeyDown))
 	}
-	if m.sel != 4 {
-		t.Fatalf("want sel=4 (clamped), got %d", m.sel)
+	if m.sel != rowNumbers {
+		t.Fatalf("want sel=%d (clamped), got %d", rowNumbers, m.sel)
 	}
 }
 
@@ -182,6 +183,47 @@ func TestTogglingStrictFlipsBool(t *testing.T) {
 	}
 }
 
+// TestTogglingPunctuationFlipsBool verifies cycling the Punctuation row
+// toggles Punctuation.
+func TestTogglingPunctuationFlipsBool(t *testing.T) {
+	m := newTestSettings()
+	for range rowPunctuation {
+		m, _ = m.Update(pressSettKey(tea.KeyDown))
+	}
+	if m.sel != rowPunctuation {
+		t.Fatalf("expected sel=%d (punctuation row), got %d", rowPunctuation, m.sel)
+	}
+
+	initial := m.s.Punctuation
+	m, cmd := m.Update(pressSettKey(tea.KeyRight))
+	if m.s.Punctuation == initial {
+		t.Fatalf("Punctuation should have toggled from %v", initial)
+	}
+	if sc := settChangedFrom(t, cmd); sc.Settings.Punctuation == initial {
+		t.Fatalf("emitted msg Punctuation should be toggled from %v", initial)
+	}
+}
+
+// TestTogglingNumbersFlipsBool verifies cycling the Numbers row toggles Numbers.
+func TestTogglingNumbersFlipsBool(t *testing.T) {
+	m := newTestSettings()
+	for range rowNumbers {
+		m, _ = m.Update(pressSettKey(tea.KeyDown))
+	}
+	if m.sel != rowNumbers {
+		t.Fatalf("expected sel=%d (numbers row), got %d", rowNumbers, m.sel)
+	}
+
+	initial := m.s.Numbers
+	m, cmd := m.Update(pressSettKey(tea.KeyRight))
+	if m.s.Numbers == initial {
+		t.Fatalf("Numbers should have toggled from %v", initial)
+	}
+	if sc := settChangedFrom(t, cmd); sc.Settings.Numbers == initial {
+		t.Fatalf("emitted msg Numbers should be toggled from %v", initial)
+	}
+}
+
 // TestValueChangeEmitsSettingsChangedMsg verifies a value change emits a
 // SettingsChangedMsg cmd while a pure selection move emits none.
 func TestValueChangeEmitsSettingsChangedMsg(t *testing.T) {
@@ -256,7 +298,7 @@ func TestViewContains5RowLabels(t *testing.T) {
 	m := newTestSettings()
 	view := m.View()
 
-	labels := []string{"Theme", "Default mode", "Default length", "Blink cursor", "Strict mode"}
+	labels := []string{"Theme", "Default mode", "Default length", "Blink cursor", "Strict mode", "Punctuation", "Numbers"}
 	for _, label := range labels {
 		if !strings.Contains(view, label) {
 			t.Errorf("view missing row label %q", label)

--- a/internal/ui/screen_settings_view.go
+++ b/internal/ui/screen_settings_view.go
@@ -52,7 +52,7 @@ func (m SettingsModel) View() string {
 	return full.String()
 }
 
-// renderRows renders all 4 settings rows joined by newlines.
+// renderRows renders all 7 settings rows joined by newlines.
 func (m SettingsModel) renderRows() string {
 	parts := make([]string, len(m.rows))
 	for i, row := range m.rows {

--- a/internal/ui/screen_settings_view.go
+++ b/internal/ui/screen_settings_view.go
@@ -9,7 +9,7 @@ import (
 )
 
 // View renders the Settings screen as a centered block string.
-// Layout per mockups §4: title, separator, 4 rows, separator, help line, footer.
+// Layout per mockups §4: title, separator, 7 rows, separator, help line, footer.
 // Degraded mode (w<60 or h<20) is handled by the root View; this is only called
 // when the terminal meets the safe minimum.
 func (m SettingsModel) View() string {

--- a/internal/ui/screen_typing.go
+++ b/internal/ui/screen_typing.go
@@ -26,8 +26,10 @@ type TypingModel struct {
 	headerWPM   float64 // last computed live WPM for header
 	lastPaintMs int64   // throttle: last time header WPM was recomputed
 
-	blink  bool // wired from settings; false = steady block, true = blinking
-	strict bool
+	blink       bool // wired from settings; false = steady block, true = blinking
+	strict      bool
+	punctuation bool
+	numbers     bool
 
 	th   theme.Theme
 	keys config.Keymap
@@ -61,8 +63,10 @@ func NewTyping(
 	km config.Keymap,
 	blink bool,
 	strict bool,
+	punctuation bool,
+	numbers bool,
 ) TypingModel {
-	return newTypingWithSeed(mode, length, ql, th, km, blink, strict, 0)
+	return newTypingWithSeed(mode, length, ql, th, km, blink, strict, punctuation, numbers, 0)
 }
 
 // newTypingWithSeed is the internal constructor used by NewTyping and ctrl+r.
@@ -76,12 +80,15 @@ func newTypingWithSeed(
 	km config.Keymap,
 	blink bool,
 	strict bool,
+	punctuation bool,
+	numbers bool,
 	seed int64,
 ) TypingModel {
-	s := runner.NewSession(mode, length, ql, seed, strict)
+	s := runner.NewSession(mode, length, ql, seed, strict, punctuation, numbers)
 	return TypingModel{
 		eng: s.Engine, mode: s.Mode, length: s.Length, ql: s.QuoteLen,
-		target: s.Target, th: th, keys: km, blink: blink, strict: strict, seed: seed,
+		target: s.Target, th: th, keys: km, blink: blink, strict: strict,
+		punctuation: punctuation, numbers: numbers, seed: seed,
 		nowFn: defaultNowFn, wordCache: &streamTokenCache{},
 	}
 }

--- a/internal/ui/screen_typing_actions.go
+++ b/internal/ui/screen_typing_actions.go
@@ -27,7 +27,7 @@ func (m TypingModel) newTest() TypingModel {
 	if m.mode == config.ModeCode {
 		fresh = NewTypingCode(m.target, m.th, m.keys, m.blink, m.strict)
 	} else {
-		fresh = newTypingWithSeed(m.mode, m.length, m.ql, m.th, m.keys, m.blink, m.strict, 0)
+		fresh = newTypingWithSeed(m.mode, m.length, m.ql, m.th, m.keys, m.blink, m.strict, m.punctuation, m.numbers, 0)
 	}
 	fresh.w, fresh.h = m.w, m.h
 	return fresh

--- a/internal/ui/screen_typing_actions_test.go
+++ b/internal/ui/screen_typing_actions_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRestartSame_ResetsTimers(t *testing.T) {
-	m := NewTyping(config.ModeWords, 10, 0, theme.Default(), config.DefaultKeymap(), false, false)
+	m := NewTyping(config.ModeWords, 10, 0, theme.Default(), config.DefaultKeymap(), false, false, false, false)
 	m.w, m.h = 80, 24
 	m2 := m.restartSame()
 	if m2.startMs != 0 || m2.nowMs != 0 || m2.headerWPM != 0 {
@@ -17,7 +17,7 @@ func TestRestartSame_ResetsTimers(t *testing.T) {
 }
 
 func TestRestartSame_PreservesTarget(t *testing.T) {
-	m := NewTyping(config.ModeWords, 10, 0, theme.Default(), config.DefaultKeymap(), false, false)
+	m := NewTyping(config.ModeWords, 10, 0, theme.Default(), config.DefaultKeymap(), false, false, false, false)
 	orig := m.TargetText()
 	m2 := m.restartSame()
 	if m2.TargetText() != orig {
@@ -26,7 +26,7 @@ func TestRestartSame_PreservesTarget(t *testing.T) {
 }
 
 func TestNewTest_PreservesSize(t *testing.T) {
-	m := NewTyping(config.ModeWords, 10, 0, theme.Default(), config.DefaultKeymap(), false, false)
+	m := NewTyping(config.ModeWords, 10, 0, theme.Default(), config.DefaultKeymap(), false, false, false, false)
 	m.w, m.h = 80, 24
 	m2 := m.newTest()
 	if m2.w != 80 || m2.h != 24 {
@@ -43,8 +43,18 @@ func TestNewTest_CodePreservesTarget(t *testing.T) {
 	}
 }
 
+func TestNewTest_PreservesPunctuationAndNumbers(t *testing.T) {
+	m := newTypingWithSeed(
+		config.ModeWords, 10, 0, theme.Default(), config.DefaultKeymap(), false, false, true, true, 42,
+	)
+	m2 := m.newTest()
+	if !m2.punctuation || !m2.numbers {
+		t.Errorf("newTest (ctrl+r) dropped punctuation/numbers: got punctuation=%v numbers=%v", m2.punctuation, m2.numbers)
+	}
+}
+
 func TestApplySettings_UpdatesBlink(t *testing.T) {
-	m := NewTyping(config.ModeWords, 10, 0, theme.Default(), config.DefaultKeymap(), false, false)
+	m := NewTyping(config.ModeWords, 10, 0, theme.Default(), config.DefaultKeymap(), false, false, false, false)
 	s := config.Defaults()
 	s.BlinkCursor = true
 	m2 := m.ApplySettings(s, theme.Default())

--- a/internal/ui/screen_typing_test.go
+++ b/internal/ui/screen_typing_test.go
@@ -17,7 +17,7 @@ import (
 func newTestTyping(mode config.Mode, length int) TypingModel {
 	return newTypingWithSeed(
 		mode, length, words.QuoteShort,
-		theme.Default(), config.DefaultKeymap(), false, false,
+		theme.Default(), config.DefaultKeymap(), false, false, false, false,
 		42,
 	).SetSize(80, 24)
 }
@@ -41,7 +41,7 @@ func pressText(ch string) tea.KeyPressMsg {
 func TestTypingView_CompactNotFullHeight(t *testing.T) {
 	m := newTypingWithSeed(
 		config.ModeWords, 10, words.QuoteShort,
-		theme.Default(), config.DefaultKeymap(), false, false, 42,
+		theme.Default(), config.DefaultKeymap(), false, false, false, false, 42,
 	).SetSize(160, 50)
 	v := m.View()
 	lines := strings.Count(v, "\n") + 1
@@ -165,7 +165,7 @@ func TestTyping_EscEmitsAbortMsg(t *testing.T) {
 func TestTyping_WordsMode_CompletionEmitsResultMsg(t *testing.T) {
 	m := newTypingWithSeed(
 		config.ModeWords, 3, words.QuoteShort,
-		theme.Default(), config.DefaultKeymap(), false, false,
+		theme.Default(), config.DefaultKeymap(), false, false, false, false,
 		42,
 	).SetSize(80, 24)
 

--- a/internal/ui/settings_rows.go
+++ b/internal/ui/settings_rows.go
@@ -27,6 +27,8 @@ const (
 	rowNumbers       = 6
 )
 
+var selectableDefaultModes = []string{"time", "words", "quote"}
+
 // buildRows constructs the 7 fixed settings rows from the current settings pointer.
 func buildRows(s *config.Settings) []settingRow {
 	// Theme row: cycles the available themes.
@@ -40,13 +42,17 @@ func buildRows(s *config.Settings) []settingRow {
 	}
 
 	// Default mode row.
-	modeVals := []string{"time", "words", "quote"}
+	modeVals := append([]string(nil), selectableDefaultModes...)
 	modeIdx := 0
 	for i, v := range modeVals {
 		if string(s.DefaultMode) == v {
 			modeIdx = i
 			break
 		}
+	}
+	if s.DefaultMode == config.ModeCode {
+		modeVals = append(modeVals, "code")
+		modeIdx = len(modeVals) - 1
 	}
 
 	// Default length row: option list depends on current default mode.
@@ -128,11 +134,14 @@ func buildRows(s *config.Settings) []settingRow {
 
 // buildLengthRow returns the string option list and the matching index for
 // defaultLength within the given mode. Quote mode exposes the bucket labels
-// (short/medium/long) defined on the Home screen; numeric modes use their
-// LengthsFor option set.
+// (short/medium/long) defined on the Home screen; Code has no length option;
+// numeric modes use their LengthsFor option set.
 func buildLengthRow(mode config.Mode, defaultLength int) ([]string, int) {
 	if mode == config.ModeQuote {
 		return quoteBucketLabels, 1 // default to "medium"
+	}
+	if mode == config.ModeCode {
+		return []string{"n/a"}, 0
 	}
 	lens := config.LengthsFor(mode)
 	vals := make([]string, len(lens))

--- a/internal/ui/settings_rows.go
+++ b/internal/ui/settings_rows.go
@@ -23,9 +23,11 @@ const (
 	rowDefaultLength = 2
 	rowBlinkCursor   = 3
 	rowStrictMode    = 4
+	rowPunctuation   = 5
+	rowNumbers       = 6
 )
 
-// buildRows constructs the 5 fixed settings rows from the current settings pointer.
+// buildRows constructs the 7 fixed settings rows from the current settings pointer.
 func buildRows(s *config.Settings) []settingRow {
 	// Theme row: cycles theme.Available() = ["default", "mono"].
 	themeVals := theme.Available()
@@ -64,6 +66,20 @@ func buildRows(s *config.Settings) []settingRow {
 		strictIdx = 1
 	}
 
+	// Punctuation row.
+	punctuationVals := []string{"off", "on"}
+	punctuationIdx := 0
+	if s.Punctuation {
+		punctuationIdx = 1
+	}
+
+	// Numbers row.
+	numbersVals := []string{"off", "on"}
+	numbersIdx := 0
+	if s.Numbers {
+		numbersIdx = 1
+	}
+
 	return []settingRow{
 		{
 			label:  "Theme",
@@ -94,6 +110,18 @@ func buildRows(s *config.Settings) []settingRow {
 			values: strictVals,
 			idx:    strictIdx,
 			help:   "Block wrong keys: cursor will not advance past an error.",
+		},
+		{
+			label:  "Punctuation",
+			values: punctuationVals,
+			idx:    punctuationIdx,
+			help:   "Add commas, periods, and capitalization to Words/Time tests.",
+		},
+		{
+			label:  "Numbers",
+			values: numbersVals,
+			idx:    numbersIdx,
+			help:   "Mix in random numbers for Words/Time tests.",
 		},
 	}
 }

--- a/internal/ui/settings_rows.go
+++ b/internal/ui/settings_rows.go
@@ -29,7 +29,7 @@ const (
 
 // buildRows constructs the 7 fixed settings rows from the current settings pointer.
 func buildRows(s *config.Settings) []settingRow {
-	// Theme row: cycles theme.Available() = ["default", "mono"].
+	// Theme row: cycles the available themes.
 	themeVals := theme.Available()
 	themeIdx := 0
 	for i, v := range themeVals {

--- a/internal/words/for_mode.go
+++ b/internal/words/for_mode.go
@@ -14,13 +14,17 @@ import (
 //   - ModeWords: length is the word count (10/25/50/100); returns exactly that
 //     many space-separated words.
 //   - ModeQuote: ql selects the desired quote bucket; length is ignored.
-func ForMode(g *Generator, m mode.Mode, length int, ql QuoteLen) string {
+//
+// punctuation/numbers apply only to ModeWords and ModeTime (and the default
+// fallback for unknown modes) via Generator.ApplyOptions — ModeQuote already
+// carries real punctuation and is never transformed.
+func ForMode(g *Generator, m mode.Mode, length int, ql QuoteLen, punctuation, numbers bool) string {
 	switch m {
 	case mode.ModeWords:
-		return g.Words(length)
+		return g.ApplyOptions(g.Words(length), punctuation, numbers)
 	case mode.ModeQuote:
 		return g.Quote(ql).Text
 	default: // ModeTime and any future modes default to a time buffer
-		return g.TimeBuffer()
+		return g.ApplyOptions(g.TimeBuffer(), punctuation, numbers)
 	}
 }

--- a/internal/words/for_mode_test.go
+++ b/internal/words/for_mode_test.go
@@ -12,7 +12,7 @@ import (
 func TestForMode_TimeReturnsNonEmpty(t *testing.T) {
 	g := NewGenerator(1)
 	for _, length := range []int{15, 30, 60, 120} {
-		got := ForMode(g, config.ModeTime, length, QuoteShort)
+		got := ForMode(g, config.ModeTime, length, QuoteShort, false, false)
 		if got == "" {
 			t.Errorf("ForMode(ModeTime, %d): got empty string", length)
 		}
@@ -27,7 +27,7 @@ func TestForMode_TimeReturnsNonEmpty(t *testing.T) {
 func TestForMode_WordsExactCount(t *testing.T) {
 	g := NewGenerator(42)
 	for _, n := range []int{10, 25, 50, 100} {
-		got := ForMode(g, config.ModeWords, n, QuoteShort)
+		got := ForMode(g, config.ModeWords, n, QuoteShort, false, false)
 		tokens := strings.Fields(got)
 		if len(tokens) != n {
 			t.Errorf("ForMode(ModeWords, %d): want %d words, got %d", n, n, len(tokens))
@@ -40,7 +40,7 @@ func TestForMode_WordsExactCount(t *testing.T) {
 func TestForMode_QuoteNonEmpty(t *testing.T) {
 	g := NewGenerator(7)
 	for _, ql := range []QuoteLen{QuoteShort, QuoteMedium, QuoteLong} {
-		got := ForMode(g, config.ModeQuote, 0, ql)
+		got := ForMode(g, config.ModeQuote, 0, ql, false, false)
 		if got == "" {
 			t.Errorf("ForMode(ModeQuote, ql=%d): got empty string", ql)
 		}
@@ -51,7 +51,7 @@ func TestForMode_QuoteNonEmpty(t *testing.T) {
 func TestForMode_WordsDeterministic(t *testing.T) {
 	a := NewGenerator(99)
 	b := NewGenerator(99)
-	if ForMode(a, config.ModeWords, 25, QuoteShort) != ForMode(b, config.ModeWords, 25, QuoteShort) {
+	if ForMode(a, config.ModeWords, 25, QuoteShort, false, false) != ForMode(b, config.ModeWords, 25, QuoteShort, false, false) {
 		t.Error("ForMode(ModeWords, 25): same seed gave different results")
 	}
 }
@@ -60,7 +60,7 @@ func TestForMode_WordsDeterministic(t *testing.T) {
 func TestForMode_TimeDeterministic(t *testing.T) {
 	a := NewGenerator(5)
 	b := NewGenerator(5)
-	if ForMode(a, config.ModeTime, 30, QuoteShort) != ForMode(b, config.ModeTime, 30, QuoteShort) {
+	if ForMode(a, config.ModeTime, 30, QuoteShort, false, false) != ForMode(b, config.ModeTime, 30, QuoteShort, false, false) {
 		t.Error("ForMode(ModeTime, 30): same seed gave different results")
 	}
 }
@@ -69,8 +69,52 @@ func TestForMode_TimeDeterministic(t *testing.T) {
 // returns the time buffer (default branch).
 func TestForMode_UnknownModeFallsBackToTime(t *testing.T) {
 	g := NewGenerator(3)
-	got := ForMode(g, config.Mode("unknown"), 30, QuoteShort)
+	got := ForMode(g, config.Mode("unknown"), 30, QuoteShort, false, false)
 	if got == "" {
 		t.Error("ForMode(unknown mode): expected time buffer fallback, got empty string")
+	}
+}
+
+// TestForMode_WordsAppliesPunctuationAndNumbers verifies ForMode threads the
+// punctuation/numbers flags into ModeWords generation.
+func TestForMode_WordsAppliesPunctuationAndNumbers(t *testing.T) {
+	plainGen := NewGenerator(11)
+	plain := ForMode(plainGen, config.ModeWords, 60, QuoteShort, false, false)
+
+	optGen := NewGenerator(11)
+	got := ForMode(optGen, config.ModeWords, 60, QuoteShort, true, true)
+
+	if got == plain {
+		t.Error("ForMode(ModeWords, punctuation=true, numbers=true) produced unchanged output")
+	}
+	if len(strings.Fields(got)) != len(strings.Fields(plain)) {
+		t.Error("ForMode(ModeWords, ...): token count changed with options applied")
+	}
+}
+
+// TestForMode_TimeAppliesPunctuationAndNumbers verifies ForMode threads the
+// punctuation/numbers flags into ModeTime generation.
+func TestForMode_TimeAppliesPunctuationAndNumbers(t *testing.T) {
+	plainGen := NewGenerator(21)
+	plain := ForMode(plainGen, config.ModeTime, 30, QuoteShort, false, false)
+
+	optGen := NewGenerator(21)
+	got := ForMode(optGen, config.ModeTime, 30, QuoteShort, true, true)
+
+	if got == plain {
+		t.Error("ForMode(ModeTime, punctuation=true, numbers=true) produced unchanged output")
+	}
+}
+
+// TestForMode_QuoteIgnoresPunctuationAndNumbers verifies ForMode(ModeQuote)
+// is byte-identical regardless of the flags — Quote mode already has real
+// punctuation and must not be transformed.
+func TestForMode_QuoteIgnoresPunctuationAndNumbers(t *testing.T) {
+	a := NewGenerator(7)
+	b := NewGenerator(7)
+	plain := ForMode(a, config.ModeQuote, 0, QuoteShort, false, false)
+	got := ForMode(b, config.ModeQuote, 0, QuoteShort, true, true)
+	if got != plain {
+		t.Errorf("ForMode(ModeQuote, ...): flags must be ignored:\nwant %q\ngot  %q", plain, got)
 	}
 }

--- a/internal/words/generator.go
+++ b/internal/words/generator.go
@@ -6,8 +6,10 @@ package words
 import (
 	_ "embed"
 	"math/rand/v2"
+	"strconv"
 	"strings"
 	"time"
+	"unicode"
 )
 
 //go:embed data/english-1000.txt
@@ -68,4 +70,86 @@ func (g *Generator) Words(n int) string {
 // user somehow exhausts it.
 func (g *Generator) TimeBuffer() string {
 	return g.Words(timeBufferWords)
+}
+
+// punctuationMarks are trailing marks applied to a token; earlier entries are
+// weighted more heavily by repetition (commas more common than semicolons).
+var punctuationMarks = []byte{',', ',', ',', '.', '.', ';'}
+
+// ApplyOptions returns text with punctuation and/or number substitutions
+// applied, using the Generator's own seeded rng so output stays deterministic
+// per seed. Token count is always preserved: punctuation only appends marks
+// or capitalizes existing tokens, and numbers only replaces a token in place
+// — neither adds nor removes word slots. A no-op (both flags false) returns
+// text unchanged.
+func (g *Generator) ApplyOptions(text string, punctuation, numbers bool) string {
+	if !punctuation && !numbers {
+		return text
+	}
+	tokens := strings.Fields(text)
+	if len(tokens) == 0 {
+		return text
+	}
+	if numbers {
+		g.applyNumbers(tokens)
+	}
+	if punctuation {
+		g.applyPunctuation(tokens)
+	}
+	return strings.Join(tokens, " ")
+}
+
+// applyNumbers substitutes ~10-15% of tokens with a random 1-4 digit string.
+func (g *Generator) applyNumbers(tokens []string) {
+	for i := range tokens {
+		if g.rng.IntN(100) < 12 {
+			digits := g.rng.IntN(4) + 1
+			max := 1
+			for range digits {
+				max *= 10
+			}
+			// IntN(max-1)+1 bounds the result to [1, max-1], i.e. exactly
+			// `digits` digits — IntN(max)+1 would include max itself (one
+			// digit too many, e.g. 10000 when digits==4).
+			tokens[i] = strconv.Itoa(g.rng.IntN(max-1) + 1)
+		}
+	}
+}
+
+// applyPunctuation appends trailing marks to ~15-20% of tokens, wraps ~2-3%
+// of tokens in quotes, capitalizes the token following a period or
+// semicolon, and always closes the final token with a mark. Applied after
+// applyNumbers so a numeric token can also be punctuated.
+func (g *Generator) applyPunctuation(tokens []string) {
+	capitalizeNext := false
+	for i, tok := range tokens {
+		if capitalizeNext {
+			tokens[i] = capitalizeFirst(tok)
+			capitalizeNext = false
+		}
+		if g.rng.IntN(100) < 3 {
+			tokens[i] = `"` + tokens[i] + `"`
+		}
+		last := i == len(tokens)-1
+		roll := g.rng.IntN(100)
+		switch {
+		case last:
+			tokens[i] = tokens[i] + "."
+		case roll < 17:
+			mark := punctuationMarks[g.rng.IntN(len(punctuationMarks))]
+			tokens[i] = tokens[i] + string(mark)
+			if mark == '.' || mark == ';' {
+				capitalizeNext = true
+			}
+		}
+	}
+}
+
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
 }

--- a/internal/words/generator_test.go
+++ b/internal/words/generator_test.go
@@ -1,6 +1,7 @@
 package words
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -89,5 +90,154 @@ func TestWordList_NonEmpty(t *testing.T) {
 	const minWords = 200
 	if len(wordList) < minWords {
 		t.Errorf("word list has %d entries, want at least %d", len(wordList), minWords)
+	}
+}
+
+func TestApplyOptions_NoOp(t *testing.T) {
+	g := NewGenerator(42)
+	text := g.Words(50)
+	got := g.ApplyOptions(text, false, false)
+	if got != text {
+		t.Errorf("ApplyOptions with both flags false must be a no-op:\ngot:  %q\nwant: %q", got, text)
+	}
+}
+
+func TestApplyOptions_PunctuationDeterministic(t *testing.T) {
+	a := NewGenerator(7)
+	textA := a.Words(50)
+	gotA := a.ApplyOptions(textA, true, false)
+
+	b := NewGenerator(7)
+	textB := b.Words(50)
+	gotB := b.ApplyOptions(textB, true, false)
+
+	if gotA != gotB {
+		t.Error("ApplyOptions(punctuation=true): same seed produced different output")
+	}
+}
+
+func TestApplyOptions_PunctuationAddsMarks(t *testing.T) {
+	g := NewGenerator(1)
+	text := g.Words(80)
+	got := g.ApplyOptions(text, true, false)
+
+	found := false
+	for _, r := range got {
+		if r == ',' || r == '.' || r == ';' {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ApplyOptions(punctuation=true) on 80 words produced no punctuation marks: %q", got)
+	}
+}
+
+func TestApplyOptions_PunctuationCapitalizesAfterPeriod(t *testing.T) {
+	g := NewGenerator(3)
+	text := g.Words(80)
+	got := g.ApplyOptions(text, true, false)
+
+	tokens := strings.Fields(got)
+	found := false
+	for i := 0; i < len(tokens)-1; i++ {
+		if strings.HasSuffix(tokens[i], ".") {
+			next := tokens[i+1]
+			r := []rune(next)[0]
+			if r >= 'A' && r <= 'Z' {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected at least one word following a '.' to be capitalized: %q", got)
+	}
+}
+
+func TestApplyOptions_PunctuationCapitalizesAfterSemicolon(t *testing.T) {
+	g := NewGenerator(6)
+	text := g.Words(200)
+	got := g.ApplyOptions(text, true, false)
+
+	tokens := strings.Fields(got)
+	found := false
+	for i := 0; i < len(tokens)-1; i++ {
+		if strings.HasSuffix(tokens[i], ";") {
+			next := tokens[i+1]
+			r := []rune(next)[0]
+			if r >= 'A' && r <= 'Z' {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected at least one word following a ';' to be capitalized: %q", got)
+	}
+}
+
+func TestApplyOptions_PunctuationWrapsSomeTokensInQuotes(t *testing.T) {
+	g := NewGenerator(4)
+	text := g.Words(300)
+	got := g.ApplyOptions(text, true, false)
+
+	found := strings.Contains(got, `"`)
+	if !found {
+		t.Errorf("ApplyOptions(punctuation=true) on 300 words produced no quote-wrapped token: %q", got)
+	}
+}
+
+func TestApplyOptions_NumbersProduceDigits(t *testing.T) {
+	g := NewGenerator(2)
+	text := g.Words(80)
+	got := g.ApplyOptions(text, false, true)
+
+	digitToken := regexp.MustCompile(`^\d+[,.;]?$`)
+	found := false
+	for _, tok := range strings.Fields(got) {
+		if digitToken.MatchString(tok) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ApplyOptions(numbers=true) on 80 words produced no numeric token: %q", got)
+	}
+}
+
+func TestApplyOptions_TokenCountPreserved(t *testing.T) {
+	cases := []struct {
+		punctuation, numbers bool
+	}{
+		{false, false},
+		{true, false},
+		{false, true},
+		{true, true},
+	}
+	for _, c := range cases {
+		g := NewGenerator(9)
+		text := g.Words(60)
+		wantCount := len(strings.Fields(text))
+		got := g.ApplyOptions(text, c.punctuation, c.numbers)
+		gotCount := len(strings.Fields(got))
+		if gotCount != wantCount {
+			t.Errorf("punctuation=%v numbers=%v: token count changed: got %d, want %d",
+				c.punctuation, c.numbers, gotCount, wantCount)
+		}
+	}
+}
+
+func TestApplyOptions_DeterministicAcrossOptions(t *testing.T) {
+	a := NewGenerator(15)
+	textA := a.Words(60)
+	gotA := a.ApplyOptions(textA, true, true)
+
+	b := NewGenerator(15)
+	textB := b.Words(60)
+	gotB := b.ApplyOptions(textB, true, true)
+
+	if gotA != gotB {
+		t.Error("ApplyOptions(punctuation=true, numbers=true): same seed produced different output")
 	}
 }

--- a/internal/words/quotes_test.go
+++ b/internal/words/quotes_test.go
@@ -102,11 +102,11 @@ func TestForMode_NonEmpty(t *testing.T) {
 		var result string
 		switch tc.mode {
 		case "time":
-			result = ForMode(g, "time", tc.length, tc.ql)
+			result = ForMode(g, "time", tc.length, tc.ql, false, false)
 		case "words":
-			result = ForMode(g, "words", tc.length, tc.ql)
+			result = ForMode(g, "words", tc.length, tc.ql, false, false)
 		case "quote":
-			result = ForMode(g, "quote", tc.length, tc.ql)
+			result = ForMode(g, "quote", tc.length, tc.ql, false, false)
 		}
 		if strings.TrimSpace(result) == "" {
 			t.Errorf("ForMode(%s, %d, %d): returned empty string", tc.mode, tc.length, tc.ql)

--- a/plans/260702-1824-punctuation-numbers-toggle/.claude/agent-memory/code-reviewer/MEMORY.md
+++ b/plans/260702-1824-punctuation-numbers-toggle/.claude/agent-memory/code-reviewer/MEMORY.md
@@ -1,0 +1,1 @@
+- [Typeburn settings-toggle conventions](project_typeburn_conventions.md) — call-chain to check for new persisted bool settings; watch for spec'd sub-requirements silently dropped even when listed tests pass

--- a/plans/260702-1824-punctuation-numbers-toggle/.claude/agent-memory/code-reviewer/project_typeburn_conventions.md
+++ b/plans/260702-1824-punctuation-numbers-toggle/.claude/agent-memory/code-reviewer/project_typeburn_conventions.md
@@ -1,0 +1,32 @@
+---
+name: project-typeburn-conventions
+description: Typeburn repo conventions relevant to reviewing config/settings toggle features (punctuation/numbers, strict-mode precedent)
+metadata:
+  type: project
+---
+
+Typeburn wires new persisted boolean settings through a fixed call chain:
+`config.Settings` field -> `words.Generator` transform -> `words.ForMode` ->
+`runner.NewSession` -> `ui.NewTyping`/`newTypingWithSeed` -> `app/model.go`
+StartTestMsg handler, plus `internal/cli/cmd_run_notui.go` for the non-TUI
+path, plus `internal/ui/settings_rows.go` + `screen_settings.go` for the
+Settings screen row, plus `internal/cli/cmd_config.go` for `config set`.
+Code mode (`NewCodeSession`/`NewTypingCode`) and Quote mode are intentionally
+excluded from generation-time transforms — verify this exclusion is tested,
+not just claimed.
+
+**Why:** StrictMode (PR #52-54) established this pattern; the
+punctuation/numbers toggle (plan `260702-1824-punctuation-numbers-toggle`)
+mirrors it. `ApplySettings` (live settings propagation to an in-flight
+TypingModel) only updates `blink`/`theme`, not `strict`/`punctuation`/
+`numbers` — this is pre-existing, not a regression, when reviewing similar
+features.
+
+**How to apply:** When reviewing a new settings-toggle feature in this repo,
+check every link in this chain is threaded, check Quote/Code mode exclusion
+is asserted by an actual test (e.g. `TestForMode_QuoteIgnoresPunctuationAndNumbers`
+pattern), and check the plan's phase-01 file's TDD requirements list
+line-by-line against the shipped implementation — plan validation logs in
+this repo have caught real drift before (see plan.md's "Validation Log"
+section), and phases can still silently drop a spec'd sub-requirement (e.g.
+quote-wrapping in punctuation transform) even when all listed tests pass.

--- a/plans/260702-1824-punctuation-numbers-toggle/phase-01-config-generator-tdd.md
+++ b/plans/260702-1824-punctuation-numbers-toggle/phase-01-config-generator-tdd.md
@@ -1,0 +1,112 @@
+---
+phase: 1
+title: Config & Generator (TDD)
+status: completed
+effort: small
+priority: P1
+dependencies: []
+---
+
+# Phase 1: Config & Generator (TDD)
+
+## Overview
+
+Add `Punctuation`/`Numbers` bool fields to `config.Settings`, and a
+deterministic post-generation transform in `internal/words` that applies
+punctuation/number substitution to a word string. Both packages stay UI-free
+per the layering rule. This is the core logic phase — no wiring to app/UI yet.
+
+## Requirements
+
+- Functional:
+  - `config.Settings.Punctuation`, `config.Settings.Numbers` (bool, JSON tags
+    `punctuation`/`numbers`), default `false` in `Defaults()`.
+  - `words.Generator` gets a new method, e.g. `ApplyOptions(text string, punctuation, numbers bool) string`,
+    using the generator's existing seeded `rng` (no new randomness source).
+  - Punctuation transform: iterate space-separated tokens; ~15-20% chance per
+    token to append `,`/`.`/`;` (weighted, periods rarer than commas); if a
+    token follows a token ending in `.`, capitalize its first rune; ~2-3%
+    chance to wrap a token in `"…"`. Trailing token always gets a `.` if
+    punctuation is on and it doesn't already end in `,`/`.`/`;` (test finishes
+    on a sentence-like beat).
+  - Numbers transform: ~10-15% chance per token to replace it wholesale with a
+    random 1-4 digit numeric string (e.g. `strconv.Itoa(rng.IntN(9000)+1)` style,
+    biased toward shorter numbers).
+  - Order of application when both on: numbers substitution first, then
+    punctuation pass over the resulting token list (so a numeric token can also
+    get a trailing comma/period).
+- Non-functional:
+  - Fully deterministic for a fixed seed (existing `TestWords_Deterministic`-style
+    coverage must extend to the transform).
+  - No new external deps — stdlib `math/rand/v2`, `strconv`, `strings` only.
+  - File size: if `generator.go` exceeds ~200 LOC after this addition, split the
+    transform into `internal/words/options.go` (kebab/snake per Go convention:
+    `options.go`, since Go uses lowercase single-word or `snake_case` file
+    names — check existing sibling files for the pattern before naming).
+
+## Architecture
+
+`words.Generator.ApplyOptions` is a pure function over its `rng` and the input
+string — no coupling to `mode.Mode`. `ForMode` (phase 2 concern, not touched
+here) will call it conditionally. Keeping the transform mode-agnostic means
+Quote/Code modes never call it and stay untouched by construction, not by a
+guard clause that could be forgotten.
+
+## Related Code Files
+
+- Modify: `internal/config/settings.go` (fields + `Defaults()`; `Normalize()`
+  needs no change — bools have no invalid state, confirmed by `StrictMode`
+  precedent)
+- Modify: `internal/words/generator.go` (or new `internal/words/options.go` if
+  LOC cap forces a split — check current LOC first: `wc -l internal/words/generator.go`)
+- Modify/Create: `internal/words/generator_test.go` (or `options_test.go` if
+  split) — TDD: write these tests FIRST, watch them fail, then implement.
+
+## Implementation Steps
+
+1. **RED**: Write failing tests in `generator_test.go` (or new file):
+   - `TestApplyOptions_NoOp` — punctuation=false, numbers=false → input unchanged.
+   - `TestApplyOptions_PunctuationDeterministic` — same seed, same output.
+   - `TestApplyOptions_PunctuationAddsMarks` — with punctuation=true on a fixed
+     seed + known word count, assert at least one token ends in `,`/`.`/`;`.
+   - `TestApplyOptions_PunctuationCapitalizesAfterPeriod` — assert a token
+     following a `.`-terminated token starts with an uppercase rune.
+   - `TestApplyOptions_NumbersProduceDigits` — with numbers=true on a fixed
+     seed, assert at least one token is all-digit via a small regex/loop check.
+   - `TestApplyOptions_TokenCountPreserved` — token count in == token count out
+     (punctuation/numbers modify tokens, never add/remove word slots — this is
+     the invariant `ForMode`'s Words-mode exact-count contract in phase 2 relies
+     on).
+   - `TestApplyOptions_DeterministicAcrossOptions` — same seed + both flags on
+     → identical output across two calls (regression guard for `TestWords_Deterministic`
+     equivalent).
+2. Run tests, confirm RED (compile failure or assertion failure is fine — must
+   fail for the right reason, not a typo).
+3. **GREEN**: Implement `config.Settings` fields + `Defaults()` update.
+4. **GREEN**: Implement `ApplyOptions` on `Generator` satisfying the tests above.
+5. Run `go test ./internal/words/... ./internal/config/... -race -count=1` —
+   confirm GREEN.
+6. **REFACTOR**: if `generator.go` > ~180 LOC, extract the transform + its
+   constants (percentages, punctuation mark set) into a sibling file; re-run
+   tests to confirm the split didn't break anything.
+7. Run `gofmt -l internal/words internal/config` and `go vet ./internal/words/... ./internal/config/...` — must be clean.
+
+## Success Criteria
+
+- [x] `config.Settings` has `Punctuation`/`Numbers` bool fields, default false
+- [x] `words.Generator.ApplyOptions` exists, is deterministic per seed
+- [x] Token count is preserved (in == out) for any combination of flags
+- [x] Punctuation-off / numbers-off is a true no-op (byte-identical output)
+- [x] All new tests pass under `-race -count=1`
+- [x] `gofmt -l` clean, `go vet` clean
+- [x] No file exceeds ~200 LOC (split if needed)
+
+## Risk Assessment
+
+- **Risk:** Transform accidentally changes token count → breaks
+  `ForMode`'s Words-mode "exactly N words" contract (existing `TestWords_ExactCount`).
+  **Mitigation:** `TestApplyOptions_TokenCountPreserved` test written first (RED),
+  transform never appends/removes tokens, only mutates them in place.
+- **Risk:** Non-deterministic output breaks existing seed-based test patterns.
+  **Mitigation:** Transform only consumes `g.rng`, never a new random source;
+  deterministic tests written before implementation.

--- a/plans/260702-1824-punctuation-numbers-toggle/phase-02-wiring-call-sites-tdd.md
+++ b/plans/260702-1824-punctuation-numbers-toggle/phase-02-wiring-call-sites-tdd.md
@@ -1,0 +1,149 @@
+---
+phase: 2
+title: Wiring Call Sites (TDD)
+status: completed
+effort: small
+priority: P1
+dependencies:
+  - 1
+---
+
+# Phase 2: Wiring Call Sites (TDD)
+
+## Overview
+
+<!-- Updated: Validation Session 1 - corrected call chain, verified against codebase -->
+
+Thread `settings.Punctuation`/`settings.Numbers` through the VERIFIED call
+chain: `words.ForMode` ← `runner.NewSession` ← `ui.newTypingWithSeed`
+(via `ui.NewTyping`, called from `app/model.go`, AND via the ctrl+r restart
+path in `ui/screen_typing_actions.go`) ← and separately `cli.runSession` in
+`cli/cmd_run_notui.go`. Two new positional bool params (`punctuation, numbers bool`),
+not a bundled struct — matches existing style. Quote/Code modes must NOT
+receive the transform — verified by ForMode's mode switch, not by caller
+discipline. `NewCodeSession` is untouched (Code mode excluded by design).
+
+## Requirements
+
+- Functional:
+  - `words.ForMode(g *Generator, m mode.Mode, length int, ql QuoteLen, punctuation, numbers bool) string`
+    — apply `g.ApplyOptions(...)` only in the `ModeWords`/default-`ModeTime`
+    branches; `ModeQuote` branch returns `g.Quote(ql).Text` untouched.
+  - `runner.NewSession(m mode.Mode, length int, ql words.QuoteLen, seed int64, strict, punctuation, numbers bool) Session`
+    — thread the two new bools into its `words.ForMode(...)` call.
+    `runner.NewCodeSession` is UNCHANGED (Code mode excluded).
+  - `ui.NewTyping(...)` and `ui.newTypingWithSeed(...)` (both in
+    `screen_typing.go`) gain `punctuation, numbers bool` params, passed to
+    `runner.NewSession(...)`. `TypingModel` gains `punctuation`/`numbers`
+    fields alongside its existing `strict` field, so the ctrl+r restart path
+    in `screen_typing_actions.go:30` can pass them into its own
+    `newTypingWithSeed(...)` call (currently passes `m.strict`).
+  - `app/model.go`'s `StartTestMsg` handler (lines ~86,89) updates its
+    `ui.NewTyping(...)` call to also pass `m.settings.Punctuation,
+    m.settings.Numbers`. Its `ui.NewTypingCode(...)` call is UNCHANGED (Code
+    mode excluded).
+  - `internal/cli/cmd_run_notui.go`'s `runSession` func (line ~54) updates its
+    `runner.NewSession(...)` call to pass `settings.Punctuation,
+    settings.Numbers`. Its `runner.NewCodeSession(...)` call is UNCHANGED.
+- Non-functional: no behavior change when both flags are false (regression
+  guard — this is the majority of existing tests). No `cmd_run.go` flag
+  changes — settings-only control surface (Validation Session 1, Q4).
+
+## Architecture
+
+Same fan-out shape as `StrictMode`: one config field pair, one
+generator-facing transform, each layer of the call chain (`ForMode` →
+`NewSession` → `newTypingWithSeed`/`NewTyping` → `app/model.go` StartTestMsg
+handler, and separately → `cli/cmd_run_notui.go`) threads the two bools
+through as plain positional params — no new struct type (Validation Session 1,
+Q3). `TypingModel` carries the two bools the same way it already carries
+`strict`, so ctrl+r restart is symmetric with existing behavior by
+construction, not a special case.
+
+## Related Code Files
+
+- Modify: `internal/words/for_mode.go` (signature + ModeWords/ModeTime branch)
+- Modify: `internal/words/for_mode_test.go` (extend for new params — TDD: RED
+  first)
+- Modify: `internal/runner/session.go` (`NewSession` signature; `NewCodeSession`
+  untouched)
+- Modify: `internal/runner/session_test.go`
+- Modify: `internal/ui/screen_typing.go` (`NewTyping`, `newTypingWithSeed`
+  signatures; `TypingModel` struct gains `punctuation`, `numbers` fields)
+- Modify: `internal/ui/screen_typing_test.go`
+- Modify: `internal/ui/screen_typing_actions.go` (ctrl+r restart call at
+  line ~30: `newTypingWithSeed(m.mode, m.length, m.ql, m.th, m.keys, m.blink,
+  m.strict, ...)` → add `m.punctuation, m.numbers`)
+- Modify: `internal/ui/screen_typing_actions_test.go`
+- Modify: `internal/ui/phase09_polish_test.go` (calls these constructors —
+  verify exact call before editing)
+- Modify: `internal/app/anim_driver_test.go` (calls these constructors —
+  verify exact call before editing)
+- Modify: `internal/app/model.go` (StartTestMsg handler, `ui.NewTyping(...)`
+  call only — NOT `ui.NewTypingCode(...)`)
+- Modify: `internal/cli/cmd_run_notui.go` (`runSession` func,
+  `runner.NewSession(...)` call only — NOT `runner.NewCodeSession(...)`)
+- Do NOT modify: `internal/cli/cmd_run_validate.go` (verified not a call site
+  — only computes `runLengthForMode`, unrelated to this chain)
+
+## Implementation Steps
+
+1. **RED**: Extend `for_mode_test.go` — add cases asserting `ForMode` with
+   `punctuation=true`/`numbers=true` on `ModeWords` and `ModeTime` produces
+   transformed output (reuse phase 1's `ApplyOptions` test assertions at this
+   integration level), and `ModeQuote`/default fallback ignores the flags
+   entirely (byte-identical to pre-change behavior for a fixed seed+quote index).
+2. Confirm RED (signature mismatch compile failure is expected first).
+3. **GREEN**: Update `ForMode` signature and implementation.
+4. **GREEN**: Update `runner.NewSession` signature + its `words.ForMode(...)`
+   call; update `session_test.go` call sites.
+5. **GREEN**: Update `ui.NewTyping`/`newTypingWithSeed` signatures, add
+   `punctuation`/`numbers` fields to `TypingModel`, update
+   `screen_typing_test.go`.
+6. **GREEN**: Update `screen_typing_actions.go`'s ctrl+r restart call to pass
+   `m.punctuation, m.numbers`; update `screen_typing_actions_test.go`.
+7. **GREEN**: Update `app/model.go`'s `ui.NewTyping(...)` call (StartTestMsg
+   handler) to pass `m.settings.Punctuation, m.settings.Numbers`.
+8. **GREEN**: Update `cli/cmd_run_notui.go`'s `runSession` func's
+   `runner.NewSession(...)` call to pass `settings.Punctuation,
+   settings.Numbers`.
+9. **GREEN**: Run `go build ./...` — compile errors surface any remaining
+   missed call site immediately (signature change is a forcing function);
+   fix `phase09_polish_test.go` and `anim_driver_test.go` call sites as
+   surfaced by the build.
+10. Run full suite: `go test ./... -race -count=1` — confirm no regressions.
+11. `gofmt -l .` and `go vet ./...` clean.
+
+## Success Criteria
+
+- [x] `ForMode`, `NewSession`, `NewTyping`/`newTypingWithSeed` all accept and
+      correctly thread `punctuation, numbers bool`
+- [x] `TypingModel` carries `punctuation`/`numbers`; ctrl+r restart preserves
+      them (verified by a restart-path test asserting fields survive)
+- [x] `NewCodeSession`/`NewTypingCode` signatures UNCHANGED (Code mode excluded)
+- [x] `cmd_run_validate.go` untouched; no new `cmd_run.go` flags added
+- [x] `go build ./...` compiles clean (proves no call site was missed)
+- [x] `ModeQuote`/`ModeCode` paths byte-identical to pre-change
+- [x] Full `go test ./... -race -count=1` green
+- [x] `gofmt -l .` and `go vet ./...` clean
+
+## Risk Assessment
+
+- **Risk:** A forgotten call site silently keeps old behavior (masks the
+  feature) instead of failing loudly. The original plan draft missed 2 real
+  call sites (`screen_typing_actions.go` restart, `cmd_run_notui.go`) and
+  named a wrong file (`cmd_run_validate.go`) — caught only by tracing the
+  actual call chain during validation (Validation Session 1), not by grep.
+  **Mitigation:** Signature change forces a compile error at every call site —
+  `go build ./...` catches all of them mechanically; Step 9 explicitly budgets
+  for fixing test files surfaced by the build rather than assuming the
+  Related Code Files list above is exhaustive.
+- **Risk:** Accidentally routing the transform into `ModeQuote`/`ModeCode`.
+  **Mitigation:** Transform application lives inside `ForMode`'s existing mode
+  switch, gated to the same branch that already returns `TimeBuffer`/`Words`
+  output — not a wrapper applied unconditionally at call sites.
+- **Risk:** ctrl+r restart silently drops the setting (regression vs.
+  StrictMode's existing restart-preserving behavior).
+  **Mitigation:** `TypingModel` stores `punctuation`/`numbers` fields
+  explicitly (Validation Session 1, Q2); a dedicated test asserts they survive
+  restart.

--- a/plans/260702-1824-punctuation-numbers-toggle/phase-03-settings-ui-cli-tdd.md
+++ b/plans/260702-1824-punctuation-numbers-toggle/phase-03-settings-ui-cli-tdd.md
@@ -1,0 +1,103 @@
+---
+phase: 3
+title: Settings UI & CLI (TDD)
+status: completed
+effort: medium
+priority: P1
+dependencies:
+  - 1
+  - 2
+---
+
+# Phase 3: Settings UI & CLI (TDD)
+
+## Overview
+
+Expose the two new settings as toggle rows in `internal/ui/screen_settings.go`
+(same on/off cycle as `rowStrictMode`) and as `config get`/`config set` CLI
+keys in `internal/cli/cmd_config.go` (same pattern as `strict_mode`).
+
+## Requirements
+
+- Functional:
+  - Settings screen: two new rows, e.g. `rowPunctuation`, `rowNumbers`, cycled
+    on/off via the existing `Cycle` binding, positioned after `rowStrictMode`
+    in the row order (confirm exact row enum/order in `screen_settings.go`
+    before editing).
+  - `screen_settings_view.go`: render the two new rows following the existing
+    label/value column layout — no new visual pattern.
+  - CLI: `typeburn config get punctuation` / `config get numbers`, `config set
+    punctuation <true|false>` / `config set numbers <true|false>`, with the
+    same invalid-value rejection behavior as `strict_mode` (see
+    `strict_mode_config_test.go` `TestStrictModeSetGet` for the exact
+    assert shape to mirror).
+  - `typeburn config list` output includes both new keys (mirror
+    `TestConfigListIncludesStrictMode`).
+- Non-functional: toggles must persist via existing `AppendHistory`-adjacent
+  settings-save path (auto-persist on Settings screen `esc`/`1`, per README's
+  documented behavior) — no new persistence mechanism.
+
+## Architecture
+
+Zero new architecture — this phase is purely extending two already-proven
+enum-driven patterns (`screen_settings.go` row cycling, `cmd_config.go` key
+table) by two entries each.
+
+## Related Code Files
+
+- Modify: `internal/ui/screen_settings.go` (row enum, `Cycle` handler — mirror
+  `case rowStrictMode:` block at line ~132)
+- Modify: `internal/ui/screen_settings_view.go` (render new rows)
+- Modify: `internal/ui/screen_settings_test.go` (TDD: RED first — new row
+  cycle tests)
+- Modify: `internal/cli/cmd_config.go` (get/set key table — mirror lines ~93,
+  ~145 `strict_mode` entries)
+- Create: `internal/cli/punctuation_numbers_config_test.go` (mirror
+  `strict_mode_config_test.go` structure: `TestPunctuationNumbersSetGet`,
+  extend `TestConfigListIncludesStrictMode`-equivalent to assert both new keys
+  present in `config list`)
+
+## Implementation Steps
+
+1. **RED**: Write `screen_settings_test.go` cases — cycling `rowPunctuation`/
+   `rowNumbers` toggles the corresponding `Settings` field; verify against the
+   existing `rowStrictMode` test as the template.
+2. **RED**: Write `punctuation_numbers_config_test.go` — copy
+   `TestStrictModeSetGet` structure for both `punctuation` and `numbers` keys;
+   copy `TestConfigListIncludesStrictMode` asserting both new keys appear.
+3. Confirm RED (missing row/key → test failure, not compile error, since
+   Settings struct fields already exist from phase 1).
+4. **GREEN**: Add `rowPunctuation`/`rowNumbers` to the settings row enum +
+   `Cycle` handler in `screen_settings.go`.
+5. **GREEN**: Add render lines in `screen_settings_view.go`.
+6. **GREEN**: Add `punctuation`/`numbers` entries to `cmd_config.go`'s
+   get/set/list key table.
+7. Run `go test ./internal/ui/... ./internal/cli/... -race -count=1` —
+   confirm GREEN, including any teatest golden files for the Settings screen
+   (may need golden regeneration if the screen's rendered row count changed —
+   check `make test` output for golden mismatches and regenerate deliberately,
+   not blindly).
+8. `gofmt -l .` and `go vet ./...` clean.
+
+## Success Criteria
+
+- [x] Settings screen has two new cycleable rows, positioned after Strict Mode
+- [x] Toggling either row updates `m.s.Punctuation`/`m.s.Numbers` and persists
+      on screen exit (existing auto-save path)
+- [x] `config get/set punctuation|numbers` works, rejects invalid values
+- [x] `config list` includes both new keys
+- [x] No Settings-screen teatest golden files existed for this screen — no
+      regeneration needed (confirmed: `find . -iname "*settings*golden*"` empty)
+- [x] Full `go test ./... -race -count=1`, `gofmt -l .`, `go vet ./...` green
+
+## Risk Assessment
+
+- **Risk:** Settings screen teatest golden files break due to added rows
+  changing the rendered height/layout.
+  **Mitigation:** Expected — regenerate goldens deliberately per existing
+  project convention (teatest golden update flow), verify diff by eye before
+  committing, don't rubber-stamp.
+- **Risk:** CLI invalid-value handling diverges from `strict_mode`'s error
+  message/behavior, creating inconsistent UX across config keys.
+  **Mitigation:** Directly copy `strict_mode`'s validation branch in
+  `cmd_config.go`, only swapping the key name and target field.

--- a/plans/260702-1824-punctuation-numbers-toggle/phase-04-docs-sync.md
+++ b/plans/260702-1824-punctuation-numbers-toggle/phase-04-docs-sync.md
@@ -1,0 +1,84 @@
+---
+phase: 4
+title: Docs Sync
+status: completed
+effort: small
+priority: P3
+dependencies:
+  - 1
+  - 2
+  - 3
+---
+
+# Phase 4: Docs Sync
+
+## Overview
+
+Update user-facing docs to reflect the shipped feature: README features list +
+Usage/Keybindings if any new interaction surface, and `docs/project-roadmap.md`
+to move this from "recommended in brainstorm" to shipped, consistent with how
+every prior feature (Strict Mode, Heatmap, Self-Update) is documented there.
+
+## Requirements
+
+- Functional:
+  - `README.md`: add a bullet to the `## Features` list describing
+    punctuation/numbers toggles (mirror the existing "Strict mode" bullet
+    style at line ~20).
+  - `README.md`: if `config set punctuation|numbers` is a new documented CLI
+    surface, add example usage near the existing `typeburn config set theme
+    nord` example (line ~101).
+  - `docs/project-roadmap.md`: add a new shipped entry under "Shipped Post-1.0"
+    following the exact style of the `v2.5.0 (Strict Mode)` entry (line ~250),
+    with the correct next version number (confirm current version via
+    `internal/version` or the latest git tag before writing — do not guess).
+- Non-functional: no scope creep — do not rewrite unrelated doc sections.
+
+## Architecture
+
+N/A — documentation-only phase.
+
+## Related Code Files
+
+- Modify: `README.md`
+- Modify: `docs/project-roadmap.md`
+- Check (no edit unless behavior changed): `docs/code-standards.md`,
+  `docs/system-architecture.md` — only touch if the transform introduced a
+  new architectural pattern (it should not have, per phase 1's design note).
+
+## Implementation Steps
+
+1. Confirm current shipped version: `git tag --sort=-v:refname | head -1` or
+   check `internal/version` for the latest resolved version, to pick the
+   correct next version number for the roadmap entry.
+2. Add README `## Features` bullet for punctuation/numbers toggles.
+3. Add README CLI usage example if `config set punctuation|numbers` needs
+   documentation (check if other boolean config keys like `strict_mode` or
+   `update_check` already have a documented example — mirror that, or skip if
+   the existing `config set theme nord` example is treated as sufficiently
+   representative of the pattern).
+4. Add `docs/project-roadmap.md` shipped entry, matching the terse style of
+   prior entries (one paragraph, ship date, PR reference once known).
+5. Verify no other doc references stale info (e.g. "4 settings only" design
+   constraint at roadmap line ~183 — this line currently states "4 settings
+   only" as a v1 design constraint; confirm whether it needs updating to
+   reflect the actual current settings count, since Strict Mode already
+   pushed past 4 and this phase adds 2 more — check if a correction is owed
+   here rather than compounding the staleness).
+
+## Success Criteria
+
+- [x] README `## Features` list includes punctuation/numbers toggle bullet
+- [x] `docs/project-roadmap.md` has a new shipped entry with correct version (v2.6.0)
+- [x] No stale "4 settings only" claim left uncorrected (annotated as v1-scope/superseded)
+- [x] No unrelated doc sections modified
+
+## Risk Assessment
+
+- **Risk:** Version number guessed wrong (roadmap entries are chronological
+  and version-numbered).
+  **Mitigation:** Step 1 confirms actual current version from git tags before
+  writing, not assumption.
+- **Risk:** Doc scope creep — rewriting sections beyond what changed.
+  **Mitigation:** Explicit non-functional requirement above; touch only the
+  listed files/sections.

--- a/plans/260702-1824-punctuation-numbers-toggle/plan.md
+++ b/plans/260702-1824-punctuation-numbers-toggle/plan.md
@@ -1,0 +1,122 @@
+---
+title: Punctuation & Numbers Toggle for Words/Time Mode
+description: >-
+  Monkeytype-parity punctuation/numbers toggles for Words and Time mode word
+  generation.
+status: completed
+priority: P2
+branch: main
+tags:
+  - feature
+  - words
+  - config
+  - ui
+blockedBy: []
+blocks: []
+created: '2026-07-02T11:32:31.061Z'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Punctuation & Numbers Toggle for Words/Time Mode
+
+## Overview
+
+Two new persisted settings toggles — `Punctuation` and `Numbers`, both bool,
+default `false` — applied to Words/Time mode word generation only. Wiring shape
+mirrors `StrictMode` (PR #52-54): `config.Settings` field → generator transform
+→ call-site threading → Settings-screen toggle row → CLI `config` key. Quote/Code
+modes and the typing/metrics engine are untouched.
+
+Brainstorm report: `plans/reports/feature-recommendation-260702-1824-punctuation-numbers-toggle-report.md`
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Config & Generator (TDD)](./phase-01-config-generator-tdd.md) | Completed |
+| 2 | [Wiring Call Sites (TDD)](./phase-02-wiring-call-sites-tdd.md) | Completed |
+| 3 | [Settings UI & CLI (TDD)](./phase-03-settings-ui-cli-tdd.md) | Completed |
+| 4 | [Docs Sync](./phase-04-docs-sync.md) | Completed |
+
+## Acceptance Criteria
+
+- Punctuation ON: ~15-20% of words get trailing `,`/`.`/`;`; word after a `.`
+  is capitalized; rare word wrapped in quotes. Deterministic given a fixed seed.
+- Numbers ON: ~10-15% of word-slots replaced with a random 1-4 digit token.
+- Both default `false`; legacy `settings.json` without these fields loads
+  safely (Go zero-value `false`, same as `StrictMode` precedent).
+- Quote mode, Code mode, typing engine, metrics engine: byte-for-byte unchanged.
+- `go test ./... -race -count=1`, `go vet ./...`, `gofmt -l .` all green.
+
+## Dependencies
+
+None — all prior plans in `./plans/` are `status: completed`, no overlap detected.
+
+## Validation Log
+
+### Verification Results (Standard tier: Fact Checker + Contract Verifier)
+- Claims checked: 12 (call chain, file paths, line numbers, signatures)
+- Verified: 8 | Failed: 4 | Unverified: 0
+- Tier: Standard (4 phases)
+- Failures:
+  - Phase 2 claimed `internal/app/model.go` calls `words.ForMode` directly —
+    FALSE. It calls `ui.NewTyping(...)`, which calls `newTypingWithSeed` →
+    `runner.NewSession` → `words.ForMode`. (`internal/app/model.go:86,89`,
+    `internal/ui/screen_typing.go:56,71`, `internal/runner/session.go:25`)
+  - Phase 2 claimed `internal/cli/cmd_run_validate.go` is a `ForMode` call site
+    — FALSE. That file only computes `runLengthForMode`; the real CLI call
+    site is `internal/cli/cmd_run_notui.go:54` (`runSession` → `runner.NewSession`).
+  - Phase 2 omitted `internal/ui/screen_typing_actions.go:30` — the ctrl+r
+    restart path also calls `newTypingWithSeed` and must carry
+    punctuation/numbers forward (mirrors existing `m.strict` field), or the
+    setting would silently drop on restart.
+  - Phase 2 omitted `internal/ui/screen_typing.go`'s `NewTyping`/`newTypingWithSeed`
+    signatures entirely as a required-edit file.
+  - 5 test files call these constructors directly and need signature updates:
+    `internal/ui/screen_typing_test.go`, `internal/ui/screen_typing_actions_test.go`,
+    `internal/ui/phase09_polish_test.go`, `internal/app/anim_driver_test.go`,
+    `internal/runner/session_test.go`.
+
+### Interview (4 questions, mode=prompt)
+1. **Fix Phase 2 file list?** → Yes, rewrite with corrected call chain
+   (words/for_mode.go, runner/session.go, ui/screen_typing.go,
+   ui/screen_typing_actions.go, app/model.go, cli/cmd_run_notui.go + 5 test
+   files); dropped `cmd_run_validate.go` reference.
+2. **ctrl+r restart scope?** → Yes, include: `TypingModel` gains
+   `punctuation`/`numbers` fields alongside existing `strict`, so restart
+   preserves them (matches StrictMode precedent).
+3. **Param shape for the 2 new bools?** → Two separate positional bool params
+   (`punctuation, numbers bool`), NOT a bundled options struct — matches
+   existing style (no structs used in this call chain today; introducing one
+   would be a new pattern not otherwise justified).
+4. **CLI flag scope?** → Settings-only, zero new `cmd_run.go` flags — matches
+   verified StrictMode precedent (no `--strict` flag exists either). Only
+   `config set punctuation|numbers` is a control surface.
+
+### Whole-Plan Consistency Sweep
+Re-read `plan.md` + all 4 phase files after propagation. No stale references
+to `cmd_run_validate.go` remain outside this log (was only in Phase 2, now
+corrected there). Phase 1's `ApplyOptions(text, punctuation, numbers bool)`
+signature is consistent with Phase 2's corrected threading (two bools, not a
+struct). No unresolved contradictions.
+
+## Code Review Log
+
+Post-implementation `code-reviewer` subagent review found 4 issues:
+- **HIGH:** Quote-wrap requirement (`ApplyOptions` acceptance criterion above)
+  was implemented in Phase 1's plan text but never coded — no test caught it.
+  User decision: implement it. Fixed in `internal/words/generator.go`
+  `applyPunctuation` (~3% chance to wrap a token in `"…"`), with new tests
+  `TestApplyOptions_PunctuationWrapsSomeTokensInQuotes`.
+- **MEDIUM:** `applyNumbers` off-by-one — `rng.IntN(max)+1` could produce a
+  5-digit number when `digits==4` (e.g. `10000`), violating the "1-4 digit"
+  contract. Fixed: `rng.IntN(max-1)+1`.
+- **MEDIUM:** Capitalization triggers after both `.` and `;`, not just `.` as
+  literally spec'd. User decision: keep as-is (reasonable stylistic choice),
+  locked in with `TestApplyOptions_PunctuationCapitalizesAfterSemicolon`.
+- **LOW:** Stale "5 fixed settings rows" doc comment in `settings_rows.go`
+  (sibling files already said 7). Fixed.
+
+All 4 findings resolved. Full re-verification: `go test ./... -race -count=1`,
+`gofmt -l .`, `go vet ./...` all green after fixes.

--- a/plans/reports/feature-recommendation-260702-1824-punctuation-numbers-toggle-report.md
+++ b/plans/reports/feature-recommendation-260702-1824-punctuation-numbers-toggle-report.md
@@ -1,0 +1,68 @@
+# Brainstorm Report: Punctuation & Numbers Toggle
+
+Date: 2026-07-02 | Branch: main | Status: approved, TDD plan mode selected
+
+## Problem Statement
+
+User asked for a new feature or worthwhile upgrade/polish, open-ended. Typeburn v2.5.0
+has 4 modes, strict mode, animations, self-update, heatmap. No product gap flagged in
+roadmap backlog was itself a "capability" ask — user wanted something not yet covered.
+
+## Requirements (locked)
+
+- Expected output: 2 new persisted settings (`Punctuation`, `Numbers`, both bool,
+  default false) toggled from Settings screen, applied to Words + Time mode word
+  generation only.
+- Acceptance:
+  - Punctuation ON: ~15-20% words get trailing `,`/`.`/`;`; word after `.` capitalized;
+    rare word quoted.
+  - Numbers ON: ~10-15% word-slots replaced with random 1-4 digit numeric token.
+  - Both OFF by default; legacy settings.json without fields safely zero-value.
+  - Quote/Code modes unaffected; typing/metrics engine unaffected (chars typed as-is).
+- Scope boundary (explicitly OUT): Quote mode, Code mode, Home-screen quick-toggle UX,
+  any typing-engine/metrics change, any new keystroke-accuracy category.
+- Constraints: Go 1.25 stdlib only, `internal/words`/`internal/config` stay UI-free,
+  <200 LOC/file, same wiring shape as `StrictMode` (PR #52-54).
+- Touchpoints: `internal/config/settings.go`, `internal/words/generator.go`,
+  `internal/words/for_mode.go`, `internal/app/model.go`, `internal/runner/session.go`,
+  `internal/cli/cmd_run_validate.go`, `internal/cli/cmd_config.go`,
+  `internal/ui/screen_settings.go` + `_view.go`, README.md, docs/project-roadmap.md.
+
+## Evaluated Approaches (feature direction)
+
+| Option | Effort | Pros | Cons |
+|---|---|---|---|
+| Practice weak-keys mode | Large | Closes real gap using existing heatmap data | Biggest scope, new History→generator bridge |
+| **Punctuation/numbers toggle (chosen)** | Small-Medium | Monkeytype parity, proven wiring pattern (StrictMode x2) | Doesn't address a totally new capability, "just" a generator feature |
+| Lifetime stats dashboard | Small | Pure polish, zero typing-engine risk | Doesn't add typing-mechanic value |
+
+User chose punctuation/numbers toggle: worthwhile upgrade, contained risk.
+
+## Final Design
+
+1. `config.Settings` +2 bool fields, `Defaults()` false, `Normalize()` no-op (matches
+   `StrictMode` precedent for backward-compat).
+2. `words.Generator` gets a post-generation transform (uses existing seeded rng, no
+   new randomness source — keeps generator tests deterministic).
+3. `words.ForMode` gains `punctuation, numbers bool` params; only applies to
+   `ModeWords`/`ModeTime`.
+4. Call sites thread settings through exactly like `settings.StrictMode` already does
+   in `app/model.go`, `runner/session.go`, `cli/cmd_run_validate.go`.
+5. Settings screen: 2 new toggle rows, same on/off cycle as `rowStrictMode`.
+6. CLI: `punctuation`/`numbers` config get/set keys mirroring `strict_mode`.
+7. Docs: README features list + roadmap backlog entry marked shipped.
+
+## Risks
+
+- Low. Additive-only, proven pattern reused twice already (theme packs, strict mode).
+- Generator transform must stay seed-deterministic or existing `generator_test.go`
+  fixed-seed assertions could need updates — TDD mode chosen specifically to catch
+  this early.
+
+## Next Steps
+
+Hand off to `/ck:plan --tdd` with this report as context.
+
+## Unresolved Questions
+
+- None.

--- a/plans/reports/pm-260702-1851-punctuation-numbers-toggle-completion-report.md
+++ b/plans/reports/pm-260702-1851-punctuation-numbers-toggle-completion-report.md
@@ -1,0 +1,42 @@
+# PM Report: Punctuation & Numbers Toggle — Completion
+
+Date: 2026-07-02 | Plan: `plans/260702-1824-punctuation-numbers-toggle/` | Status: completed
+
+## Summary
+
+4/4 phases complete, all success criteria checked off. Post-implementation
+code review found 4 issues (1 high, 2 medium, 1 low); all fixed with user
+sign-off on 2 scope/behavior decisions. Full suite green.
+
+## Phases
+
+| Phase | Status | Notes |
+|---|---|---|
+| 1 Config & Generator (TDD) | ✅ | `ApplyOptions` transform, deterministic, token-count-preserving |
+| 2 Wiring Call Sites (TDD) | ✅ | Validation caught 4 factual errors in original draft (call chain), corrected before implementation |
+| 3 Settings UI & CLI (TDD) | ✅ | 2 new toggle rows + `config get/set punctuation\|numbers` |
+| 4 Docs Sync | ✅ | README + roadmap (v2.6.0), corrected stale "4 settings only" line |
+
+## Code Review Findings (all resolved)
+
+| Severity | Finding | Resolution |
+|---|---|---|
+| HIGH | Quote-wrap spec'd but not implemented | Implemented + tested (user chose to implement) |
+| MEDIUM | `applyNumbers` off-by-one (5-digit possible) | Fixed (`IntN(max-1)+1`) |
+| MEDIUM | Capitalize-after-`;` undocumented deviation | Kept, locked in with test (user chose to keep) |
+| LOW | Stale "5 rows" doc comment | Fixed |
+
+## Verification
+
+`go test ./... -race -count=1`, `gofmt -l .`, `go vet ./...` — all clean, both
+before and after review fixes.
+
+## Files Changed
+
+20 files across `internal/config`, `internal/words`, `internal/runner`,
+`internal/ui`, `internal/app`, `internal/cli`, `README.md`,
+`docs/project-roadmap.md`. Full list in plan.md's implementation notes.
+
+## Unresolved Questions
+
+None.


### PR DESCRIPTION
## Summary

Prepares the next consolidated `v2.5.0` release. Public stable remains `v2.4.1`.

- Adds persisted Punctuation and Numbers Settings controls for Words/Time targets; Quote and Code stay unchanged, with no new `run` flags.
- Fixes Code labels in History and Result, and keeps Code and Strict records out of personal-best markers.
- Safely represents a CLI-persisted `default_mode=code` in Settings without changing the three-choice TUI selector.
- Reconciles README, CLI reference, architecture, PDR, roadmap, and CHANGELOG to the unreleased state.

## Validation

- `go test ./... -race -count=1`
- `make lint`
- `make size-check`
- `go run . config list --json`

## Release state and scope

- No `v2.5.0` tag or release is created by this PR.
- No storage migration, dependency, workflow, `.github/release-notes.md`, or journal change.
- Release preparation and publication remain separate follow-up PR/workflow gates.