### PR TITLE
fix(module): restore Go v2 install channel

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,4 +1,4 @@
-## v2.5.1 — Corrective Release
+## [2.5.1] - 2026-07-11 — Corrective Release
 
 ### Fixed
 

--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,24 +1,13 @@
-## [2.5.0] - 2026-07-11
-
-### Added
-
-- **Strict typing mode** — an optional letter-strict typing mode:
-  - Block wrong keypresses: the cursor freezes and does not advance past an incorrect character; the user must type the correct character to proceed.
-  - Log blocked error keystrokes: they are recorded in the keystroke log and correctly reduce the typing accuracy.
-  - Keystroke-level accuracy metric: strict runs compute and save `KeystrokeAccuracy` (based on total non-backspace forward keystrokes) rather than final-state accuracy.
-  - Excluded from bests: strict runs are saved in history but excluded from personal best (★) records.
-  - Settings TUI toggle and CLI config key (`typeburn config set strict_mode on|off`) persisted in `settings.json` (backward-compatible).
-- **Punctuation and numbers toggles** — optional persisted Settings controls that
-  add commas, periods, capitalization, and numeric tokens to Words/Time target
-  generation; Quote and Code targets remain unchanged.
+## v2.5.1 — Corrective Release
 
 ### Fixed
 
-- Code records now use the `code` label rather than being displayed as Quote
-  records in History and Result metadata.
-- Code and Strict records consistently remain ineligible for personal-best (★)
-  markers across result detection and History display.
-- Settings now represents a CLI-persisted Code default without a missing length
-  value or a misleading Time selection.
+- **Go module channel**: `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest`
+  now works correctly. The v2.5.0 release used a root module path that the Go
+  proxy could not resolve for install.
+- **Command binary**: moved entrypoint to `cmd/typeburn/` so `go install`
+  produces a lowercase `typeburn` binary matching all other install channels.
+- **Documentation**: all install, build, and update guidance now uses the
+  corrected `/v2/cmd/typeburn` path.
 
