### PR TITLE
chore(release): prepare v2.5.0

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,20 +1,24 @@
-## [2.4.1] - 2026-06-20
+## [2.5.0] - 2026-07-11
 
 ### Added
 
-- **UI/UX animation system** — a stdlib-only terminal motion layer, always on
-  and auto-adapting under `NO_COLOR`:
-  - Animated typing caret: blink (530ms), freshly-typed cell fade, and a
-    just-vacated trail.
-  - Result screen reveal: WPM count-up (fixed-width slot, no jitter), sparkline
-    draw-in, and staggered stat cards.
-  - One-shot sparkle burst when a result beats the per-mode personal best.
-  - A short Typing→Result transition (dim-curtain crossfade in color, a
-    row-wipe under `NO_COLOR`).
-  - Driven by a self-stopping ~33ms frame loop that schedules zero ticks when
-    idle, independent of the existing 100ms timer. Motion never shifts layout
-    (line count + rune width preserved) and every settled frame matches the
-    prior static render; the typing hot path is kept cheap by a prefix-token
-    cache.
+- **Strict typing mode** — an optional letter-strict typing mode:
+  - Block wrong keypresses: the cursor freezes and does not advance past an incorrect character; the user must type the correct character to proceed.
+  - Log blocked error keystrokes: they are recorded in the keystroke log and correctly reduce the typing accuracy.
+  - Keystroke-level accuracy metric: strict runs compute and save `KeystrokeAccuracy` (based on total non-backspace forward keystrokes) rather than final-state accuracy.
+  - Excluded from bests: strict runs are saved in history but excluded from personal best (★) records.
+  - Settings TUI toggle and CLI config key (`typeburn config set strict_mode on|off`) persisted in `settings.json` (backward-compatible).
+- **Punctuation and numbers toggles** — optional persisted Settings controls that
+  add commas, periods, capitalization, and numeric tokens to Words/Time target
+  generation; Quote and Code targets remain unchanged.
 
-[2.4.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.4.1
+### Fixed
+
+- Code records now use the `code` label rather than being displayed as Quote
+  records in History and Result metadata.
+- Code and Strict records consistently remain ineligible for personal-best (★)
+  markers across result detection and History display.
+- Settings now represents a CLI-persisted Code default without a missing length
+  value or a misleading Time selection.
+
+[2.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,29 @@ jobs:
       - name: Test (race detector)
         run: go test ./... -race -count=1
 
+  verify-main:
+    name: Verify tag commit is reachable from main
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Reject tags outside main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          tag_commit=$(git rev-parse "${{ github.ref_name }}^{commit}")
+          if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
+            echo "::error::tag commit $tag_commit is not reachable from origin/main"
+            exit 1
+          fi
+
   goreleaser:
     name: Publish release
-    needs: [test]
+    needs: [test, verify-main]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -65,18 +85,35 @@ jobs:
         with:
           go-version: "1.25.x"
           cache: true
-      - name: Run GoReleaser
+      - name: Verify Homebrew tap write permission
+        if: ${{ !contains(github.ref_name, '-') }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          can_push=$(gh api repos/bavanchun/homebrew-tap-typeburn --jq '.permissions.push')
+          if [ "$can_push" != "true" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN cannot push to the Homebrew tap"
+            exit 1
+          fi
+      - name: Run GoReleaser (prerelease)
+        if: ${{ contains(github.ref_name, '-') }}
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
           version: "v2.15.4"
           args: release --clean --release-notes=.github/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Scoped at the STEP level only (never job-level): a fine-grained
-          # PAT with contents r/w on bavanchun/homebrew-tap-typeburn ONLY.
-          # GoReleaser reads it as {{ .Env.HOMEBREW_TAP_TOKEN }} to commit the
-          # cask cross-repo; the default GITHUB_TOKEN cannot. Job `permissions:`
-          # (contents: write, source repo) is intentionally left unchanged.
+      - name: Run GoReleaser (stable)
+        if: ${{ !contains(github.ref_name, '-') }}
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
+        with:
+          version: "v2.15.4"
+          args: release --clean --release-notes=.github/release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Scoped at the stable publish step only: a fine-grained PAT with
+          # contents r/w on bavanchun/homebrew-tap-typeburn. Prereleases never
+          # receive it, and this step follows the non-mutating permission check.
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       - name: Assert asset count
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-07-11
+
 ### Added
 
 - **Strict typing mode** — an optional letter-strict typing mode:
@@ -29,6 +31,8 @@ release section is extracted verbatim and passed to GoReleaser via
   records in History and Result metadata.
 - Code and Strict records consistently remain ineligible for personal-best (★)
   markers across result detection and History display.
+- Settings now represents a CLI-persisted Code default without a missing length
+  value or a misleading Time selection.
 
 ## [2.4.1] - 2026-06-20
 
@@ -328,7 +332,8 @@ terminal typing test built with Go and Bubble Tea v2.
   HTTPS transport and the pipeline-generated `checksums.txt`. See
   [SECURITY.md](./SECURITY.md).
 
-[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v2.4.1...HEAD
+[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v2.5.0...HEAD
+[2.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.5.0
 [2.4.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.4.1
 [2.0.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.0.0
 [1.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v1.5.0


### PR DESCRIPTION
## Summary

Prepares the pending stable `v2.5.0` release from proven feature SHA `6c42c78`. Public stable remains `v2.4.1` until the tag workflow succeeds.

- Cuts the consolidated v2.5.0 CHANGELOG section dated 2026-07-11 UTC and derives matching release notes.
- Rejects tag commits not reachable from `origin/main` before the write-capable publish job.
- Splits prerelease and stable GoReleaser steps: prereleases never receive the tap PAT; stable releases first perform a read-only tap push-permission check.

## Validation

- CHANGELOG extraction equals `.github/release-notes.md` byte-for-byte.
- `goreleaser v2.15.4 check` and `make snapshot`.
- `make lint`, `make test-race`, `make size-check`, `make notui-noexit-check`.
- `shellcheck install.sh scripts/test-install-sh.sh` and installer harness (14/14).

## Scope

Only `CHANGELOG.md`, `.github/release-notes.md`, and `.github/workflows/release.yml`; `ci.yml`, journals, and plan artifacts remain untouched. No tag or GitHub release is created by this PR.