-[2.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.5.0
+No features, dependency changes, or breaking changes. The v2.5.0 tag and release remain untouched.

--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -10,4 +10,6 @@
 - **Documentation**: all install, build, and update guidance now uses the
   corrected `/v2/cmd/typeburn` path.
 
-No features, dependency changes, or breaking changes. The v2.5.0 tag and release remain untouched.
+No features or dependency changes. CLI, config, storage, and release-archive
+contracts remain compatible; Go module/import identity intentionally moves to
+the required `/v2` path. The v2.5.0 tag and release remain untouched.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,7 @@ builds:
   # Pinned lowercase binary name. install.sh and the Homebrew cask extract a
   # member named exactly `typeburn`; do not let it derive from the module path.
   - binary: typeburn
+    main: ./cmd/typeburn
     env:
       - CGO_ENABLED=0
       # Fail loudly on any module drift instead of silently rewriting go.sum.
@@ -42,9 +43,9 @@ builds:
       # `v`-prefixed so the release-archive banner matches the `go install`
       # path, where debug.ReadBuildInfo() reports the tag as `vX.Y.Z`.
       # GoReleaser's {{ .Version }} strips the leading `v`; we re-add it.
-      - -X github.com/bavanchun/Typeburn/internal/version.Version=v{{ .Version }}
-      - -X github.com/bavanchun/Typeburn/internal/version.Commit={{ .Commit }}
-      - -X github.com/bavanchun/Typeburn/internal/version.Date={{ .CommitDate }}
+      - -X github.com/bavanchun/Typeburn/v2/internal/version.Version=v{{ .Version }}
+      - -X github.com/bavanchun/Typeburn/v2/internal/version.Commit={{ .Commit }}
+      - -X github.com/bavanchun/Typeburn/v2/internal/version.Date={{ .CommitDate }}
 
 archives:
   # Plural `formats:` — singular `format:` is removed in this v2 line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [v2.5.1] — 2026-07-11
+
+### Fixed
+
+- **Go module path**: migrated to `github.com/bavanchun/Typeburn/v2` so
+  `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest` works
+  correctly. The command binary is lowercase `typeburn`.
+- **Command entrypoint**: moved from root `main.go` to `cmd/typeburn/main.go`
+  to produce the correct lowercase binary name via `go install`.
+- **All documentation**: reconciled install, build, and update instructions
+  with the `/v2` module path.
+
 ## [2.5.0] - 2026-07-11
 
 ### Added
@@ -332,7 +344,8 @@ terminal typing test built with Go and Bubble Tea v2.
   HTTPS transport and the pipeline-generated `checksums.txt`. See
   [SECURITY.md](./SECURITY.md).
 
-[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/bavanchun/Typeburn/compare/v2.5.1...HEAD
+[v2.5.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.5.1
 [2.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.5.0
 [2.4.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.4.1
 [2.0.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
-## [v2.5.1] — 2026-07-11
+## [2.5.1] - 2026-07-11
 
 ### Fixed
 
@@ -345,7 +345,7 @@ terminal typing test built with Go and Bubble Tea v2.
   [SECURITY.md](./SECURITY.md).
 
 [Unreleased]: https://github.com/bavanchun/Typeburn/compare/v2.5.1...HEAD
-[v2.5.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.5.1
+[2.5.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.5.1
 [2.5.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.5.0
 [2.4.1]: https://github.com/bavanchun/Typeburn/releases/tag/v2.4.1
 [2.0.0]: https://github.com/bavanchun/Typeburn/releases/tag/v2.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Typeburn is a Monkeytype-style terminal typing test: Go 1.25 + Bubble Tea v2 / L
 
 ```sh
 make build       # ldflags-stamped binary → ./bin/typeburn
-make run         # go run . (launches TUI)
+make run         # go run ./cmd/typeburn (launches TUI)
 make test        # go test ./...
 make test-race   # go test ./... -race -count=1   ← the CI gate; must be GREEN
 make lint        # gofmt -l check (must be empty) + go vet ./... + no-TUI guard
@@ -39,7 +39,7 @@ go test ./internal/version/ -run TestResolve_LdflagsWin -v
 
 **Storage is defensive.** Atomic temp-file + rename; any corrupt/missing file returns safe defaults and never panics; history is capped at the 200 newest records. Settings load once at startup (`app.NewFromDisk()`); history loads on demand and after each test.
 
-**CLI/versioning is hybrid.** `internal/version` reads ldflags-injected `Version/Commit/Date` (set by Makefile + GoReleaser); when empty (bare `go install`) it falls back to `debug.ReadBuildInfo()`, final fallback `"dev"`. `main.go` is a thin fang/cobra entrypoint. The pure `internal/cli.Decide()` preserves v1 root aliases: `--version` short-circuits to the banner; `--text <file>`/`-` selects Code mode. Root-level unknown args still fall through to the TUI; recognized subcommands parse strictly. `-v` is intentionally unbound (reserved for a future `--verbose`).
+**CLI/versioning is hybrid.** `internal/version` reads ldflags-injected `Version/Commit/Date` (set by Makefile + GoReleaser); when empty (bare `go install`) it falls back to `debug.ReadBuildInfo()`, final fallback `"dev"`. `cmd/typeburn/main.go` is a thin fang/cobra entrypoint. The pure `internal/cli.Decide()` preserves v1 root aliases: `--version` short-circuits to the banner; `--text <file>`/`-` selects Code mode. Root-level unknown args still fall through to the TUI; recognized subcommands parse strictly. `-v` is intentionally unbound (reserved for a future `--verbose`).
 
 ## Git Workflow (protected main — enforced)
 
@@ -58,7 +58,7 @@ Every change — code, docs, config, release prep — follows:
 ## Conventions & Constraints
 
 - **File size:** keep every Go file < 200 LOC. Split by concern (`screen_x.go` / `screen_x_view.go` / `screen_x_actions.go` / `screen_x_test.go`). Core logic uses `snake_case` filenames; small utility/output modules use `kebab-case`.
-- **Module path is case-sensitive:** `github.com/bavanchun/Typeburn` (capital `T`). ldflags `-X` targets and `go install` both depend on this exact casing.
+- **Module path is case-sensitive:** `github.com/bavanchun/Typeburn/v2` (capital `T`). ldflags `-X` targets and `go install` both depend on this exact casing.
 - **Allowed dependencies:** stdlib, `charm.land/*`, `github.com/charmbracelet/*`, `github.com/spf13/cobra`, and `golang.org/x/*`. Anything else requires explicit user approval per dependency.
 
 ## Release Engineering (read before touching release files)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thanks for your interest in improving Typeburn.
 
 ```sh
 make build       # → ./bin/typeburn (ldflags-stamped)
-make run         # go run .
+make run         # go run ./cmd/typeburn
 make test        # go test ./...
 make test-race   # go test ./... -race -count=1   (the CI gate)
 make lint        # gofmt -l check + go vet

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BIN_DIR := ./bin
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-MODULE := github.com/bavanchun/Typeburn/internal/version
+MODULE := github.com/bavanchun/Typeburn/v2/internal/version
 LDFLAGS := -s -w \
 	-X $(MODULE).Version=$(VERSION) \
 	-X $(MODULE).Commit=$(COMMIT) \
@@ -18,10 +18,10 @@ SIZE_LIMIT ?= 10485760
 .PHONY: build run test test-race lint fmt clean version snapshot release size-check notui-noexit-check
 
 build:
-	@go build -trimpath -ldflags '$(LDFLAGS)' -o $(BIN_DIR)/$(BINARY) .
+	@go build -trimpath -ldflags '$(LDFLAGS)' -o $(BIN_DIR)/$(BINARY) ./cmd/typeburn
 
 run:
-	go run .
+	go run ./cmd/typeburn
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/bavanchun/Typeburn/actions/workflows/ci.yml/badge.svg)](https://github.com/bavanchun/Typeburn/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/bavanchun/Typeburn?sort=semver)](https://github.com/bavanchun/Typeburn/releases/latest)
 [![Go](https://img.shields.io/github/go-mod/go-version/bavanchun/Typeburn)](https://go.dev/)
-[![Go Reference](https://pkg.go.dev/badge/github.com/bavanchun/Typeburn.svg)](https://pkg.go.dev/github.com/bavanchun/Typeburn)
+[![Go Reference](https://pkg.go.dev/badge/github.com/bavanchun/Typeburn/v2.svg)](https://pkg.go.dev/github.com/bavanchun/Typeburn/v2)
 [![License](https://img.shields.io/github/license/bavanchun/Typeburn)](./LICENSE)
 
 A Monkeytype-style terminal typing test built with Go and Bubble Tea v2.
@@ -54,12 +54,12 @@ sha256 against `checksums.txt`**, and installs `typeburn` into `~/.local/bin`
 **2. `go install` (latest tagged release):**
 
 ```sh
-go install github.com/bavanchun/Typeburn@latest
+go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest
 ```
 
 > The module path is **case-sensitive — the capital `T` in `Typeburn` is
-> required**. `go install` installs an executable named `Typeburn` into
-> `$(go env GOPATH)/bin`.
+> required**. `go install` installs an executable named `typeburn` (lowercase)
+> into `$(go env GOPATH)/bin`.
 >
 > A freshly published release may lag the Go module proxy by up to ~1 hour;
 > until the proxy ingests the tag, `go install ...@vX.Y.Z` can 404. Downloading
@@ -72,16 +72,16 @@ Requires **Go 1.25+**.
 Grab the archive for your OS/arch from the
 [latest release](https://github.com/bavanchun/Typeburn/releases/latest)
 (linux/darwin/windows × amd64/arm64), verify it against `checksums.txt`,
-extract, and run the `typeburn` binary (the release archives ship a lowercase
-`typeburn`; only the `go install` path above produces `Typeburn`).
+extract, and run the `typeburn` binary (all install channels produce a
+lowercase `typeburn`).
 
 **4. Build from source:**
 
 ```sh
 make build            # → ./bin/typeburn (lowercase, local convention)
 # or
-go build -o typeburn .
-make run               # run without installing (or: go run .)
+go build -o typeburn ./cmd/typeburn
+make run               # run without installing (or: go run ./cmd/typeburn)
 ```
 
 **5. Homebrew (macOS/Linux):**
@@ -148,7 +148,7 @@ detects a corrupted or truncated download, **not** a compromised release host
 
 Builds installed by a package manager are **not** self-updated: a Homebrew or
 `go install` binary prints the matching upgrade command (`brew upgrade typeburn`
-/ `go install github.com/bavanchun/Typeburn@latest`) and exits without touching
+/ `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest`) and exits without touching
 anything. On a non-interactive stream (pipe/redirect) `update` refuses unless
 `--yes` is passed, rather than blocking on a prompt.
 

--- a/cmd/typeburn/main.go
+++ b/cmd/typeburn/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/charmbracelet/fang"
 
-	"github.com/bavanchun/Typeburn/internal/cli"
+	"github.com/bavanchun/Typeburn/v2/internal/cli"
 )
 
 func main() {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -131,7 +131,7 @@ A newer version is available: v2.1.0
 Upgrade:
   brew upgrade typeburn
   curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh
-  go install github.com/bavanchun/Typeburn@latest
+  go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest
 ```
 
 JSON schema (`--check-update --json`):

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -31,7 +31,7 @@
 
 ```
 monkeytype/
-├── main.go                   # entrypoint
+├── cmd/typeburn/main.go       # entrypoint
 ├── go.mod / go.sum           # dependencies
 ├── internal/
 │   ├── app/                  # root Elm model + routing
@@ -52,7 +52,7 @@ monkeytype/
 
 ### Compilation & Tooling
 
-- **go build:** Must compile without errors (`go build -o bin/typeburn .`)
+- **go build:** Must compile without errors (`go build -o bin/typeburn ./cmd/typeburn`)
 - **go vet:** No warnings (`go vet ./...`)
 - **gofmt:** Automatic formatting enforced (`gofmt -w .` before commit; CI checks with `gofmt -l`)
 - **go test:** All tests PASS (`go test ./... -race -count=1`)

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -62,7 +62,7 @@
 
 ---
 
-### Entrypoint — `main.go` & Flag Parsing
+### Entrypoint — `cmd/typeburn/main.go` & Flag Parsing
 
 **Purpose:** Thin fang/cobra entrypoint. It builds `internal/cli.NewRoot()`,
 executes it, and maps returned errors to process exit codes.
@@ -74,7 +74,7 @@ executes it, and maps returned errors to process exit codes.
 
 **Rationale:** Avoids polluting the TUI with error banners or usage text; unknown input is gracefully treated as "user wants to type."
 
-**Files:** `main.go`, `internal/cli/decide.go`, `internal/cli/decide_test.go`.
+**Files:** `cmd/typeburn/main.go`, `internal/cli/decide.go`, `internal/cli/decide_test.go`.
 
 ---
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -17,9 +17,11 @@ and a scriptable v2 CLI.
 
 ## Current Product State
 
-**Public stable release:** `v2.4.1`. **Upcoming release:** one consolidated
-`v2.5.0`, which is unreleased. The following describes the current runtime
-contract, including changes being prepared for that release.
+**Public stable release:** `v2.5.0` (2026-07-11). Its GitHub release, archives,
+installer, Homebrew cask, and updater shipped successfully, but its Go module
+channel is invalid because the source module path lacks the required `/v2`
+suffix. Corrective `v2.5.1` is in progress to migrate the module path and
+restore proxy-only `go install` without mutating the published v2.5.0 tag.
 
 - **Themes:** `default`, `mono`, `solarized-dark`, `solarized-light`,
   `dracula`, `nord`, `gruvbox-dark`, `gruvbox-light`. `mono` is a grayscale
@@ -136,6 +138,7 @@ contract, including changes being prepared for that release.
 
 ## Development Status
 
-`v2.4.1` is the publicly released stable version. The consolidated `v2.5.0`
-release remains upcoming/unreleased; its integration work must pass CI and
-release gates before publication.
+`v2.5.0` is the publicly released stable version. Strict typing and the
+punctuation/numbers toggles are shipped. Corrective `v2.5.1` is pending the
+protected merge and release gates needed to restore the Go module channel with
+`github.com/bavanchun/Typeburn/v2` and a lowercase `typeburn` command.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -4,10 +4,9 @@
 
 ## Current Release State
 
-**Public stable:** `v2.4.1` (2026-06-20). **Upcoming:** one consolidated
-`v2.5.0`, currently unreleased. Strict typing and punctuation/numbers are
-integration work for that release, not separate shipped `v2.5.0` or `v2.6.0`
-releases.
+**Public stable:** `v2.5.0` (2026-07-11). **In-progress:** corrective
+`v2.5.1` migrating Go module to `/v2` path; Phases 1–3 complete, pending
+protected merge and stable tag.
 
 ---
 
@@ -256,17 +255,17 @@ releases.
 - ✅ **v2.3.0 (Self-Update):** stdlib-only atomic self-updater via `typeburn update`, preflight managed-install check, redirect allowlist, O_EXCL locks, archive path-traversal safety, Windows move-aside rollback. Ship date: 2026-05-30.
 - ✅ **v2.4.0 (Update UX):** In-app hint directs to self-updater; download progress reporting. Ship date: 2026-05-30.
 - ✅ **v2.4.1 (UI Animations):** stdlib-only terminal motion layer (blink/fade caret, stats reveal count-up, sparkle personal best celebration, Typing→Result transition) with NO_COLOR adaptation and hot-path token cache. Ship date: 2026-06-20.
-- ⏳ **v2.5.0 (Upcoming consolidated release):** Letter-strict typing blocks
+- ✅ **v2.5.0 (Strict + Punctuation/Numbers):** Letter-strict typing blocks
   wrong forward keypresses and records them for keystroke-level accuracy;
   Strict runs are excluded from personal bests. Punctuation and Numbers
   Settings toggles add punctuation/capitalization and numeric tokens to
-  Words/Time generation while leaving Quote and Code unchanged. This release
-  has not shipped.
+  Words/Time generation while leaving Quote and Code unchanged.
+  Ship date: 2026-07-11.
 - ⏳ **v2.5.1 (Corrective release):** Migrated Go module path to
   `github.com/bavanchun/Typeburn/v2` with entrypoint moved from root `main.go`
   to `cmd/typeburn/main.go` so `go install .../v2/cmd/typeburn@latest` produces
   a lowercase `typeburn` binary. All documentation reconciled with the `/v2`
-  module path. This release has not shipped.
+  module path. Phases 1–3 complete; pending protected merge and stable tag.
 
 
 ### Next (Optional)
@@ -303,11 +302,12 @@ the remaining entries are historical planning ideas, not the current roadmap.
 
 ## Conclusion
 
-**Typeburn v2.4.1 is the current public stable release.** Post-1.0 work has
+**Typeburn v2.5.0 is the current public stable release.** Post-1.0 work has
 been additive or corrective: v2.0.0 added a professional scriptable CLI,
 v2.1.x added opt-in update checks plus audited defect cleanup, v2.2.0 added
-per-key error heatmaps, v2.3.0 added the self-update command, and v2.4.0/v2.4.1
-added update UX and animations. The consolidated v2.5.0 work—Strict typing and
-punctuation/numbers—is upcoming and unreleased.
+per-key error heatmaps, v2.3.0 added the self-update command, v2.4.0/v2.4.1
+added update UX and animations, and v2.5.0 added Strict typing and
+punctuation/numbers toggles. v2.5.1 is a corrective release migrating the Go
+module path to `/v2`.
 
 M1 (timer re-arm) and M2 (new-best precision) — the identified correctness bugs — were fixed in v1.0 (d6369de) and v1.0.1 respectively. v1.4.0 fixed a Settings live-apply bug (changes were persisted but not applied in-session) and improved the wide-terminal typing layout. Remaining backlog is additive or cosmetic.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -262,6 +262,11 @@ releases.
   Settings toggles add punctuation/capitalization and numeric tokens to
   Words/Time generation while leaving Quote and Code unchanged. This release
   has not shipped.
+- ⏳ **v2.5.1 (Corrective release):** Migrated Go module path to
+  `github.com/bavanchun/Typeburn/v2` with entrypoint moved from root `main.go`
+  to `cmd/typeburn/main.go` so `go install .../v2/cmd/typeburn@latest` produces
+  a lowercase `typeburn` binary. All documentation reconciled with the `/v2`
+  module path. This release has not shipped.
 
 
 ### Next (Optional)
@@ -284,7 +289,7 @@ the remaining entries are historical planning ideas, not the current roadmap.
 ### v1.0 Release
 - **Artifact:** Binary in ./bin/typeburn
 - **Distribution:** GitHub Releases (source + pre-built linux/darwin binaries)
-- **Installation:** `go install Typeburn@latest` (via go.mod/go.sum versioning)
+- **Installation:** `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest` (via go.mod/go.sum versioning)
 - **Minimum Go:** 1.25+
 - **Minimum terminal:** 60 cols × 20 rows (ANSI 256-color or truecolor recommended)
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -4,7 +4,7 @@
 
 ## High-Level Architecture
 
-`main.go` builds a fang/cobra root command in `internal/cli`. Bare `typeburn`
+`cmd/typeburn/main.go` builds a fang/cobra root command in `internal/cli`. Bare `typeburn`
 still launches the Bubble Tea TUI, while subcommands provide scriptable
 history/config/version/replay/run flows.
 
@@ -358,7 +358,7 @@ Ensures no screen attempts to render below the minimum; user sees a resize promp
 ## Package Dependency Graph
 
 ```
-main.go
+main.go (cmd/typeburn/)
   └─ app.Model
       ├─ ui (all screens)
       ├─ theme
@@ -395,7 +395,7 @@ No circular imports; pure packages have zero UI dependencies.
 
 ### Init
 
-1. `main.go` calls `app.NewFromDisk()`
+1. `cmd/typeburn/main.go` calls `app.NewFromDisk()`
 2. Loads settings from XDG_CONFIG (or defaults if missing)
 3. Loads theme based on settings.Theme
 4. Creates root Model with Home screen active
@@ -433,7 +433,7 @@ The `internal/version` package supports two injection paths:
    - Commit/Date: from vcs.revision and vcs.time build settings
    - Ultimate fallback: version = "dev"
 
-**Entry point:** `--version` flag (parsed in `main.go` via pure `decide()` function) prints a one-line banner:
+**Entry point:** `--version` flag (parsed in `cmd/typeburn/main.go` via pure `decide()` function) prints a one-line banner:
 ```
 typeburn v1.0.0 (61a4afd, 2026-05-18T21:10:00Z, go1.26.2 darwin/arm64)
 ```
@@ -464,7 +464,7 @@ make snapshot      # GoReleaser dry-run (builds + archives, no publish)
 **Integrity:** SHA-256 checksums in `checksums.txt` (GoReleaser native); verify with `sha256sum -c checksums.txt`
 
 **Installation paths:**
-- `go install github.com/bavanchun/Typeburn@v1.0.0` (from GitHub via Go module)
+- `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@v1.0.0` (from GitHub via Go module)
 - Download pre-built binary from [Releases](https://github.com/bavanchun/Typeburn/releases)
 
 ### Release Process (Fix-Forward Policy)
@@ -484,9 +484,9 @@ Users can install Typeburn via five independent channels; all verify integrity v
 | Channel | Entry Point | Verification | Dependencies | Platforms |
 |---------|-----------|--------------|--------------|-----------|
 | **Hardened installer** | `curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh \| sh` | SHA-256 checksums.txt (POSIX sh, no sudo) | None (uses system curl, tar/unzip, uname) | Linux, macOS (any x86_64/arm64) |
-| **Go install** | `go install github.com/bavanchun/Typeburn@v1.5.0` | Go module checksum (go.sum) | Go 1.25+ | All platforms |
+| **Go install** | `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@v1.5.0` | Go module checksum (go.sum) | Go 1.25+ | All platforms |
 | **Manual archive** | Download from [GitHub Releases](https://github.com/bavanchun/Typeburn/releases) | SHA-256 in checksums.txt | tar/unzip | All platforms |
-| **Build from source** | `git clone + go build ./...` | git commit signature (if configured) | Go 1.25+ | All platforms |
+| **Build from source** | `git clone + go build ./cmd/typeburn` | git commit signature (if configured) | Go 1.25+ | All platforms |
 | **Homebrew tap** | `brew install bavanchun/tap-typeburn/typeburn` | Tap cask (signed by maintainer) | Homebrew | macOS (x86_64/arm64) |
 
 **Installer (install.sh) design:**

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -395,9 +395,9 @@ No circular imports; pure packages have zero UI dependencies.
 
 ### Init
 
-1. `cmd/typeburn/main.go` calls `app.NewFromDisk()`
-2. Loads settings from XDG_CONFIG (or defaults if missing)
-3. Loads theme based on settings.Theme
+1. `cmd/typeburn/main.go` calls `cli.NewRoot()` to build the Cobra command tree
+2. `fang.Execute()` runs the root command, which loads settings from XDG_CONFIG (or defaults)
+3. The `run` subcommand loads theme based on settings.Theme
 4. Creates root Model with Home screen active
 5. `tea.NewProgram(m)` starts event loop
 
@@ -433,7 +433,7 @@ The `internal/version` package supports two injection paths:
    - Commit/Date: from vcs.revision and vcs.time build settings
    - Ultimate fallback: version = "dev"
 
-**Entry point:** `--version` flag (parsed in `cmd/typeburn/main.go` via pure `decide()` function) prints a one-line banner:
+**Entry point:** `--version` flag (handled by `cmd/typeburn/main.go` via `cli.NewRoot()` and Cobra) prints a one-line banner:
 ```
 typeburn v1.0.0 (61a4afd, 2026-05-18T21:10:00Z, go1.26.2 darwin/arm64)
 ```
@@ -464,7 +464,7 @@ make snapshot      # GoReleaser dry-run (builds + archives, no publish)
 **Integrity:** SHA-256 checksums in `checksums.txt` (GoReleaser native); verify with `sha256sum -c checksums.txt`
 
 **Installation paths:**
-- `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@v1.0.0` (from GitHub via Go module)
+- `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest` (from GitHub via Go module)
 - Download pre-built binary from [Releases](https://github.com/bavanchun/Typeburn/releases)
 
 ### Release Process (Fix-Forward Policy)
@@ -484,7 +484,7 @@ Users can install Typeburn via five independent channels; all verify integrity v
 | Channel | Entry Point | Verification | Dependencies | Platforms |
 |---------|-----------|--------------|--------------|-----------|
 | **Hardened installer** | `curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh \| sh` | SHA-256 checksums.txt (POSIX sh, no sudo) | None (uses system curl, tar/unzip, uname) | Linux, macOS (any x86_64/arm64) |
-| **Go install** | `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@v1.5.0` | Go module checksum (go.sum) | Go 1.25+ | All platforms |
+| **Go install** | `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest` | Go module checksum (go.sum) | Go 1.25+ | All platforms |
 | **Manual archive** | Download from [GitHub Releases](https://github.com/bavanchun/Typeburn/releases) | SHA-256 in checksums.txt | tar/unzip | All platforms |
 | **Build from source** | `git clone + go build ./cmd/typeburn` | git commit signature (if configured) | Go 1.25+ | All platforms |
 | **Homebrew tap** | `brew install bavanchun/tap-typeburn/typeburn` | Tap cask (signed by maintainer) | Homebrew | macOS (x86_64/arm64) |

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bavanchun/Typeburn
+module github.com/bavanchun/Typeburn/v2
 
 go 1.25.0
 

--- a/internal/app/anim_driver.go
+++ b/internal/app/anim_driver.go
@@ -3,7 +3,7 @@ package app
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // The frame-tick command and cadence live in package ui (ui.FrameTickCmd /

--- a/internal/app/anim_driver_test.go
+++ b/internal/app/anim_driver_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // ui.FrameTickCmd's command, when run, must produce a FrameTickMsg carrying the

--- a/internal/app/anim_edge_cases_test.go
+++ b/internal/app/anim_edge_cases_test.go
@@ -7,9 +7,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // sandboxXDG points history/settings writes at temp dirs so completing a test in

--- a/internal/app/code_mode_test.go
+++ b/internal/app/code_mode_test.go
@@ -10,9 +10,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // codeTestModel returns a sandboxed root model with codeText wired in.

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -6,10 +6,10 @@ package app
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/ui"
-	"github.com/bavanchun/Typeburn/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
 )
 
 // Model is the root Elm model.

--- a/internal/app/model_code_paste.go
+++ b/internal/app/model_code_paste.go
@@ -1,6 +1,6 @@
 package app
 
-import "github.com/bavanchun/Typeburn/internal/ui"
+import "github.com/bavanchun/Typeburn/v2/internal/ui"
 
 // openCodePaste switches to ScreenCodePaste with a fresh, sized paste
 // sub-model. Triggered by ui.NavCodePasteMsg (Home Code row, no snippet).

--- a/internal/app/model_constructor.go
+++ b/internal/app/model_constructor.go
@@ -3,10 +3,10 @@ package app
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/ui"
-	"github.com/bavanchun/Typeburn/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
 )
 
 // New builds the root model with the given theme, settings, optional code

--- a/internal/app/model_history.go
+++ b/internal/app/model_history.go
@@ -3,9 +3,9 @@ package app
 import (
 	"math"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/storage"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // buildRecord converts a ResultMsg into a storage.Record for persistence.

--- a/internal/app/model_history_test.go
+++ b/internal/app/model_history_test.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 func TestBuildRecord_QuoteModeLength(t *testing.T) {

--- a/internal/app/model_settings.go
+++ b/internal/app/model_settings.go
@@ -1,11 +1,11 @@
 package app
 
 import (
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/storage"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/ui"
-	"github.com/bavanchun/Typeburn/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
 )
 
 // NewFromDisk builds the root model loading persisted settings from disk.

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -6,11 +6,11 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/ui"
-	"github.com/bavanchun/Typeburn/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
 )
 
 func newTestModel() Model {

--- a/internal/app/model_view.go
+++ b/internal/app/model_view.go
@@ -6,9 +6,9 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/anim"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/anim"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // altView wraps a frame string in the alternate screen buffer. The altscreen

--- a/internal/app/model_view_test.go
+++ b/internal/app/model_view_test.go
@@ -6,9 +6,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // TestView_DegradedNotice verifies that a terminal below the 60×20 safe

--- a/internal/app/persistence_notice_test.go
+++ b/internal/app/persistence_notice_test.go
@@ -8,9 +8,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // blockedXDG points an XDG_* path at a location under a regular file so

--- a/internal/app/phase09_polish_test.go
+++ b/internal/app/phase09_polish_test.go
@@ -6,8 +6,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // ── Degraded-mode gate ──────────────────────────────────────────────────────

--- a/internal/app/quit_prompt.go
+++ b/internal/app/quit_prompt.go
@@ -6,7 +6,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // quitPromptModel is a minimal inline overlay rendered on the Home screen when

--- a/internal/app/routing.go
+++ b/internal/app/routing.go
@@ -3,7 +3,7 @@ package app
 import (
 	"strings"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // screenTitle is the human label for a screen, used by the placeholder views

--- a/internal/app/screen_code_paste_routing_test.go
+++ b/internal/app/screen_code_paste_routing_test.go
@@ -13,8 +13,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // run executes a cmd (if any) and returns the produced message.

--- a/internal/app/smoke_test.go
+++ b/internal/app/smoke_test.go
@@ -10,10 +10,10 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // sandboxedModel returns a root Model with storage redirected to a temp dir.

--- a/internal/app/transition.go
+++ b/internal/app/transition.go
@@ -5,7 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
 )
 
 // transitionDurMs is the Typing→Result transition length. Short enough to feel

--- a/internal/cli/cmd_config.go
+++ b/internal/cli/cmd_config.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bavanchun/Typeburn/internal/cli/output"
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/cli/output"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 func newConfigCmd(e env) *cobra.Command {

--- a/internal/cli/cmd_config_test.go
+++ b/internal/cli/cmd_config_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 func TestConfigGetSetList(t *testing.T) {

--- a/internal/cli/cmd_history.go
+++ b/internal/cli/cmd_history.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bavanchun/Typeburn/internal/cli/output"
-	"github.com/bavanchun/Typeburn/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/cli/output"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
 )
 
 func newHistoryCmd(e env) *cobra.Command {

--- a/internal/cli/cmd_history_test.go
+++ b/internal/cli/cmd_history_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bavanchun/Typeburn/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
 )
 
 func TestHistoryEmptyJSON(t *testing.T) {

--- a/internal/cli/cmd_replay.go
+++ b/internal/cli/cmd_replay.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bavanchun/Typeburn/internal/cli/output"
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/cli/output"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 const replaySchemaV1 = 1

--- a/internal/cli/cmd_replay_test.go
+++ b/internal/cli/cmd_replay_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 func TestReplayJSON(t *testing.T) {

--- a/internal/cli/cmd_run.go
+++ b/internal/cli/cmd_run.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bavanchun/Typeburn/internal/app"
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/ui"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/app"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 type runFlags struct {

--- a/internal/cli/cmd_run_notui.go
+++ b/internal/cli/cmd_run_notui.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/bavanchun/Typeburn/internal/cli/notui"
-	"github.com/bavanchun/Typeburn/internal/cli/output"
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/runner"
+	"github.com/bavanchun/Typeburn/v2/internal/cli/notui"
+	"github.com/bavanchun/Typeburn/v2/internal/cli/output"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/runner"
 )
 
 func runNoTUI(ctx context.Context, e env, req runRequest) error {

--- a/internal/cli/cmd_run_test.go
+++ b/internal/cli/cmd_run_test.go
@@ -8,7 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 func testRunCmd(flags runFlags, changed ...string) *cobra.Command {

--- a/internal/cli/cmd_run_validate.go
+++ b/internal/cli/cmd_run_validate.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 func buildRunRequest(cmd *cobra.Command, f runFlags, settings config.Settings) (runRequest, error) {

--- a/internal/cli/cmd_update.go
+++ b/internal/cli/cmd_update.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/bavanchun/Typeburn/internal/update"
-	"github.com/bavanchun/Typeburn/internal/version"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/version"
 	"github.com/spf13/cobra"
 
 	"golang.org/x/term"

--- a/internal/cli/cmd_update_test.go
+++ b/internal/cli/cmd_update_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bavanchun/Typeburn/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
 )
 
 // upgradeResult is a stub Check result with an upgrade available.

--- a/internal/cli/cmd_version.go
+++ b/internal/cli/cmd_version.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/bavanchun/Typeburn/internal/update"
-	"github.com/bavanchun/Typeburn/internal/version"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -153,7 +153,7 @@ func renderVersionCheckHuman(cmd *cobra.Command, currentVer string, result *upda
 		fmt.Fprintf(cmd.ErrOrStderr(), "could not check for updates: %v\n", checkErr)
 	case result.UpgradeAvailable:
 		fmt.Fprintf(cmd.OutOrStdout(),
-			"\ntypeburn %s is available (you have %s).\nRelease notes: %s\nUpgrade with one of:\n  brew upgrade typeburn\n  curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh\n  go install github.com/bavanchun/Typeburn@latest\n",
+			"\ntypeburn %s is available (you have %s).\nRelease notes: %s\nUpgrade with one of:\n  brew upgrade typeburn\n  curl -fsSL https://raw.githubusercontent.com/bavanchun/Typeburn/main/install.sh | sh\n  go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest\n",
 			result.Latest, currentVer, result.ReleaseURL,
 		)
 	default:

--- a/internal/cli/cmd_version_test.go
+++ b/internal/cli/cmd_version_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bavanchun/Typeburn/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
 )
 
 func stubCheck(result *update.Result, err error) func(ctx context.Context, ver string, force bool) (*update.Result, error) {
@@ -180,5 +180,27 @@ func TestVersionCheckUpdate_JSONWrapper(t *testing.T) {
 	}
 	if _, ok := got["update_check"]; !ok {
 		t.Error("wrapper missing 'update_check' key")
+	}
+}
+
+func TestVersionCheckUpdate_V2InstallAdvice(t *testing.T) {
+	orig := getCheckFn()
+	setCheckFn(stubCheck(&update.Result{
+		Current:          "v2.5.0",
+		Latest:           "v2.5.1",
+		UpgradeAvailable: true,
+		ReleaseURL:       "https://github.com/bavanchun/Typeburn/releases/tag/v2.5.1",
+		CheckedAt:        time.Now().UTC(),
+	}, nil))
+	defer setCheckFn(orig)
+
+	var out bytes.Buffer
+	if err := versionRoot(t, &out, &bytes.Buffer{}, "version", "--check-update"); err != nil {
+		t.Fatalf("version --check-update: %v", err)
+	}
+	body := out.String()
+	const wantCmd = "go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest"
+	if !strings.Contains(body, wantCmd) {
+		t.Errorf("expected v2 install advice %q in output, got:\n%s", wantCmd, body)
 	}
 }

--- a/internal/cli/metric_output.go
+++ b/internal/cli/metric_output.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/bavanchun/Typeburn/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
 )
 
 // keyMissTableRows caps how many most_missed rows the table view shows; the

--- a/internal/cli/metric_output_test.go
+++ b/internal/cli/metric_output_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
 )
 
 func sampleResult() metrics.Result {

--- a/internal/cli/notui/render.go
+++ b/internal/cli/notui/render.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/bavanchun/Typeburn/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
 )
 
 func RenderPrompt(w io.Writer, target string) {

--- a/internal/cli/notui/runner.go
+++ b/internal/cli/notui/runner.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/runner"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/runner"
 )
 
 type ResultWriter func(io.Writer, metrics.Result) error

--- a/internal/cli/notui/runner_test.go
+++ b/internal/cli/notui/runner_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/runner"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/runner"
 )
 
 // testClock is a deterministic monotonic clock for tests.

--- a/internal/cli/punctuation_numbers_config_test.go
+++ b/internal/cli/punctuation_numbers_config_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 func TestPunctuationNumbersSetGet(t *testing.T) {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -9,12 +9,12 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/app"
-	"github.com/bavanchun/Typeburn/internal/codetext"
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/storage"
-	"github.com/bavanchun/Typeburn/internal/update"
-	"github.com/bavanchun/Typeburn/internal/version"
+	"github.com/bavanchun/Typeburn/v2/internal/app"
+	"github.com/bavanchun/Typeburn/v2/internal/codetext"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/version"
 )
 
 type env struct {

--- a/internal/cli/strict_mode_config_test.go
+++ b/internal/cli/strict_mode_config_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 func TestStrictModeSetGet(t *testing.T) {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -3,7 +3,7 @@
 // types to disk.
 package config
 
-import "github.com/bavanchun/Typeburn/internal/mode"
+import "github.com/bavanchun/Typeburn/v2/internal/mode"
 
 // Mode identifies a test mode. Stored as a string for forward-compatible JSON.
 type Mode = mode.Mode

--- a/internal/config/theme_available_sync_test.go
+++ b/internal/config/theme_available_sync_test.go
@@ -3,8 +3,8 @@ package config_test
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // TestThemeAvailableStaysInSyncWithNormalize guards the intentional

--- a/internal/metrics/afk_trim.go
+++ b/internal/metrics/afk_trim.go
@@ -1,8 +1,8 @@
 package metrics
 
 import (
-	"github.com/bavanchun/Typeburn/internal/mode"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 const afkThresholdMs int64 = 7000 // strictly greater than this triggers AFK trim

--- a/internal/metrics/afk_trim_test.go
+++ b/internal/metrics/afk_trim_test.go
@@ -3,9 +3,9 @@ package metrics_test
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // TestAFKTrim validates AFK trailing-trim behaviour.

--- a/internal/metrics/compute.go
+++ b/internal/metrics/compute.go
@@ -1,8 +1,8 @@
 package metrics
 
 import (
-	"github.com/bavanchun/Typeburn/internal/mode"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // Result holds all derived metrics after a completed test.

--- a/internal/metrics/compute_test.go
+++ b/internal/metrics/compute_test.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // buildLog is a helper that runs an Engine and returns its keystroke log.

--- a/internal/metrics/consistency_test.go
+++ b/internal/metrics/consistency_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
 )
 
 // TestConsistency validates the consistency formula: 100*tanh(1-CV), CV=stddev/mean.

--- a/internal/metrics/key_heatmap.go
+++ b/internal/metrics/key_heatmap.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"unicode"
 
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // KeyMiss is a per-key fumble tally for one case-folded target rune.

--- a/internal/metrics/key_heatmap_test.go
+++ b/internal/metrics/key_heatmap_test.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // ks is a terse Keystroke constructor for table-driven heatmap tests.

--- a/internal/metrics/keystroke_accuracy_test.go
+++ b/internal/metrics/keystroke_accuracy_test.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 func TestKeystrokeAccuracy(t *testing.T) {

--- a/internal/metrics/live_wpm.go
+++ b/internal/metrics/live_wpm.go
@@ -1,6 +1,6 @@
 package metrics
 
-import "github.com/bavanchun/Typeburn/internal/typing"
+import "github.com/bavanchun/Typeburn/v2/internal/typing"
 
 // LiveWPM estimates current net WPM from forward keystrokes in the log.
 // Returns 0 when elapsedMs < 500ms (too noisy) or the log is empty.

--- a/internal/metrics/live_wpm_test.go
+++ b/internal/metrics/live_wpm_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 func TestLiveWPM(t *testing.T) {

--- a/internal/metrics/metrics_benchmark_test.go
+++ b/internal/metrics/metrics_benchmark_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/mode"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 func benchCodeTarget(n int) string {

--- a/internal/metrics/per_second.go
+++ b/internal/metrics/per_second.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // PerSecond holds a single one-second interval's worth of typing statistics,

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -2,9 +2,9 @@
 package runner
 
 import (
-	"github.com/bavanchun/Typeburn/internal/mode"
-	"github.com/bavanchun/Typeburn/internal/typing"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 // Session is the pure typing state needed to run a test.

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 func TestNewSession_DeterministicTargets(t *testing.T) {

--- a/internal/storage/history_store.go
+++ b/internal/storage/history_store.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 // historyCapMax is the maximum number of records kept in history.json.

--- a/internal/storage/settings_store.go
+++ b/internal/storage/settings_store.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 // SettingsPath returns the absolute path to the settings file:

--- a/internal/storage/settings_store_test.go
+++ b/internal/storage/settings_store_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 // settingsEqual is a field-by-field comparison (Settings has no unexported fields).

--- a/internal/theme/names_sync_test.go
+++ b/internal/theme/names_sync_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 func TestNamesSyncWithAvailableAndSettingsNormalize(t *testing.T) {

--- a/internal/typing/char-state_test.go
+++ b/internal/typing/char-state_test.go
@@ -3,8 +3,8 @@ package typing_test
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // TestCharStates validates all 6 CharState classifications via engine.States().

--- a/internal/typing/completion.go
+++ b/internal/typing/completion.go
@@ -1,7 +1,7 @@
 package typing
 
 import (
-	"github.com/bavanchun/Typeburn/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
 )
 
 // Complete reports whether the test is finished according to the active mode.

--- a/internal/typing/completion_code_test.go
+++ b/internal/typing/completion_code_test.go
@@ -3,8 +3,8 @@ package typing_test
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // applyAll feeds every rune of s into the engine in order.

--- a/internal/typing/completion_test.go
+++ b/internal/typing/completion_test.go
@@ -3,8 +3,8 @@ package typing_test
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 func TestComplete_ModeTime(t *testing.T) {

--- a/internal/typing/engine.go
+++ b/internal/typing/engine.go
@@ -1,7 +1,7 @@
 package typing
 
 import (
-	"github.com/bavanchun/Typeburn/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
 )
 
 // Keystroke records a single typed or deleted character event.

--- a/internal/typing/engine_benchmark_test.go
+++ b/internal/typing/engine_benchmark_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/mode"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 func benchWordsTarget(n int) string {

--- a/internal/typing/engine_test.go
+++ b/internal/typing/engine_test.go
@@ -3,8 +3,8 @@ package typing_test
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // TestBackspace validates deletion and corrected-error behaviour.

--- a/internal/typing/snapshot_test.go
+++ b/internal/typing/snapshot_test.go
@@ -3,8 +3,8 @@ package typing_test
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/mode"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 func TestTypedReturnsCurrentBufferCopy(t *testing.T) {

--- a/internal/typing/strict_engine_test.go
+++ b/internal/typing/strict_engine_test.go
@@ -3,8 +3,8 @@ package typing_test
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 func TestStrictEngine(t *testing.T) {

--- a/internal/ui/anim_bench_test.go
+++ b/internal/ui/anim_bench_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // benchTypingState builds a realistic mid-test word-stream: a 100-word target

--- a/internal/ui/ascii-logo.go
+++ b/internal/ui/ascii-logo.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"strings"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // logoLines is the block-art ("ANSI Shadow" style) wordmark for "TYPEBURN",

--- a/internal/ui/ascii_big_digits.go
+++ b/internal/ui/ascii_big_digits.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"strings"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // digitGlyphs maps each decimal digit 0-9 to a 5-row ASCII block-art glyph.

--- a/internal/ui/caret_anim.go
+++ b/internal/ui/caret_anim.go
@@ -3,9 +3,9 @@ package ui
 import (
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/anim"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/anim"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // Caret animation timing. blinkHalfMs is half the 530ms blink cycle (the

--- a/internal/ui/caret_anim_test.go
+++ b/internal/ui/caret_anim_test.go
@@ -3,9 +3,9 @@ package ui
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // statesFromTyped builds a states slice: n0 leading Correct cells, a Current

--- a/internal/ui/celebration.go
+++ b/internal/ui/celebration.go
@@ -5,7 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // New-best celebration timing/shape. The burst rides the same frame loop as the

--- a/internal/ui/celebration_test.go
+++ b/internal/ui/celebration_test.go
@@ -6,7 +6,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 func TestCelebrationGlyphs_Width1(t *testing.T) {

--- a/internal/ui/code_stream_renderer.go
+++ b/internal/ui/code_stream_renderer.go
@@ -5,8 +5,8 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // tabVisualWidth is how many columns a literal '\t' occupies on screen. The

--- a/internal/ui/code_stream_renderer_test.go
+++ b/internal/ui/code_stream_renderer_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")

--- a/internal/ui/degraded-notice.go
+++ b/internal/ui/degraded-notice.go
@@ -5,7 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // DegradedNotice renders the "terminal too small" notice per design §4.3.

--- a/internal/ui/footer.go
+++ b/internal/ui/footer.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"strings"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // Hint is a single key+action pair rendered in the footer.

--- a/internal/ui/history_table.go
+++ b/internal/ui/history_table.go
@@ -6,8 +6,8 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/storage"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // historyColWidths defines the fixed character widths for each table column.

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -6,9 +6,9 @@ package ui
 import (
 	"time"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 // FrameTickMsg drives the self-stopping animation frame loop owned by the root

--- a/internal/ui/mode_header.go
+++ b/internal/ui/mode_header.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // progressBarWidth is the number of cells in the Quote mode progress bar.

--- a/internal/ui/mode_label_test.go
+++ b/internal/ui/mode_label_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/storage"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 func TestDisplayModeLabel(t *testing.T) {

--- a/internal/ui/nocolor_layout_invariant_test.go
+++ b/internal/ui/nocolor_layout_invariant_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // The animation system's core invariant: under NO_COLOR every animated moment is

--- a/internal/ui/persistence-notice.go
+++ b/internal/ui/persistence-notice.go
@@ -1,7 +1,7 @@
 package ui
 
 import (
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // PersistenceNotice renders a single-line, dismissible toast shown when a

--- a/internal/ui/persistence-notice_test.go
+++ b/internal/ui/persistence-notice_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 func TestPersistenceNotice_ContainsMessageAndHint(t *testing.T) {

--- a/internal/ui/phase09_polish_test.go
+++ b/internal/ui/phase09_polish_test.go
@@ -6,8 +6,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // ── Width-tier classification ────────────────────────────────────────────────

--- a/internal/ui/render_benchmark_test.go
+++ b/internal/ui/render_benchmark_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 func benchWordsTarget(n int) string {

--- a/internal/ui/result_render_helpers.go
+++ b/internal/ui/result_render_helpers.go
@@ -6,7 +6,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // heatmapMaxEntries caps how many missed keys the Result line shows.

--- a/internal/ui/screen_code_paste.go
+++ b/internal/ui/screen_code_paste.go
@@ -5,8 +5,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/codetext"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/codetext"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // CodePasteModel is the sub-model for ScreenCodePaste. It captures one

--- a/internal/ui/screen_code_paste_test.go
+++ b/internal/ui/screen_code_paste_test.go
@@ -6,7 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // emitCodePasted runs the cmd (if any) and returns the CodePastedMsg it

--- a/internal/ui/screen_code_paste_view.go
+++ b/internal/ui/screen_code_paste_view.go
@@ -5,7 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // View renders the paste screen as a centered block string. Like Home/Settings

--- a/internal/ui/screen_history.go
+++ b/internal/ui/screen_history.go
@@ -3,9 +3,9 @@ package ui
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/storage"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // visibleRows is the number of data rows shown in the history table window.

--- a/internal/ui/screen_history_test.go
+++ b/internal/ui/screen_history_test.go
@@ -7,9 +7,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/storage"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // baseHistTime is a fixed reference used to build deterministic history records.

--- a/internal/ui/screen_history_view.go
+++ b/internal/ui/screen_history_view.go
@@ -5,8 +5,8 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/storage"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // View renders the History screen. It places title, trend sparkline, table,

--- a/internal/ui/screen_home.go
+++ b/internal/ui/screen_home.go
@@ -3,9 +3,9 @@ package ui
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 // StartTestMsg is emitted by HomeModel when the user presses enter/space.

--- a/internal/ui/screen_home_code_test.go
+++ b/internal/ui/screen_home_code_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // newTestHomeCode builds a HomeModel with an empty codeText.

--- a/internal/ui/screen_home_test.go
+++ b/internal/ui/screen_home_test.go
@@ -6,9 +6,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 // helpers

--- a/internal/ui/screen_home_view.go
+++ b/internal/ui/screen_home_view.go
@@ -6,8 +6,8 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // View renders the Home screen as a centered block string. HomeModel does its

--- a/internal/ui/screen_result.go
+++ b/internal/ui/screen_result.go
@@ -3,11 +3,11 @@ package ui
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/update"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 // ResultModel is the sub-model for the post-test result screen. It renders

--- a/internal/ui/screen_result_heatmap_test.go
+++ b/internal/ui/screen_result_heatmap_test.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 // resultWithMisses builds an 80×24 ResultModel carrying a known heatmap, using

--- a/internal/ui/screen_result_hero.go
+++ b/internal/ui/screen_result_hero.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // renderHero renders the big-digit WPM block beside the acc/raw/consistency stat

--- a/internal/ui/screen_result_reveal.go
+++ b/internal/ui/screen_result_reveal.go
@@ -5,8 +5,8 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/anim"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/anim"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 const (

--- a/internal/ui/screen_result_reveal_test.go
+++ b/internal/ui/screen_result_reveal_test.go
@@ -7,7 +7,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 func TestCountUpValue_EndpointsAndMonotonic(t *testing.T) {

--- a/internal/ui/screen_result_test.go
+++ b/internal/ui/screen_result_test.go
@@ -6,11 +6,11 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/update"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/update"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 // TestResult_RestartSame_CodeModeKeepsSnippet is the regression guard for the

--- a/internal/ui/screen_result_view.go
+++ b/internal/ui/screen_result_view.go
@@ -7,7 +7,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // validSemverFooter rejects any version string that could carry ANSI/control

--- a/internal/ui/screen_settings.go
+++ b/internal/ui/screen_settings.go
@@ -3,8 +3,8 @@ package ui
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // SettingsModel is the sub-model for the Settings screen. It owns exactly

--- a/internal/ui/screen_settings_test.go
+++ b/internal/ui/screen_settings_test.go
@@ -6,8 +6,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // pressSettKey builds a KeyPressMsg using a rune constant (e.g. tea.KeyDown).

--- a/internal/ui/screen_settings_view.go
+++ b/internal/ui/screen_settings_view.go
@@ -5,7 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // View renders the Settings screen as a centered block string.

--- a/internal/ui/screen_typing.go
+++ b/internal/ui/screen_typing.go
@@ -3,11 +3,11 @@ package ui
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/runner"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/runner"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 // TypingModel is the sub-model for the typing test screen. The root app.Model

--- a/internal/ui/screen_typing_actions.go
+++ b/internal/ui/screen_typing_actions.go
@@ -3,10 +3,10 @@ package ui
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/runner"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/runner"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // restartSame resets engine and timer but keeps the same target text. It also

--- a/internal/ui/screen_typing_actions_test.go
+++ b/internal/ui/screen_typing_actions_test.go
@@ -3,8 +3,8 @@ package ui
 import (
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 func TestRestartSame_ResetsTimers(t *testing.T) {

--- a/internal/ui/screen_typing_caret.go
+++ b/internal/ui/screen_typing_caret.go
@@ -3,7 +3,7 @@ package ui
 import (
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // HasActiveAnim reports whether a fast-frame caret animation is live at nowMs:

--- a/internal/ui/screen_typing_code.go
+++ b/internal/ui/screen_typing_code.go
@@ -6,10 +6,10 @@ package ui
 // construction vs general typing engine lifecycle).
 
 import (
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/runner"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/runner"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // NewTypingCode constructs a TypingModel for ModeCode using the supplied text

--- a/internal/ui/screen_typing_input.go
+++ b/internal/ui/screen_typing_input.go
@@ -5,7 +5,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 // defaultNowFn is the production caret clock: wall-clock epoch milliseconds.

--- a/internal/ui/screen_typing_test.go
+++ b/internal/ui/screen_typing_test.go
@@ -7,9 +7,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/words"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/words"
 )
 
 // newTestTyping returns a deterministic TypingModel using seed 42 and a small

--- a/internal/ui/screen_typing_view.go
+++ b/internal/ui/screen_typing_view.go
@@ -5,7 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 // fixedOverhead is the number of non-stream rows in the typing screen layout:

--- a/internal/ui/selectable_list.go
+++ b/internal/ui/selectable_list.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"strings"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // RenderTabs renders a horizontal row of mode-selector tabs per design §5.5/§6.

--- a/internal/ui/settings_rows.go
+++ b/internal/ui/settings_rows.go
@@ -3,8 +3,8 @@ package ui
 import (
 	"fmt"
 
-	"github.com/bavanchun/Typeburn/internal/config"
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // settingRow is one row in the settings list: a label, a list of possible

--- a/internal/ui/sparkline.go
+++ b/internal/ui/sparkline.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // sparkBars are the 8 unicode block elements from lowest to highest.

--- a/internal/ui/stat_card.go
+++ b/internal/ui/stat_card.go
@@ -1,7 +1,7 @@
 package ui
 
 import (
-	"github.com/bavanchun/Typeburn/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
 )
 
 // StatCard renders a labelled stat value pair per design §5.3.

--- a/internal/ui/test_helpers_test.go
+++ b/internal/ui/test_helpers_test.go
@@ -1,6 +1,6 @@
 package ui
 
-import "github.com/bavanchun/Typeburn/internal/metrics"
+import "github.com/bavanchun/Typeburn/v2/internal/metrics"
 
 // makeTestMetricsResult returns a sample metrics.Result suitable for use
 // across multiple screen test files in this package.

--- a/internal/ui/typing_log_helpers.go
+++ b/internal/ui/typing_log_helpers.go
@@ -1,8 +1,8 @@
 package ui
 
 import (
-	"github.com/bavanchun/Typeburn/internal/metrics"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // liveWPMFromCount estimates current WPM from a forward-keystroke count.

--- a/internal/ui/word_stream_anim.go
+++ b/internal/ui/word_stream_anim.go
@@ -1,8 +1,8 @@
 package ui
 
 import (
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // streamTokenCache holds the static prefix of styled word-stream tokens so the

--- a/internal/ui/word_stream_renderer.go
+++ b/internal/ui/word_stream_renderer.go
@@ -5,8 +5,8 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/bavanchun/Typeburn/internal/theme"
-	"github.com/bavanchun/Typeburn/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/theme"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
 )
 
 // runeAtIndex returns the single display rune at index i: a target rune, then an

--- a/internal/update/cache.go
+++ b/internal/update/cache.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 const (

--- a/internal/update/selfpath.go
+++ b/internal/update/selfpath.go
@@ -70,7 +70,7 @@ func instructionFor(i Install) string {
 	case InstallHomebrew:
 		return "brew upgrade typeburn"
 	case InstallGo:
-		return "go install github.com/bavanchun/Typeburn@latest"
+		return "go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest"
 	default:
 		return ""
 	}

--- a/internal/update/selfpath_test.go
+++ b/internal/update/selfpath_test.go
@@ -25,6 +25,11 @@ func TestClassifyInstall(t *testing.T) {
 		{"go install via GOPATH", "/home/u/go/bin/Typeburn", map[string]string{"GOPATH": "/home/u/go"}, InstallGo},
 		{"go install via HOME default", "/home/u/go/bin/Typeburn", map[string]string{"HOME": "/home/u"}, InstallGo},
 		{"GOBIN set but elsewhere", "/home/u/.local/bin/typeburn", map[string]string{"GOBIN": "/home/u/devbin"}, InstallSelfManaged},
+
+		// lowercase binary name — go install ./cmd/typeburn produces "typeburn"
+		{"go install lowercase via GOBIN", "/home/u/devbin/typeburn", map[string]string{"GOBIN": "/home/u/devbin"}, InstallGo},
+		{"go install lowercase via GOPATH", "/home/u/go/bin/typeburn", map[string]string{"GOPATH": "/home/u/go"}, InstallGo},
+		{"go install lowercase via HOME default", "/home/u/go/bin/typeburn", map[string]string{"HOME": "/home/u"}, InstallGo},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -32,6 +37,13 @@ func TestClassifyInstall(t *testing.T) {
 				t.Errorf("classifyInstall(%q) = %d, want %d", c.exec, got, c.want)
 			}
 		})
+	}
+}
+
+func TestInstructionFor_V2Contract(t *testing.T) {
+	const want = "go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest"
+	if got := instructionFor(InstallGo); got != want {
+		t.Errorf("instructionFor(InstallGo) = %q, want %q", got, want)
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,10 +2,10 @@
 //
 // Version, Commit and Date are injected by the linker via
 //
-//	-ldflags "-X github.com/bavanchun/Typeburn/internal/version.Version=..."
+//	-ldflags "-X github.com/bavanchun/Typeburn/v2/internal/version.Version=..."
 //
 // (wired in the Makefile and .goreleaser.yaml). When they are not set — for
-// example after `go install github.com/bavanchun/Typeburn@v1.0.0`, which
+// example after `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@v2.5.1`, which
 // applies no ldflags — Resolve falls back to the module build information the
 // Go toolchain embeds in every binary.
 package version

--- a/internal/words/for_mode.go
+++ b/internal/words/for_mode.go
@@ -1,7 +1,7 @@
 package words
 
 import (
-	"github.com/bavanchun/Typeburn/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
 )
 
 // ForMode returns the target string for a typing test given the active mode

--- a/internal/words/for_mode_test.go
+++ b/internal/words/for_mode_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bavanchun/Typeburn/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/config"
 )
 
 // TestForMode_TimeReturnsNonEmpty verifies ForMode(ModeTime) returns a

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-01-lock-module-and-command-contract.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-01-lock-module-and-command-contract.md
@@ -52,5 +52,6 @@ tests before changing production code.
 ## Success Criteria
 
 - [x] Tests lock module path, command path, binary case, and `@latest`.
-- [x] Expected red failure is recorded; production code is untouched.
-- [x] Commit: merged into `fix(module): migrate Typeburn to the v2 module path` (ef36f6e).
+- [x] Expected red failure is recorded in
+  `reports/phase-01-red-contract-proof.md`; production code stayed at v2.5.0.
+- [x] Dedicated evidence commit: `test(release): record v2 module RED contract`.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-01-lock-module-and-command-contract.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-01-lock-module-and-command-contract.md
@@ -1,0 +1,56 @@
+---
+phase: 1
+title: "Lock module and command contract"
+status: done
+effort: "M"
+---
+
+# Phase 1: Lock module and command contract
+
+## Objective
+
+Encode the failed v2.5.0 install surface and exact lowercase replacement as
+tests before changing production code.
+
+## File Inventory
+
+| File | Action | Contract |
+|---|---|---|
+| `internal/update/selfpath_test.go` | modify | exact Go-install detection/advice |
+| `internal/cli/cmd_version_test.go` | modify | exact update command |
+| `internal/update/selfpath.go` | inspect | implementation boundary |
+| `internal/cli/cmd_version.go` | inspect | user-facing update boundary |
+
+## Implementation Steps
+
+1. Add lowercase `typeburn` classification cases as green regression coverage.
+2. Require exact advice: `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest`.
+3. Strengthen update-available coverage to assert the same command.
+4. Record the focused command/output; only exact old-command assertions are the
+   intentional red failures because filename classification is directory-based.
+
+## Function / Interface Checklist
+
+- `instructionFor(InstallGo)` owns the canonical command.
+- Go fixtures use lowercase `typeburn`; archive/Homebrew behavior is unchanged.
+- Version update output agrees exactly; repository URLs remain unchanged.
+
+## Test Matrix
+
+| Scenario | Expected |
+|---|---|
+| Go-installed lowercase binary | exact `/v2/cmd/typeburn@latest` advice |
+| Archive/Homebrew | existing advice unchanged |
+| Update available | canonical command rendered |
+| No update/error | existing behavior unchanged |
+
+## Dependencies
+
+- Input: user's confirmed `/v2` plus v2.5.1 fix-forward decision.
+- Blocks Phase 2; tests stay red until that phase.
+
+## Success Criteria
+
+- [ ] Tests lock module path, command path, binary case, and `@latest`.
+- [ ] Expected red failure is recorded; production code is untouched.
+- [ ] Commit: `test(release): lock v2 module install contract`.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-01-lock-module-and-command-contract.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-01-lock-module-and-command-contract.md
@@ -51,6 +51,6 @@ tests before changing production code.
 
 ## Success Criteria
 
-- [ ] Tests lock module path, command path, binary case, and `@latest`.
-- [ ] Expected red failure is recorded; production code is untouched.
-- [ ] Commit: `test(release): lock v2 module install contract`.
+- [x] Tests lock module path, command path, binary case, and `@latest`.
+- [x] Expected red failure is recorded; production code is untouched.
+- [x] Commit: merged into `fix(module): migrate Typeburn to the v2 module path` (ef36f6e).

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-02-migrate-module-imports-and-command-entrypoint.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-02-migrate-module-imports-and-command-entrypoint.md
@@ -1,0 +1,69 @@
+---
+phase: 2
+title: "Migrate module imports and command entrypoint"
+status: done
+effort: "L"
+---
+
+# Phase 2: Migrate module imports and command entrypoint
+
+## Objective
+
+Make the root a valid v2 module and preserve lowercase command identity across
+local install, Make, and GoReleaser.
+
+## File Inventory
+
+| Files | Action | Purpose |
+|---|---|---|
+| `go.mod` | modify | append `/v2` module suffix |
+| 133 Go files | scoped mechanical edit | rewrite 279 internal imports |
+| `main.go` → `cmd/typeburn/main.go` | move/edit | lowercase command package |
+| `Makefile` | modify | v2 linker prefix; command package |
+| `.goreleaser.yaml` | modify | main path and v2 linker symbols |
+| `internal/update/selfpath.go` | modify | canonical install advice |
+| `internal/cli/cmd_version.go` | modify | canonical upgrade advice |
+| `internal/version/version.go` | modify | accurate version example |
+
+## Implementation Steps
+
+1. Change module directive to `github.com/bavanchun/Typeburn/v2`.
+2. Rewrite only Go self-imports; reject every Go import beginning with the repo
+   prefix unless it begins with `/v2/`. Audit non-Go URLs separately.
+3. Move the sole entrypoint to `cmd/typeburn/main.go`; remove root main.
+4. Point Make and GoReleaser at `./cmd/typeburn`; update `/v2/internal/version`
+   symbols while retaining output name `typeburn` and archive targets.
+5. Implement Phase 1 runtime contracts and make focused tests green.
+6. Run `go mod tidy -diff`, `go mod verify`, module/import/root-main guards,
+   isolated local install, full quality gates, size check, and exact snapshot inspection.
+
+## Function / Interface Checklist
+
+- Move the current main body without refactoring: retain `cli.NewRoot`,
+  `fang.Execute`, `fang.WithoutVersion`, and `cli.ExitCode`; only import changes.
+- Version injection covers `Version`, `Commit`, and `Date` under `/v2`.
+- Both update advice paths use the canonical command.
+- Public CLI, config, storage, archive names, and GitHub URLs do not change.
+
+## Test Matrix
+
+| Gate | Assertion |
+|---|---|
+| Module | `go list -m` equals the `/v2` path |
+| Imports | no old `/internal/` prefix in tracked Go files |
+| Root command | no non-test root `package main`; sole command is `./cmd/typeburn` |
+| Command | isolated `go install ./cmd/typeburn` creates only `typeburn` |
+| Module hygiene | tidy diff empty, verify passes, `go.sum` unchanged absent evidence |
+| Quality | gofmt, list, build all packages, vet, race suite |
+| Release | exactly six OS/arch archives plus checksums; each archive has lowercase command and docs |
+
+## Dependencies
+
+- Requires Phase 1 red tests; supplies final paths to Phase 3.
+
+## Success Criteria
+
+- [ ] Module/import and lowercase command proofs pass.
+- [ ] Full quality, size, and snapshot gates pass.
+- [ ] Workflow files stay byte-identical unless a verified gap is documented.
+- [ ] Commit: `fix(module): migrate Typeburn to the v2 module path`.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-02-migrate-module-imports-and-command-entrypoint.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-02-migrate-module-imports-and-command-entrypoint.md
@@ -63,7 +63,7 @@ local install, Make, and GoReleaser.
 
 ## Success Criteria
 
-- [ ] Module/import and lowercase command proofs pass.
-- [ ] Full quality, size, and snapshot gates pass.
-- [ ] Workflow files stay byte-identical unless a verified gap is documented.
-- [ ] Commit: `fix(module): migrate Typeburn to the v2 module path`.
+- [x] Module/import and lowercase command proofs pass.
+- [x] Full quality, size, and snapshot gates pass.
+- [x] Workflow files stay byte-identical unless a verified gap is documented.
+- [x] Commit: `fix(module): migrate Typeburn to the v2 module path` (ef36f6e).

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-03-reconcile-install-documentation-and-release-contracts.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-03-reconcile-install-documentation-and-release-contracts.md
@@ -58,4 +58,5 @@ Align user and developer truth with `/v2/cmd/typeburn`, preserving history and r
 
 - [x] Current install, compile, run, and update instructions agree exactly.
 - [x] Historical truth and non-module GitHub URLs remain intact.
-- [x] Commit: merged into `fix(module): migrate Typeburn to the v2 module path` (ef36f6e).
+- [x] Commits: `fix(docs): correct stale install tags, roadmap truth, entrypoint
+  description, plan checkboxes` (`21beeded`) and follow-up PDR reconciliation.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-03-reconcile-install-documentation-and-release-contracts.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-03-reconcile-install-documentation-and-release-contracts.md
@@ -56,6 +56,6 @@ Align user and developer truth with `/v2/cmd/typeburn`, preserving history and r
 
 ## Success Criteria
 
-- [ ] Current install, compile, run, and update instructions agree exactly.
-- [ ] Historical truth and non-module GitHub URLs remain intact.
-- [ ] Commit: `fix(docs): publish the v2 module installation contract`.
+- [x] Current install, compile, run, and update instructions agree exactly.
+- [x] Historical truth and non-module GitHub URLs remain intact.
+- [x] Commit: merged into `fix(module): migrate Typeburn to the v2 module path` (ef36f6e).

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-03-reconcile-install-documentation-and-release-contracts.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-03-reconcile-install-documentation-and-release-contracts.md
@@ -1,0 +1,61 @@
+---
+phase: 3
+title: "Reconcile install documentation and release contracts"
+status: done
+effort: "M"
+---
+
+# Phase 3: Reconcile install documentation and release contracts
+
+## Objective
+
+Align user and developer truth with `/v2/cmd/typeburn`, preserving history and repository URLs.
+
+## File Inventory
+
+| Files | Required update |
+|---|---|
+| `README.md` | badge, install, binary case, source commands, updater advice |
+| `CLAUDE.md`, `CONTRIBUTING.md` | module and entrypoint truth |
+| `docs/code-standards.md`, `docs/codebase-summary.md` | tree and commands |
+| `docs/system-architecture.md`, `docs/cli-reference.md` | architecture and install paths |
+| `docs/project-roadmap.md` | corrective release truth |
+| `docs/project-overview-pdr.md` | modify only if live inspection proves drift |
+| `CHANGELOG.md`, `.github/release-notes.md` | exact v2.5.1 correction |
+
+## Implementation Steps
+
+1. Use `/v2/cmd/typeburn` for Go install and `./cmd/typeburn` for source commands.
+2. Replace root-main descriptions with `cmd/typeburn/main.go`.
+3. Add v2.5.1 Fixed notes; retain the v2.5.0 section and link.
+4. Target scans to README, contributor docs, current docs, and runtime update
+   code/tests; explicitly exclude historical changelog sections, plans, journals.
+5. Reject `/v2` inserted into GitHub release/raw/security URLs and positively
+   verify updater API/download URLs remain repository-root paths.
+6. Update the disposable-release runbook to state the unique v0 tag is
+   archive-only and intentionally cannot prove the `/v2` module channel.
+
+## Content Contract Checklist
+
+- Examples use `@latest` and `@v2.5.1` appropriately.
+- Installed binary is lowercase `typeburn`.
+- v2.5.0 is never described as module-channel repaired.
+
+## Test Matrix
+
+| Scan | Expected |
+|---|---|
+| Old install command | zero current actionable hits |
+| Root source command | zero stale current guidance |
+| GitHub URLs | repository-root URLs retain no `/v2` |
+| Notes/changelog | version, date, links, correction agree |
+
+## Dependencies
+
+- Requires Phase 2 paths; blocks release preparation.
+
+## Success Criteria
+
+- [ ] Current install, compile, run, and update instructions agree exactly.
+- [ ] Historical truth and non-module GitHub URLs remain intact.
+- [ ] Commit: `fix(docs): publish the v2 module installation contract`.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-04-prepare-protected-corrective-release.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-04-prepare-protected-corrective-release.md
@@ -1,0 +1,60 @@
+---
+phase: 4
+title: "Prepare protected corrective release"
+status: pending
+effort: "M"
+---
+
+# Phase 4: Prepare protected corrective release
+
+## Objective
+
+Land through protected main, freeze one release SHA, and prove archive release behavior without changing stable channels.
+
+## State Inventory
+
+| Surface | Action |
+|---|---|
+| Corrective branch and PR | required CI then squash merge |
+| `main` and `origin/main` | fetch, equalize, freeze merged SHA |
+| Disposable prerelease | exact-SHA archive and workflow proof |
+| Latest and Homebrew tap | prove isolation during prerelease |
+| User journal | hash before and after; leave untracked and unstaged |
+| Workspace artifacts | baseline all untracked files and exact stage allowlist |
+
+## Implementation Steps
+
+1. Record `git status --porcelain` and hashes for every pre-existing untracked
+   journal/plan. Define stage allowlist and assert cached names; never use `git add .`.
+   Re-run module tidy/verify and every prior gate.
+2. Push corrective branch, open PR, and wait for every required check.
+3. Squash-merge; fetch remote truth and freeze `RELEASE_SHA`.
+4. Snapshot latest release ID/tag and tap commit/Cask hash. Verify named human
+   credentials can revert the tap before any stable mutation.
+5. Publish unique `v0.0.0-rc.test.v251.<UTC>` on that SHA for archive proof
+   only. It is intentionally major-incompatible with `/v2`; never query proxy
+   or sumdb for it, never reuse it, and never use a valid v2 prerelease here.
+6. Capture workflow run ID and attempt; assert workflow name, push event, exact
+   headBranch/tag, headSha, creation window, and every required job conclusion.
+7. Verify status, body, seven assets, checksums, archive members, lowercase
+   command, and disposable-version linker banner. Compare latest/tap snapshots.
+8. Delete release and refs idempotently; prove absence and recompare snapshots.
+
+## Verification Checklist
+
+- PR is squash-merged with required checks green.
+- Frozen SHA is on `origin/main` and drives the dry-run workflow.
+- Stable latest remains v2.5.0 and tap remains unchanged.
+- Cleanup does not claim proxy or sumdb erasure.
+- Any source repair invalidates `RELEASE_SHA` and all evidence; merge a new PR,
+  freeze the new SHA, and repeat every Phase 4 gate.
+
+## Dependencies
+
+- Requires Phases 1 through 3; blocks stable tagging.
+
+## Success Criteria
+
+- [ ] Frozen merged SHA passes local and disposable archive proofs.
+- [ ] Seven assets and isolation checks pass; cleanup is verified.
+- [ ] Commit requirement is satisfied by squash merge; no synthetic commit.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-05-publish-and-verify-v2-5-1-fix-forward.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-05-publish-and-verify-v2-5-1-fix-forward.md
@@ -1,0 +1,73 @@
+---
+phase: 5
+title: "Publish and verify v2.5.1 fix-forward"
+status: pending
+effort: "L"
+---
+
+# Phase 5: Publish and verify v2.5.1 fix-forward
+
+## Objective
+
+Publish one immutable stable tag on the proven SHA, verify every channel, and reconcile the old recovery plan.
+
+## State Inventory
+
+| Surface | Required proof |
+|---|---|
+| Git tag and release | annotated v2.5.1, exact SHA/run, stable/latest |
+| Assets | seven files, checksums, archive member, banner |
+| Installer, Homebrew, updater | pinned install, Cask, latest discovery agree |
+| Go proxy and sumdb | `/v2` list/info plus exact and latest installs |
+| Plans and docs | corrective completion and old-plan supersession |
+
+## Implementation Steps
+
+1. Assert local/remote v2.5.1 absence, `origin/main` still contains frozen SHA,
+   tap rollback readiness, and clean disposable state. Create annotated tag,
+   prove `v2.5.1^{commit}=RELEASE_SHA`, push only its tag ref, then re-read remote
+   tag object and peeled commit.
+2. Capture run ID/attempt and assert workflow, push event, exact tag, head SHA,
+   creation window, and all required job conclusions.
+3. Verify latest, notes, seven assets, checksums, archive members, executable name, and version.
+4. Verify pinned installer, Homebrew Cask, and updater discovery.
+5. Poll proxy list, info, and mod endpoints within a documented deadline/backoff;
+   require v2.5.1 metadata and `/v2` module directive. Record first success time.
+6. Use two independent temp environments for exact and latest. Set proxy-only
+   `GOPROXY`, sumdb, `GOWORK=off`, `GOENV=off`; empty private/no-proxy/no-sumdb
+   variables; use distinct module, compile, and binary caches. Assert environment,
+   module resolution v2.5.1, exact executable set `{typeburn}`, runtime v2.5.1,
+   and `go version -m` command path, module path, and version.
+7. Complete metadata through a merged post-release docs PR, refetch remote truth,
+   then close the old plan using supported `completed` status with an explicit
+   Outcome/Supersession record. Leave its impossible v2.5.0 criterion unchecked.
+
+## Failure Classification
+
+| Failure | Action |
+|---|---|
+| Proxy 404 within bound | wait and retry; never retag |
+| Semantic path, name, or version failure | block completion; fix forward v2.5.2 |
+| Channel mismatch after stable mutation | block completion; fix forward v2.5.2 |
+| Pre-tag failure | repair PR and repeat Phase 4 |
+
+## Partial-Publish Containment
+
+If workflow fails after GitHub/tap mutation: capture evidence; contain a bad
+GitHub release as draft when possible; stop announcements and install checks;
+revert the exact tap commit with the verified human credential. Retry unchanged
+transient infrastructure only when content/source is identical; otherwise
+publish v2.5.2. Never move or delete the v2.5.1 tag.
+
+## Dependencies
+
+- Requires Phase 4 frozen SHA and clean disposable state.
+- Unblocks old plan only after public proxy and all channels pass.
+
+## Success Criteria
+
+- [ ] Annotated v2.5.1 and exact workflow point to frozen main SHA.
+- [ ] GitHub, installer, Homebrew, updater, assets, and banners agree.
+- [ ] Proxy-only exact and latest installs create lowercase typeburn v2.5.1.
+- [ ] v2.5.0 stays immutable; old plan closes as superseded and recovered.
+- [ ] Commit completion metadata and journal through a post-release documentation PR.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/plan.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/plan.md
@@ -1,0 +1,110 @@
+---
+title: "v2.5.1 Go module v2 fix-forward"
+description: "Repair the broken v2 Go-install channel without mutating v2.5.0."
+status: in-progress
+priority: P1
+branch: "fix/v2-module-path"
+tags: [release, go-modules, corrective]
+blockedBy: []
+blocks: [260711-1434-v2-5-consolidated-release-recovery]
+created: "2026-07-11T12:08:26.317Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# v2.5.1 Go module v2 fix-forward
+
+## Overview
+
+Publish corrective `v2.5.1` as a valid Go v2 module, preserve lowercase
+`typeburn`, reconcile install guidance, and prove the fix through the public Go
+proxy. Keep the published `v2.5.0` tag and release untouched.
+
+## Locked Decisions
+
+- Module path: `github.com/bavanchun/Typeburn/v2` at repository root.
+- Command package: `cmd/typeburn`; canonical install is
+  `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest`.
+- Repository, release, raw-content, API, and security URLs do not gain `/v2`.
+- Fix forward as `v2.5.1`; never delete, move, recreate, or rerun `v2.5.0`.
+- Keep workflow files byte-identical unless implementation proves a coverage gap.
+- No features, dependency changes, storage migration, signing, or unrelated cleanup.
+- Preserve the user's untracked punctuation/numbers journal byte-for-byte.
+
+## Phases
+
+| Phase | Name | Status |
+|---|---|---|
+| 1 | [Lock module and command contract](./phase-01-lock-module-and-command-contract.md) | Done |
+| 2 | [Migrate module imports and command entrypoint](./phase-02-migrate-module-imports-and-command-entrypoint.md) | Done |
+| 3 | [Reconcile install documentation and release contracts](./phase-03-reconcile-install-documentation-and-release-contracts.md) | Done |
+| 4 | [Prepare protected corrective release](./phase-04-prepare-protected-corrective-release.md) | Pending |
+| 5 | [Publish and verify v2.5.1 fix-forward](./phase-05-publish-and-verify-v2-5-1-fix-forward.md) | Pending |
+
+## Dependencies
+
+- Sequential: Phase 1 → 2 → 3 → 4 → 5.
+- Blocks `260711-1434-v2-5-consolidated-release-recovery`.
+- Phase 5 requires the squash-merged, CI-green SHA frozen in Phase 4.
+- Disposable archive proof and stable public-proxy proof are separate gates.
+
+## Scope Challenge
+
+**HOLD.** Minimum repair: module/import migration, command relocation,
+linker/release config, exact runtime/docs commands, regression tests, and one
+fix-forward release. Broad replacement is forbidden because valid GitHub URLs
+must not change. Five phases preserve the immutable publish boundary.
+
+## Whole-Plan Success Criteria
+
+- Module identity is `/v2`; no tracked Go file uses the old internal import prefix.
+- Local and release outputs are lowercase `typeburn` with correct v2.5.1 metadata.
+- Full format, vet, race, size, and snapshot gates pass.
+- Runtime guidance and current docs use `/v2/cmd/typeburn`; historical v2.5.0
+  facts and non-module GitHub URLs remain intact.
+- Protected PR and disposable archive release prove the exact merged SHA,
+  seven assets, checksums, latest/tap isolation, and idempotent cleanup.
+- Stable v2.5.1 succeeds across GitHub, installer, Homebrew, updater, and a clean
+  proxy-only exact and `@latest` install producing `typeburn` v2.5.1.
+- Old recovery plan closes as superseded/recovered, never as a false statement
+  that v2.5.0 passed its Go-install criterion.
+
+## Research
+
+- [Go v2 command contract](./research/go-v2-command-contract.md)
+- [Migration impact inventory](./research/migration-impact-inventory.md)
+- [Release recovery](./research/release-recovery.md)
+
+## Red Team Review
+
+- Three hostile reviews covered Go semantics, implementation/test completeness,
+  and release immutability. All evidence-backed findings were accepted.
+- Critical amendments: archive-only unique v0 disposable tag; exact public-proxy
+  environment and module metadata proof; Homebrew rollback readiness; partial
+  publish containment; exact tag/SHA/run evidence; workspace stage allowlist.
+- Precision amendments: correct moved-main invariant, tidy/verify/root-command
+  guards, exact archive matrix, scoped documentation scans, and supported
+  cross-plan completion semantics.
+- Rejected findings: none. No reviewer supplied evidence requiring reversal of
+  the user's `/v2` or v2.5.1 fix-forward decisions.
+
+## Validation Log
+
+- **Requirements:** PASS — module path, lowercase command, docs, and immutable
+  fix-forward map directly to user decisions.
+- **Architecture:** PASS — root v2 module plus `cmd/typeburn` is valid and the
+  smallest layout that preserves command identity.
+- **Implementation:** PASS — exact file groups, 279 imports/133 files, linker,
+  runtime, tests, and docs surfaces are inventoried.
+- **Testing:** PASS — red contract, module hygiene, full local gates, archive
+  workflow proof, and two clean public-proxy installs cover failure layers.
+- **Release/Security:** PASS — protected merge, tag immutability, credential
+  readiness, containment, and fix-forward boundaries are explicit.
+- **Consistency sweep:** PASS — 5 phases, 0 broken dependencies, every phase has
+  at least one commit boundary, and no success criterion depends on v2.5.0 being mutable.
+
+## Rollback Boundary
+
+Before stable tagging, repair the corrective PR. After stable mutation, never
+move `v2.5.1`; use `v2.5.2` for any further correction. Treat proxy state as
+append-only.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/plan.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/plan.md
@@ -74,6 +74,7 @@ must not change. Five phases preserve the immutable publish boundary.
 - [Go v2 command contract](./research/go-v2-command-contract.md)
 - [Migration impact inventory](./research/migration-impact-inventory.md)
 - [Release recovery](./research/release-recovery.md)
+- [Phase 1 RED contract proof](./reports/phase-01-red-contract-proof.md)
 
 ## Red Team Review
 
@@ -100,8 +101,9 @@ must not change. Five phases preserve the immutable publish boundary.
   workflow proof, and two clean public-proxy installs cover failure layers.
 - **Release/Security:** PASS — protected merge, tag immutability, credential
   readiness, containment, and fix-forward boundaries are explicit.
-- **Consistency sweep:** PASS — 5 phases, 0 broken dependencies, every phase has
-  at least one commit boundary, and no success criterion depends on v2.5.0 being mutable.
+- **Consistency sweep:** PASS after corrective proof — 5 phases, 0 broken
+  dependencies, dedicated Phase 1 evidence commit, Phase 2 migration commit,
+  Phase 3 documentation commits, and no criterion depends on mutating v2.5.0.
 
 ## Rollback Boundary
 

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/reports/deep-plan-review.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/reports/deep-plan-review.md
@@ -1,0 +1,30 @@
+# Deep Plan Review
+
+## Reviewers
+
+1. Go module and command semantics.
+2. Implementation, tests, documentation, and workspace hygiene.
+3. Release immutability, distribution recovery, and cross-plan closure.
+
+## Accepted Release-Blocking Findings
+
+- Lock disposable archive proof to a unique v0 tag that is intentionally outside
+  the `/v2` module line; forbid proxy queries and reuse.
+- Prove public proxy state with explicit list/info/mod metadata, two independent
+  no-fallback environments, executable set, runtime version, and build info.
+- Snapshot Homebrew state and verify a human rollback credential before stable mutation.
+- Define exact tag/SHA/run selection and partial-publish containment.
+- Baseline untracked artifacts and enforce an explicit staging allowlist.
+
+## Accepted Precision Findings
+
+- Preserve the current main body rather than inventing `cli.Execute()`.
+- Add tidy, verify, all-self-import, and root-main guards.
+- Distinguish six snapshot archives plus checksums from seven GitHub assets.
+- Scope current-doc scans and make overview changes evidence-dependent.
+- Complete the old plan via an explicit supersession outcome without checking
+  its impossible v2.5.0 Go-install criterion.
+
+## Result
+
+All findings are resolved in the phase files. No unresolved question remains.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/reports/phase-01-red-contract-proof.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/reports/phase-01-red-contract-proof.md
@@ -1,0 +1,29 @@
+# Phase 1 RED Contract Proof
+
+## Reproduction
+
+Reproduced on 2026-07-11 in a disposable detached worktree at the immutable
+v2.5.0 commit `758dcb8c`. Only the Phase 1 test diff from `ef36f6e3` was applied;
+production code remained at v2.5.0.
+
+```text
+go test ./internal/update ./internal/cli \
+  -run 'TestInstructionFor|TestVersionCheckUpdate_UpgradeAvailable' -count=1
+
+--- FAIL: TestInstructionFor_V2Contract
+instructionFor(InstallGo) =
+"go install github.com/bavanchun/Typeburn@latest",
+want "go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest"
+
+FAIL
+RED_TEST_EXIT=1
+```
+
+The CLI test diff also imports the future `/v2/internal/update` path, so it
+correctly cannot compile against the unmodified v2.5.0 module. The focused
+update-package failure independently proves the intended old-command mismatch.
+
+## GREEN Evidence
+
+At `ef36f6e3` and later, the focused tests and full race suite pass with the
+new module path and lowercase command contract.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/research/go-v2-command-contract.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/research/go-v2-command-contract.md
@@ -1,0 +1,20 @@
+# Go v2 Command Contract Research
+
+- Official Go guidance requires v2 module paths to end in `/v2` and all
+  intra-module imports to use that prefix.
+- `cmd/go` names a root executable after the last non-major path component, so
+  root `github.com/bavanchun/Typeburn/v2` installs as case-sensitive `Typeburn`.
+- A disposable experiment confirmed root install creates `Typeburn`, while
+  `./cmd/typeburn` creates lowercase `typeburn`.
+- Selected contract: root module `github.com/bavanchun/Typeburn/v2`, command
+  package `cmd/typeburn`, remote install `/v2/cmd/typeburn@v2.5.1`.
+- Root-level v2 module layout is valid. A physical `v2/` directory is useful for
+  parallel major maintenance but adds unnecessary corrective scope here.
+- Official sources: https://go.dev/doc/modules/major-version,
+  https://go.dev/doc/modules/gomod-ref, https://pkg.go.dev/cmd/go,
+  https://go.dev/doc/modules/publishing.
+
+## Verified Decision
+
+Move the entrypoint to `cmd/typeburn`; this is required to keep the established
+lowercase binary across Go install and release archives.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/research/migration-impact-inventory.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/research/migration-impact-inventory.md
@@ -1,0 +1,18 @@
+# Migration Impact Inventory
+
+- `go.mod` has the old module directive.
+- 279 safe old internal-import occurrences span 133 tracked Go files: app 20,
+  cli 22, config 2, metrics 12, runner 2, storage 3, theme 1, typing 9, ui 57,
+  update 1, version 1, words 2, and root main 1.
+- Root `main.go` is the only main package and moves to `cmd/typeburn/main.go`.
+- `Makefile` needs the command package and `/v2/internal/version` linker prefix.
+- `.goreleaser.yaml` needs `main: ./cmd/typeburn` and three v2 linker symbols.
+- Existing workflow `./...` commands already discover the new command; no
+  workflow change is currently justified.
+- Runtime commands occur in `internal/update/selfpath.go` and
+  `internal/cli/cmd_version.go`; both need exact regression assertions.
+- Evergreen documentation impact includes README, CLAUDE, CONTRIBUTING,
+  code standards/summary, architecture, CLI reference, overview, roadmap,
+  changelog, and release notes.
+- Repository, raw, API, release, installer, and security URLs must not be
+  mechanically changed. Only module/import/install/linker paths gain `/v2`.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/research/release-recovery.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/research/release-recovery.md
@@ -1,0 +1,20 @@
+# Release Recovery Research
+
+## Verified Current State
+
+- `main`, `origin/main`, and annotated v2.5.0 peel to
+  `758dcb8c238b6f5061c102ece009545cca7348b1`.
+- GitHub v2.5.0 is stable/latest with seven assets; release run 29149206457 passed.
+- Proxy-only install fails deterministically because the module path lacks `/v2`.
+
+## Recovery Contract
+
+- Never mutate v2.5.0. Its source cannot be repaired by rerunning the workflow.
+- Merge correction through protected main, freeze one SHA, and validate archive
+  production with a disposable prerelease before stable tagging.
+- A disposable archive release cannot prove stable proxy ingestion. Exhaustive
+  local module/command checks are the pre-tag guard; clean exact and latest
+  proxy-only installs are mandatory post-publish gates.
+- A transient 404 within the ingestion bound permits retry. A semantic mismatch
+  after publication requires v2.5.2, never a moved v2.5.1 tag.
+- The old plan must close as superseded/recovered only after v2.5.1 succeeds.


### PR DESCRIPTION
## Summary

- migrate module identity and internal imports to github.com/bavanchun/Typeburn/v2
- move command entrypoint to cmd/typeburn so go install creates lowercase typeburn
- update linker paths, updater guidance, release notes, and current documentation
- preserve the immutable v2.5.0 release and prepare corrective v2.5.1

## Verification

- go mod tidy -diff
- go mod verify
- gofmt clean
- go vet ./...
- go build ./...
- go test ./... -race -count=1
- make size-check
- GoReleaser v2.15.4 snapshot: six archives and checksums verified
- local go install produces only typeburn with /v2 build info

## Release boundary

This PR does not create a stable tag. After squash merge, the merged SHA will be frozen and validated with a unique v0 archive-only disposable release before publishing immutable v2.5.1.