### PR TITLE
docs(release): record v2.5.1 completion

### DIFF
--- a/docs/journals/260711-1457-v2-5-consolidated-release-planning.md
+++ b/docs/journals/260711-1457-v2-5-consolidated-release-planning.md
@@ -1,0 +1,57 @@
+---
+date: 2026-07-11
+topic: "Typeburn v2.5.0 consolidated release planning"
+status: planned
+plan: "plans/260711-1434-v2-5-consolidated-release-recovery/plan.md"
+---
+
+# Typeburn v2.5.0 Consolidated Release Planning
+
+## Context
+
+Public stable remains `v2.4.1`. Strict Mode is merged but unreleased, while
+punctuation/numbers remains in PR #57. The session aligned code display fixes,
+documentation truth, integration, and release recovery into one deep plan.
+
+## What Happened
+
+- Accepted one consolidated `v2.5.0`; no separate or phantom `v2.6.0` release.
+- Locked Code-mode display to exact `code` in History and Result. Stored rune
+  count remains unchanged; non-empty unknown modes render raw and empty renders
+  `unknown`.
+- Defined pre-release docs truth: 8 themes, 8 persisted/CLI keys, 7 Settings UI
+  rows, stable `v2.4.1`, and all upcoming work under `Unreleased`.
+- Created a five-phase deep plan covering TDD fixes, docs reconciliation, PR #57
+  integration, release preparation, disposable publish proof, and post-release
+  verification.
+
+## Reflection
+
+The highest risks were release controls, not the small label bug. Red-team review
+found that tag publication needs a trusted-`main` ancestry gate, disposable
+prereleases must not receive `HOMEBREW_TAP_TOKEN`, and partial public publication
+needs an explicit resumable recovery matrix. Real tags remain immutable: contain
+bad output and fix forward instead of deleting or retagging `v2.5.0`.
+
+## Decisions
+
+- Extend PR #57 for code and pre-release docs; use a separate release-prep PR.
+- Require a cleaned disposable-tag run before creating the annotated stable tag.
+- Treat prerelease proof as GitHub-publish evidence only; stable Homebrew writes
+  require permission preflight and rollback readiness.
+- Keep the existing untracked punctuation/numbers journal untouched and unstaged.
+- Add no storage migration, dependency, signing, or unrelated cleanup.
+
+## Validation
+
+Deep validation checked 78 claims: 77 passed initially and one tool-availability
+failure was resolved by planning a temporary exact GoReleaser `v2.15.4` install.
+Final verification has zero remaining failures, zero unresolved contradictions,
+and zero open questions. The plan remains `pending`; no implementation, merge,
+tag, or release occurred in this session.
+
+## Next
+
+Execute the plan sequentially from Phase 1 through Phase 5, preserving protected
+`main`, exact-SHA evidence, immutable stable tags, and the documented recovery
+boundaries.

--- a/docs/journals/260711-1908-v2-5-1-go-module-fix-forward-planning.md
+++ b/docs/journals/260711-1908-v2-5-1-go-module-fix-forward-planning.md
@@ -1,0 +1,19 @@
+# v2.5.1 Go Module Fix-Forward Planning
+
+## Context
+
+The v2.5.0 GitHub release succeeded, but public Go installation failed because
+its module directive did not match major version 2. The release is immutable,
+so recovery requires v2.5.1.
+
+## Decisions
+
+- Migrate the root module to `github.com/bavanchun/Typeburn/v2`.
+- Move the command to `cmd/typeburn` so Go install preserves lowercase `typeburn`.
+- Update only module/import/install/linker paths; retain repository URLs.
+- Publish through protected main and fix forward; never retag v2.5.0.
+- Treat public proxy-only installation as a hard post-publish gate.
+
+## Plan
+
+See `plans/260711-1908-v2-5-1-go-module-v2-fix-forward/plan.md` for the five-phase implementation and release sequence.

--- a/docs/journals/260711-2310-v2-5-1-go-module-fix-forward-release.md
+++ b/docs/journals/260711-2310-v2-5-1-go-module-fix-forward-release.md
@@ -1,0 +1,46 @@
+---
+title: Typeburn v2.5.1 Go Module Fix-Forward Release
+date: 2026-07-11
+status: complete
+release: v2.5.1
+---
+
+# Typeburn v2.5.1 Go Module Fix-Forward Release
+
+## Context
+
+The immutable `v2.5.0` release shipped working archives but exposed an invalid Go v2 install path. The corrective release migrated the module to `github.com/bavanchun/Typeburn/v2`, moved the command entrypoint to `cmd/typeburn`, and preserved the lowercase `typeburn` executable across all install channels.
+
+## What Happened
+
+- PR [#59](https://github.com/bavanchun/Typeburn/pull/59) merged into `main` as `8307ee6c9384dceb27aaa639bdac980b43906e0b`.
+- Disposable release run [29158988295](https://github.com/bavanchun/Typeburn/actions/runs/29158988295) completed successfully from the merge SHA.
+- Immutable release run [29159099750](https://github.com/bavanchun/Typeburn/actions/runs/29159099750) published stable `v2.5.1` successfully.
+- The release contains checksums plus six Darwin, Linux, and Windows archives for amd64 and arm64.
+
+## Verification Evidence
+
+- Public Go proxy exact lookup and `@latest` both resolve `v2.5.1` to `8307ee6c`.
+- `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@v2.5.1` resolves through the public module channel and installs lowercase `typeburn`.
+- The installer resolves and verifies the `v2.5.1` release archive.
+- Homebrew cask now declares version `2.5.1` with release-specific hashes for all supported macOS and Linux architectures.
+- The updater discovers `v2.5.1` as the latest stable release and preserves package-manager guidance.
+
+## Reflection
+
+Release archives alone were insufficient proof of a healthy Go release. A major-version module must be validated through the public proxy, exact and latest queries, installed command name, and binary build metadata. Disposable release execution caught packaging risk before the immutable tag was published.
+
+## Decisions
+
+- Keep `v2.5.0` immutable; repair the distribution contract only through `v2.5.1`.
+- Use `/v2` only for Go module and import paths; GitHub repository, raw-content, and release URLs remain unchanged.
+- Keep `cmd/typeburn` as the canonical Go command path so `go install` produces the established lowercase binary name.
+- Treat release tags and published assets as immutable. Any future defect receives another fix-forward version.
+
+## Outcome
+
+The corrective release is complete. GitHub Release, public Go proxy, installer, Homebrew, and updater all converge on `v2.5.1` at merge SHA `8307ee6c`.
+
+## Next Steps
+
+None. No unresolved questions.

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -17,11 +17,11 @@ and a scriptable v2 CLI.
 
 ## Current Product State
 
-**Public stable release:** `v2.5.0` (2026-07-11). Its GitHub release, archives,
-installer, Homebrew cask, and updater shipped successfully, but its Go module
-channel is invalid because the source module path lacks the required `/v2`
-suffix. Corrective `v2.5.1` is in progress to migrate the module path and
-restore proxy-only `go install` without mutating the published v2.5.0 tag.
+**Public stable release:** `v2.5.1` (2026-07-11). This corrective release
+migrated the module to `github.com/bavanchun/Typeburn/v2` and restored
+proxy-only `go install`. Protected merge, release publication, and public proxy
+validation completed successfully. The published `v2.5.0` tag remains
+immutable; its broken Go-module channel was fixed forward by `v2.5.1`.
 
 - **Themes:** `default`, `mono`, `solarized-dark`, `solarized-light`,
   `dracula`, `nord`, `gruvbox-dark`, `gruvbox-light`. `mono` is a grayscale
@@ -138,7 +138,8 @@ restore proxy-only `go install` without mutating the published v2.5.0 tag.
 
 ## Development Status
 
-`v2.5.0` is the publicly released stable version. Strict typing and the
-punctuation/numbers toggles are shipped. Corrective `v2.5.1` is pending the
-protected merge and release gates needed to restore the Go module channel with
-`github.com/bavanchun/Typeburn/v2` and a lowercase `typeburn` command.
+`v2.5.1` is the publicly released stable version. Strict typing and the
+punctuation/numbers toggles shipped in `v2.5.0`; the immutable release's broken
+Go-module channel was fixed forward in `v2.5.1`. The `/v2` module path,
+lowercase `typeburn` command, protected merge, release gates, and public proxy
+verification are complete.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -4,9 +4,9 @@
 
 ## Current Release State
 
-**Public stable:** `v2.5.0` (2026-07-11). **In-progress:** corrective
-`v2.5.1` migrating Go module to `/v2` path; Phases 1–3 complete, pending
-protected merge and stable tag.
+**Public stable:** `v2.5.1` (2026-07-11). The corrective release migrated the
+Go module to its required `/v2` path and restored proxy-only `go install`.
+Protected merge, release publication, and public proxy validation are complete.
 
 ---
 
@@ -261,11 +261,14 @@ protected merge and stable tag.
   Settings toggles add punctuation/capitalization and numeric tokens to
   Words/Time generation while leaving Quote and Code unchanged.
   Ship date: 2026-07-11.
-- ⏳ **v2.5.1 (Corrective release):** Migrated Go module path to
+- ✅ **v2.5.1 (Corrective release):** Migrated Go module path to
   `github.com/bavanchun/Typeburn/v2` with entrypoint moved from root `main.go`
   to `cmd/typeburn/main.go` so `go install .../v2/cmd/typeburn@latest` produces
   a lowercase `typeburn` binary. All documentation reconciled with the `/v2`
-  module path. Phases 1–3 complete; pending protected merge and stable tag.
+  module path. The protected merge, immutable release, and public Go proxy
+  checks completed successfully. The published `v2.5.0` tag remains immutable;
+  its broken Go-module install channel was fixed forward by `v2.5.1`.
+  Ship date: 2026-07-11.
 
 
 ### Next (Optional)
@@ -302,12 +305,12 @@ the remaining entries are historical planning ideas, not the current roadmap.
 
 ## Conclusion
 
-**Typeburn v2.5.0 is the current public stable release.** Post-1.0 work has
+**Typeburn v2.5.1 is the current public stable release.** Post-1.0 work has
 been additive or corrective: v2.0.0 added a professional scriptable CLI,
 v2.1.x added opt-in update checks plus audited defect cleanup, v2.2.0 added
 per-key error heatmaps, v2.3.0 added the self-update command, v2.4.0/v2.4.1
 added update UX and animations, and v2.5.0 added Strict typing and
-punctuation/numbers toggles. v2.5.1 is a corrective release migrating the Go
-module path to `/v2`.
+punctuation/numbers toggles. v2.5.1 fixed forward the immutable v2.5.0 Go
+module-channel defect by migrating the module path to `/v2`.
 
 M1 (timer re-arm) and M2 (new-best precision) — the identified correctness bugs — were fixed in v1.0 (d6369de) and v1.0.1 respectively. v1.4.0 fixed a Settings live-apply bug (changes were persisted but not applied in-session) and improved the wide-terminal typing layout. Remaining backlog is additive or cosmetic.

--- a/plans/260711-1434-v2-5-consolidated-release-recovery/phase-01-code-mode-display-and-best-marker-tdd.md
+++ b/plans/260711-1434-v2-5-consolidated-release-recovery/phase-01-code-mode-display-and-best-marker-tdd.md
@@ -1,0 +1,159 @@
+---
+phase: 1
+title: Code Mode Display and Best Marker TDD
+status: completed
+priority: P1
+effort: 2h
+dependencies: []
+---
+
+# Phase 1: Code Mode Display and Best Marker TDD
+
+## Overview
+
+Write regressions first, then replace two default-to-Quote formatters with one
+UI formatter. Align History ★ rendering with the existing Code/Strict
+personal-best exclusion without changing stored records or JSON.
+
+## Context Links
+
+- Plan: [plan.md](./plan.md)
+- Research: [Code/display research](./research/code-mode-display-and-best-marker.md)
+- Bug sources: `internal/ui/history_table.go`, `internal/ui/result_render_helpers.go`
+
+## Requirements
+
+### Functional
+
+- `time/30` → `time 30`; `words/50` → `words 50`.
+- Quote ignores length and renders `quote`; Code ignores rune count and renders `code`.
+- Non-empty unknown mode renders its raw identifier; empty renders `unknown`.
+- Code and Strict history rows never display ★; normal eligible ties keep current behavior.
+
+### Non-functional
+
+- No storage schema, history migration, new dependency, or target-generation change.
+- One canonical formatter serves current History and Result paths; future reuse is allowed.
+- Keep touched Go files under 200 LOC; add focused test files instead of growing
+  existing oversized screen test files.
+
+## Architecture
+
+`displayModeLabel(mode string, length int)` lives in `internal/ui` because it is
+presentation logic and History owns forward-compatible raw string modes. Result
+converts `config.Mode` to string. Storage exposes one eligibility predicate used
+by `IsNewBest`, bucket aggregation, and History row rendering so the ★ contract
+cannot drift between result celebration and history.
+
+### Dependency Map
+
+```text
+storage.Record.Mode/Strict
+  ├─> storage.EligibleForBest ─> IsNewBest
+  └─> History.View ─> EligibleForBest + BestWPMPerBucket ─> renderHistoryRow
+
+Result config.Mode ─┐
+                    ├─> ui.displayModeLabel
+History raw mode ───┘
+```
+
+## File Inventory
+
+| Action | File | Change | Test impact |
+|---|---|---|---|
+| Create | `internal/ui/mode_label.go` | Shared explicit formatter | Unit contract |
+| Create | `internal/ui/mode_label_test.go` | Formatter + History/Result regressions | New coverage |
+| Modify | `internal/ui/history_table.go` | Use shared helper; delete duplicate | History label |
+| Modify | `internal/ui/result_render_helpers.go` | Delete duplicate helper | Result label |
+| Modify | `internal/ui/screen_result_view.go` | Call shared helper | Result meta |
+| Modify | `internal/ui/screen_history_view.go` | Gate stars by eligibility | Code/Strict stars |
+| Modify | `internal/storage/new_best.go` | Central eligibility helper; filter buckets | PB consistency |
+| Create | `internal/storage/best_eligibility_test.go` | Code/Strict/normal eligibility | Storage contract |
+
+## Function and Interface Checklist
+
+- [ ] Add `displayModeLabel(string, int) string` with explicit known cases.
+- [ ] Replace `modeLabel` caller and remove old definition.
+- [ ] Replace `modeMetaLabel` caller and remove old definition.
+- [ ] Add `storage.EligibleForBest(Record) bool`; reuse in `IsNewBest`.
+- [ ] Make `BestWPMPerBucket` ignore ineligible records.
+- [ ] Make `IsNewBest` ignore ineligible historical records as well as candidates.
+- [ ] Require eligibility before History compares row WPM with bucket best.
+- [ ] Verify `Record`, JSON tags, `buildRecord`, and best bucket keys remain unchanged.
+
+## Tests Before
+
+1. Add the formatter table and confirm Code/unknown rows fail against current code.
+2. Add History Code and Result Code rendering tests; assert bounded metadata,
+   not raw ANSI sequences.
+3. Add History tests proving Code and Strict rows have no ★ while eligible
+   Time/Words/Quote behavior remains.
+4. Add a normal-candidate regression where a faster historical Strict/Code run
+   must not suppress a valid eligible PB.
+5. Add storage eligibility/bucket tests before changing implementation.
+
+## Test Scenario Matrix
+
+| Priority | Scenario | Expected |
+|---|---|---|
+| Critical | Result `ModeCode` | `· code · english`, never Quote |
+| Critical | History Code record with `Length=142` | `code`, no rune count, no ★ |
+| Critical | Strict Time record faster than normal | Strict row has no ★ |
+| Critical | Faster historical Strict/Code then normal candidate | Ineligible history cannot suppress PB |
+| High | Time 30 / Words 50 / Quote | Existing labels unchanged |
+| High | Unknown `custom` / empty mode | `custom` / `unknown` |
+| High | Eligible tied normal records | History marks co-record holders; Result celebrates only strict improvement |
+| Medium | Time/Words length 0 | Deterministic `time 0` / `words 0` |
+
+## Refactor
+
+1. Implement the shared formatter.
+2. Rewire both screen paths and remove duplicate helpers.
+3. Centralize best eligibility and reuse it in result/history best paths.
+4. Keep comments domain-based; do not mention plan phases or finding IDs.
+
+## Tests After and Regression Gate
+
+```sh
+go test ./internal/ui ./internal/storage ./internal/app -count=1
+go test ./... -race -count=1
+make lint
+make size-check
+```
+
+## Implementation Steps
+
+1. Record baseline test results/workspace status and SHA-256 + metadata for the
+   untracked journal without printing its contents.
+2. Write failing tests from the matrix.
+3. Implement formatter and eligibility changes.
+4. Search for stale symbols: old formatter names must have zero matches.
+5. Run focused and full gates; inspect rendered substrings manually.
+6. Stage only explicit Phase 1 paths; never `git add -A`.
+
+## Success Criteria
+
+- [ ] All matrix cases pass.
+- [ ] Exactly one canonical mode-label formatter serves both current display paths.
+- [ ] Code/Strict ★ contract matches README and `IsNewBest` semantics.
+- [ ] Storage JSON and public CLI output shapes are byte-compatible.
+- [ ] Full gates green; journal remains untouched/untracked.
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Unknown modes still lie as Quote | Corrupt display meaning | Raw fallback test |
+| Ineligible row equals eligible best | False ★ despite bucket filter | Row-level eligibility guard |
+| Large test files grow further | Violates repo convention | New focused test files |
+| Accidental PB/schema redesign | Scope and compatibility risk | Read-only boundary checklist |
+
+## Security Considerations
+
+Unknown mode values originate from local JSON. Preserve current rendering model;
+do not add sanitization or schema policy without a separate threat model. Accepted
+risk: a hand-edited long/control-character mode ID can disturb terminal layout.
+
+## Unresolved Questions
+
+None.

--- a/plans/260711-1434-v2-5-consolidated-release-recovery/phase-02-pre-release-documentation-truth.md
+++ b/plans/260711-1434-v2-5-consolidated-release-recovery/phase-02-pre-release-documentation-truth.md
@@ -1,0 +1,146 @@
+---
+phase: 2
+title: Pre-Release Documentation Truth
+status: completed
+priority: P1
+effort: 3h
+dependencies:
+  - 1
+---
+
+# Phase 2: Pre-Release Documentation Truth
+
+## Overview
+
+Reconcile evergreen docs and CHANGELOG with runtime and remote truth while the
+release is still pending. Expand PR #57 with the verified code/docs scope;
+leave `.github/release-notes.md` at the latest published `v2.4.1`.
+
+## Context Links
+
+- Plan: [plan.md](./plan.md)
+- Research: [Documentation truth](./research/documentation-and-release-truth.md)
+- Runtime authorities: `internal/theme/theme.go`, `internal/config/settings.go`,
+  `internal/ui/settings_rows.go`, `internal/cli/cmd_config.go`
+
+## Requirements
+
+- Document 8 selectable themes and describe `mono` as grayscale color.
+- Describe `NO_COLOR` separately as attribute-only rendering.
+- Document 8 persisted/CLI keys vs 7 TUI Settings rows; `update_check` is CLI-only.
+- Correct current architecture, CLI, runner and screen descriptions.
+- State public stable `v2.4.1`; combined `v2.5.0` is upcoming/unreleased.
+- Move premature Strict `v2.5.0` CHANGELOG section back under `Unreleased`, add
+  punctuation/numbers and Code-label/best-marker fixes, and compare from v2.4.1.
+- Do not edit release notes or any historical journal.
+
+## Architecture
+
+Use a three-state documentation model:
+
+```text
+Integration: stable v2.4.1; v2.5.0 content under Unreleased
+Release prep: cut v2.5.0 section + exact release-notes artifact
+Published: remote tag/release/workflow evidence proves v2.5.0
+```
+
+Evergreen docs derive names/fields from code authorities. Historical v1 sections
+remain historical; avoid blind global replacements.
+
+### Dependency Map
+
+```text
+Phase 1 verified behavior ─> docs/CHANGELOG fixed behavior
+runtime theme/config/UI ─> evergreen docs
+remote v2.4.1 truth ─> pre-release roadmap state
+Phase 2 complete ─> PR #57 merge gate
+```
+
+## File Inventory
+
+| Action | File | Required reconciliation | Authority |
+|---|---|---|---|
+| Modify | `README.md` | 8 themes; mono vs NO_COLOR | `theme.go`, `mono-theme.go` |
+| Modify | `docs/cli-reference.md` | 8 keys, values/defaults/scope | `cmd_config.go`, `settings.go` |
+| Modify | `docs/system-architecture.md` | Full Settings schema and surfaces | runtime structs |
+| Modify | `docs/codebase-summary.md` | 7 rows/8 keys, themes, runner signature | runtime packages |
+| Modify | `docs/project-overview-pdr.md` | Current 6 screens/4 modes/settings/themes | app/UI/theme |
+| Modify | `docs/project-roadmap.md` | Combined upcoming v2.5; no phantom v2.6 | remote tags/releases |
+| Modify | `CHANGELOG.md` | Restore Unreleased truth | release policy |
+| Modify | `internal/ui/settings_rows.go` | Correct stale source comments only | current rows/themes |
+| Modify | `internal/ui/screen_settings.go` | Correct selection-range comment only | current row constants |
+| Modify | `internal/ui/screen_settings_view.go` | Correct row-count comment only | current rows |
+| No change | `.github/release-notes.md` | Must remain v2.4.1 | latest release |
+| Exclude | `docs/journals/**` | Historical/immutable; user journal untouched | scope decision |
+
+## Function and Interface Checklist
+
+- [ ] Verify `theme.Available()` contains eight exact names.
+- [ ] Verify `config.Settings` and CLI expose eight persisted keys.
+- [ ] Verify Settings screen exposes seven rows and omits `update_check`.
+- [ ] Verify CLI accepts Code default mode although TUI row cycles three modes.
+- [ ] Verify runner docs use current strict/punctuation/numbers signature.
+- [ ] Keep release notes unchanged in integration PR.
+
+## Test Scenario Matrix
+
+| Priority | Validation | Expected |
+|---|---|---|
+| Critical | Roadmap/CHANGELOG release state | No shipped v2.5/v2.6 claim; Unreleased from v2.4.1 |
+| Critical | Journal path diff/status | No content/staging change |
+| High | `typeburn config list --json` | Exactly 8 keys |
+| High | Theme authority vs docs | Eight names; mono grayscale; NO_COLOR attribute-only |
+| High | TUI settings docs | Seven named rows; CLI-only update check explicit |
+| Medium | Historical v1 prose | Preserved or clearly labelled historical |
+
+## Implementation Steps
+
+1. Capture code authority outputs and remote release truth in command output.
+2. Update named evergreen documents; avoid global count-only replacement.
+3. Normalize CHANGELOG to one honest `Unreleased` section.
+4. Correct source comments without changing behavior.
+5. Run docs drift searches excluding `docs/journals/**` and manually classify
+   legitimate historical release text.
+6. Run focused package tests plus full gates.
+7. Stage explicit files only; assert release notes and journal are unstaged.
+8. End when code/docs commits are pushed; Phase 3 exclusively owns PR metadata,
+   final checks, review and merge readiness.
+
+## Validation Commands
+
+```sh
+go test ./internal/config ./internal/cli ./internal/theme ./internal/ui -count=1
+go run . config list --json
+rg -n 'v2\.6\.0.*(stable|current|shipped)|mono.*attribute-only|4 settings only' \
+  README.md CHANGELOG.md docs --glob '!docs/journals/**'
+git diff -- .github/release-notes.md
+make lint && make test-race && make size-check
+```
+
+## Success Criteria
+
+- [ ] Every named drift is reconciled against a code authority.
+- [ ] Pre-release docs cannot be mistaken for a published v2.5/v2.6 release.
+- [ ] CHANGELOG has Strict, punctuation/numbers, Code label and marker fixes under Unreleased.
+- [ ] `.github/release-notes.md` remains the v2.4.1 artifact.
+- [ ] Code/docs changes are pushed and ready for Phase 3 PR reconciliation.
+- [ ] Journal remains untouched and untracked.
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Calling mono attribute-only | User-facing false docs | Separate grayscale and NO_COLOR contracts |
+| Blindly replacing historical v1 facts | Corrupt release history | Manual section classification |
+| Updating release notes early | Latest-release artifact lies | Hard no-change assertion |
+| Counts drift again | Repeat debt | Named lists plus authority links |
+| Untracked journal content changes invisibly to git diff | User data modified | Baseline SHA-256 + untracked assertion |
+
+## Security Considerations
+
+Documentation must retain the unsigned-release trust boundary. Do not imply
+checksums protect against a compromised release host.
+
+## Unresolved Questions
+
+None.

--- a/plans/260711-1434-v2-5-consolidated-release-recovery/phase-03-pr-57-integration-and-main-verification.md
+++ b/plans/260711-1434-v2-5-consolidated-release-recovery/phase-03-pr-57-integration-and-main-verification.md
@@ -1,0 +1,133 @@
+---
+phase: 3
+title: PR 57 Integration and Main Verification
+status: completed
+priority: P1
+effort: 1h
+dependencies:
+  - 2
+---
+
+# Phase 3: PR 57 Integration and Main Verification
+
+## Overview
+
+Prove PR #57 is current, reviewable, complete and CI-green; squash-merge it to
+protected `main`, then verify remote main CI and freeze the feature integration
+SHA. Fix the review-discovered Code-default Settings panic before the merge. No
+release metadata is cut in this phase.
+
+## Context Links
+
+- Plan: [plan.md](./plan.md)
+- Research: [Release flow](./research/release-flow.md)
+- PR: `https://github.com/bavanchun/Typeburn/pull/57`
+
+## Requirements
+
+- Existing PR #57 is extended; do not replace it or force-push reviewed history.
+- A persisted `default_mode=code` must render Settings safely with an explicit
+  no-length value; add a regression test before merge.
+- Satisfy live branch-protection requirements; resolve actionable conversations.
+- Merge only via squash; branch auto-delete; never push directly to main.
+- Verify main by remote SHA and exact workflow run, not local assumptions.
+- Preserve journal as the only unrelated untracked file.
+
+## Architecture
+
+```text
+feature branch + explicit commits
+  ─> PR #57 required checks/review
+  ─> squash merge protected main
+  ─> origin/main CI success
+  ─> FEATURE_SHA evidence
+  ─> release-prep branch may begin
+```
+
+### Dependency Map
+
+- Requires Phase 1 behavior/tests and Phase 2 truth docs on PR #57.
+- Blocks release-prep branch creation.
+- Any post-review code change resets required check evidence.
+
+## File Inventory
+
+| Action | Surface | Expected state |
+|---|---|---|
+| Modify | `internal/ui/settings_rows.go`, `internal/ui/screen_settings.go`, `internal/ui/screen_settings_test.go` | Code default has a safe no-length Settings row and regression test |
+| Modify | `docs/cli-reference.md`, `docs/system-architecture.md`, `docs/project-overview-pdr.md`, `docs/codebase-summary.md` | Explain how the three-choice TUI represents a persisted Code default |
+| External update | PR #57 title/body | Consolidated v2.5 scope and gate evidence |
+| External mutation | GitHub merge | Squash merge after checks/reviews |
+| Local ref update | `main`, `origin/main` | Fast-forward to squash SHA |
+
+## Function and Interface Checklist
+
+- [ ] Review complete PR diff, including shared formatter and best eligibility callers.
+- [ ] Verify the Code-default Settings regression covers the CLI-persisted mode.
+- [ ] Confirm no storage schema, dependency, workflow or release-note change slipped in.
+- [ ] Confirm required branch-protection checks by name and conclusion.
+- [ ] Confirm PR merge commit equals updated `origin/main`.
+
+## Verification Matrix
+
+| Priority | Gate | Expected |
+|---|---|---|
+| Critical | `gh pr view 57` | OPEN/CLEAN/MERGEABLE before merge; MERGED after |
+| Critical | Required checks | Ubuntu, macOS, installer/release config all success |
+| Critical | Merge method | Squash only; origin/main at squash SHA |
+| High | Main workflow | Exact push run for squash SHA succeeds |
+| High | Workspace | Journal untouched/untracked; no accidental staged path |
+| Medium | Branch deletion | Remote feature branch auto-deleted |
+
+## Implementation Steps
+
+1. Fetch/prune/tags; verify branch divergence and clean intended diff.
+2. Update PR #57 title/body with consolidated scope and evidence.
+3. Fix and test the review-discovered Code-default Settings panic, then run one
+   final local integration gate and explicit staging audit.
+4. Capture the protected journal SHA-256/metadata. Confirm the plan directory
+   and new `260711-1457-v2-5-consolidated-release-planning.md` are the only other
+   authorized untracked artifacts; both remain local until Phase 5.
+5. Watch PR checks by exact head SHA; verify actual protection requirements.
+6. Squash-merge PR #57 using repository policy.
+7. Switch to main and `git pull --ff-only origin main`.
+8. Capture `FEATURE_SHA`; select/watch the exact main CI run ID to success.
+9. Recheck tags/releases: stable must still be v2.4.1.
+
+## Command Skeleton
+
+```sh
+git fetch origin --prune --tags
+git rev-list --left-right --count origin/main...HEAD
+gh pr checks 57 -R bavanchun/Typeburn --watch
+gh pr merge 57 -R bavanchun/Typeburn --squash --delete-branch
+git switch main && git pull --ff-only origin main
+FEATURE_SHA=$(git rev-parse HEAD)
+test "$(git rev-parse origin/main)" = "$FEATURE_SHA"
+# Resolve the run by workflow + push event + headSha; persist its databaseId.
+```
+
+## Success Criteria
+
+- [ ] PR #57 merged by squash with all required checks successful.
+- [ ] Exact main CI push run succeeds for `FEATURE_SHA`.
+- [ ] No v2.5.0 tag/release exists yet.
+- [ ] Feature branch deletion and workspace/journal state verified.
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Mergeability changes while waiting | Stale approval/check evidence | Refresh immediately before merge |
+| Force-push invalidates review | Hidden history change | Normal commits or GitHub update branch |
+| Watching wrong CI run | False green | Match exact head SHA/event |
+| Local main diverges | Release from wrong commit | ff-only pull + SHA equality |
+
+## Security Considerations
+
+Branch protection and required checks are release supply-chain controls. Do not
+bypass administrators, dismiss checks, or use privileged direct pushes.
+
+## Unresolved Questions
+
+None.

--- a/plans/260711-1434-v2-5-consolidated-release-recovery/phase-04-v2-5-0-release-preparation.md
+++ b/plans/260711-1434-v2-5-consolidated-release-recovery/phase-04-v2-5-0-release-preparation.md
@@ -1,0 +1,155 @@
+---
+phase: 4
+title: v2.5.0 Release Preparation
+status: completed
+priority: P1
+effort: 2h
+dependencies:
+  - 3
+---
+
+# Phase 4: v2.5.0 Release Preparation
+
+## Overview
+
+Create a focused release-prep PR from proven main, harden the privileged tag
+workflow, cut the combined `v2.5.0` metadata with the intended stable-tag UTC
+date, merge after CI, freeze `RELEASE_SHA`, and prove local artifacts.
+
+## Context Links
+
+- Plan: [plan.md](./plan.md)
+- Research: [Release flow](./research/release-flow.md)
+- Runbook: `CONTRIBUTING.md`, `.github/workflows/release.yml`, `.goreleaser.yaml`
+
+## Requirements
+
+- Branch `chore/release-v2.5.0` from current `origin/main`.
+- Modify only `CHANGELOG.md`, `.github/release-notes.md`, and
+  `.github/workflows/release.yml` in release prep; keep `ci.yml` byte-identical.
+- Cut all combined content from Unreleased to dated v2.5.0; leave Unreleased empty.
+- Release-notes body matches the v2.5.0 CHANGELOG section exactly by defined extraction.
+- Use GoReleaser exactly v2.15.4; prove build/archive locally.
+- Any fix after SHA freeze requires a new PR and complete re-freeze/retest.
+- Tag workflow must reject commits not reachable from `origin/main` before the
+  privileged publish job.
+- Prerelease GoReleaser step must not receive `HOMEBREW_TAP_TOKEN`; stable step
+  receives it only after a non-mutating tap push-permission preflight.
+
+## Architecture
+
+Release prep is a bounded transaction. Metadata is prepared and merged only
+when Phase 5 will immediately prove/publish it. Reserve one operator and a
+four-hour release window. If dry-run cannot start within 30 minutes of prep
+merge or cannot finish within two hours, create a corrective PR restoring honest
+Unreleased state; never leave another phantom release.
+
+### Dependency Map
+
+```text
+merged FEATURE_SHA
+  ─> release-prep branch (metadata only)
+  ─> CI + squash merge
+  ─> immutable RELEASE_SHA
+  ─> exact-SHA local gates/snapshot
+  ─> Phase 5 disposable publish
+```
+
+## File Inventory
+
+| Action | File | Change | Verification |
+|---|---|---|---|
+| Modify | `CHANGELOG.md` | Cut final v2.5.0 section/date/links | Extraction diff |
+| Modify | `.github/release-notes.md` | Exact curated v2.5.0 section | Deterministic diff |
+| Modify | `.github/workflows/release.yml` | Main ancestry gate; split prerelease/stable token paths; tap permission preflight | Disposable proof |
+| Read-only | `.goreleaser.yaml` | Confirm matrix/notes/prerelease/tap | `goreleaser check` |
+| Read-only | `Makefile`, installer scripts | Run local gates | Command exit status |
+
+## Function and Interface Checklist
+
+- [ ] Strict, punctuation/numbers, Code label and marker fixes all appear once.
+- [ ] `[Unreleased]` link advances to `v2.5.0...HEAD` only in release prep.
+- [ ] `[2.5.0]` link targets the future immutable release URL.
+- [ ] Release notes omit raw git log and match curated CHANGELOG content.
+- [ ] Define extraction bytes: v2.5 heading/body through the line before the
+  next version heading, one blank line, then the `[2.5.0]` reference link.
+- [ ] Workflow and GoReleaser pins remain v2.15.4 and otherwise untouched.
+- [ ] `ci.yml` remains byte-identical per repository release constraint.
+
+## Test and Artifact Matrix
+
+| Priority | Gate | Expected |
+|---|---|---|
+| Critical | CHANGELOG vs release notes | Defined content byte-equal |
+| Critical | Tag commit outside main | Test job fails before publish receives write/PAT |
+| Critical | Disposable prerelease environment | Tap PAT absent; GitHub release path succeeds |
+| Critical | Stable tap credential preflight | Token reports push permission without mutation |
+| Critical | `RELEASE_SHA` | Equals origin/main after prep merge |
+| Critical | Snapshot assets | 6 archives + checksums with expected names |
+| Critical | Checksums | All downloaded/local assets verify |
+| High | Archive members | lowercase binary + README/LICENSE/CHANGELOG |
+| High | Native binary banner | Snapshot version + RELEASE_SHA |
+| High | Installer harness/shellcheck | Success |
+| Medium | Source tree | No feature changes in prep PR |
+
+## Implementation Steps
+
+1. Preflight release owner/window, GitHub access, tap availability, non-mutating
+   tap push permission, and human rollback credential availability.
+2. Fetch and branch from current `origin/main`; verify v2.5 tag absent.
+3. Add tag-commit ancestry gate before privileged publish; split prerelease and
+   stable GoReleaser steps so only stable receives the tap PAT.
+4. Cut CHANGELOG using the intended stable-tag UTC date and exact combined scope.
+5. Deterministically extract v2.5 heading/body plus reference link to release notes;
+   compare with `cmp -s`/`diff -u` and document newline boundaries.
+6. Install GoReleaser v2.15.4 into a temporary `GOBIN`, assert its reported
+   GitVersion, and run focused workflow/config gates with that exact binary.
+7. Push focused prep branch, open PR, watch CI, and immediately before merge
+   verify its base SHA still equals the frozen feature main SHA.
+8. Squash-merge, fast-forward main, freeze and record `RELEASE_SHA`.
+9. Re-run exact-SHA artifact matrix, `goreleaser check`, and `make snapshot`.
+10. Inspect asset count, names, members, checksum consistency and binary metadata.
+
+## Gate Commands
+
+```sh
+make lint
+make test-race
+make size-check
+make notui-noexit-check
+shellcheck install.sh scripts/test-install-sh.sh
+./scripts/test-install-sh.sh
+TOOLS_DIR=$(mktemp -d)
+GOBIN="$TOOLS_DIR" go install github.com/goreleaser/goreleaser/v2@v2.15.4
+"$TOOLS_DIR/goreleaser" --version | grep -Eq 'GitVersion:[[:space:]]+2\.15\.4'
+"$TOOLS_DIR/goreleaser" check
+PATH="$TOOLS_DIR:$PATH" make snapshot
+```
+
+## Success Criteria
+
+- [ ] Release-prep PR contains only the three approved metadata/workflow files.
+- [ ] Curated notes and CHANGELOG pass exact-content comparison.
+- [ ] Prep PR squash-merges with CI green; `RELEASE_SHA == origin/main`.
+- [ ] Local exact-SHA snapshot and all artifact gates pass.
+- [ ] No real or disposable tag remains before Phase 5 starts.
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Metadata merge without publish | Phantom release repeats | Bounded transaction + correction PR if abandoned |
+| Notes extraction differs | Wrong public release body | Byte-comparison gate |
+| Snapshot run on stale SHA | False proof | Re-run after merge/freeze |
+| Tool version drift | Different artifacts | Exact v2.15.4 assertion |
+| Prep date crosses before stable tag | False release date | New prep PR, refreeze SHA, rerun gates |
+
+## Security Considerations
+
+Snapshot runs without publish credentials. Never expose GitHub or Homebrew
+tokens locally. Prerelease receives no tap PAT; stable PAT remains scoped to
+its single step after read-only permission preflight.
+
+## Unresolved Questions
+
+None.

--- a/plans/260711-1434-v2-5-consolidated-release-recovery/phase-05-disposable-dry-run-publish-and-post-release-verification.md
+++ b/plans/260711-1434-v2-5-consolidated-release-recovery/phase-05-disposable-dry-run-publish-and-post-release-verification.md
@@ -1,0 +1,194 @@
+---
+phase: 5
+title: Disposable Dry Run Publish and Post-Release Verification
+status: completed
+priority: P1
+effort: 3h + proxy wait
+dependencies:
+  - 4
+---
+
+# Phase 5: Disposable Dry Run Publish and Post-Release Verification
+
+## Overview
+
+Prove the GitHub prerelease publish path with a unique disposable tag, capture
+evidence, clean GitHub/git refs idempotently, then create immutable `v2.5.0` on
+the same `RELEASE_SHA`. Stable-only Homebrew write remains a preflighted,
+fix-forward risk and is verified immediately after the real publish.
+
+## Context Links
+
+- Plan: [plan.md](./plan.md)
+- Research: [Release flow](./research/release-flow.md)
+- Workflows: `.github/workflows/release.yml`, `.goreleaser.yaml`
+
+## Requirements
+
+- Unique disposable tag; never reuse `v0.0.0-rc.test` names.
+- Dry-run must be prerelease, non-draft, exactly 7 assets, exact notes, valid
+  checksums, correct archive members/banners, and leave latest/tap unchanged.
+- Capture evidence before cleanup; independently delete release, remote tag and
+  local tag if present. Never claim deletion from proxy/sumdb/CDN history.
+- Real `v2.5.0` tag must be annotated, absent remotely, and peel to `RELEASE_SHA`.
+- Never delete/move/re-tag real v2.5.0 after push; fix forward to v2.5.1.
+- Verify GitHub, installer, Go module, Homebrew tap, and update discovery.
+- Publish a final docs/plan PR after remote truth succeeds: roadmap becomes
+  published v2.5.0 and this completed plan directory becomes durable.
+
+## Architecture
+
+```text
+RELEASE_SHA
+  ─> unique disposable annotated tag
+  ─> tag Release workflow + publish assertions
+  ─> evidence + complete cleanup
+  ─> immutable annotated v2.5.0 tag on same SHA
+  ─> Release workflow success
+  ─> multi-channel remote truth
+```
+
+### Dependency Map
+
+- Blocked by exact-SHA local snapshot and release-prep truth.
+- Real tag blocked by every disposable gate and cleanup assertion.
+- Post-release verification blocked by successful real Release workflow.
+- Any content correction after real tag becomes `v2.5.1`, never a moved tag.
+
+## File and External Surface Inventory
+
+| Action | Surface | Verification |
+|---|---|---|
+| Create/delete | Unique disposable git tag + GitHub prerelease | Full workflow proof |
+| Create immutable | Annotated `v2.5.0` tag/release | SHA + workflow proof |
+| Read | Release assets/checksums/body | Exact matrix |
+| Read | `bavanchun/homebrew-tap-typeburn/Casks/typeburn.rb` | Dry unchanged; stable updated |
+| Execute in temp dirs | `install.sh`, `go install` | Version/banner smoke |
+| Read | GitHub latest/update endpoint/main CI/PRs | Final remote truth |
+| Modify after publish | `docs/project-roadmap.md` | Published v2.5.0 evidence |
+| Add after publish | This plan/research directory | Durable completed artifact |
+| Add after publish | `docs/journals/260711-1457-v2-5-consolidated-release-planning.md` | Planning decision record |
+| No change | User journal and other source files | Hash/status assertion |
+
+## Function and Interface Checklist
+
+- [ ] Locate workflow runs by exact tag/head SHA, not latest run order.
+- [ ] Peel annotated tags and compare with frozen SHA.
+- [ ] Validate six platform archives plus `checksums.txt`.
+- [ ] Validate prerelease does not become `/releases/latest` or update tap.
+- [ ] Validate stable release does become latest and updates tap correctly.
+- [ ] Bound Go proxy retry to documented ingestion window; do not treat lag as corruption.
+- [ ] Use isolated `XDG_STATE_HOME` and forced `version --check-update` path.
+- [ ] Capture workflow run ID using Release workflow, push event, tag ref,
+  creation window and head SHA; record run attempt and job conclusions.
+
+## Publish and Channel Matrix
+
+| Priority | Scenario | Expected |
+|---|---|---|
+| Critical | Disposable Release workflow | Success; prerelease=true; draft=false |
+| Critical | Disposable assets/body | 7 assets; checksums/members/banner/notes valid |
+| Critical | Disposable isolation | Latest remains v2.4.1; tap Cask unchanged |
+| Critical | Disposable cleanup | GitHub release and git refs absent; external cache observability acknowledged |
+| Critical | Real tag | Annotated v2.5.0 peels to RELEASE_SHA on main |
+| Critical | Real workflow | Test and publish jobs success; stable/latest v2.5.0 |
+| High | Installer pinned v2.5.0 | Temp install succeeds; lowercase binary banner correct |
+| High | `go install @v2.5.0` | Bounded retry; capital binary banner correct |
+| High | Homebrew tap | Cask version/URLs/checksums match release |
+| High | Update discovery | Older released binary sees v2.5.0 |
+| Medium | Final repo truth | PRs merged, workflows green, no release PR/tag drift |
+| Medium | Post-release docs | Roadmap truth + completed plan PR merged after tag |
+
+## Implementation Steps
+
+1. Reassert `RELEASE_SHA`, absent v2.5 tag and intended release UTC date. If
+   main advanced, require `RELEASE_SHA` remains on main; do not silently retarget.
+2. Record journal SHA-256/metadata and tap Cask commit/content; confirm rollback operator.
+3. Create/push unique timestamped disposable annotated tag.
+4. Resolve/persist exact run ID; inspect/download/verify prerelease evidence.
+5. Confirm latest release and tap did not change and the tap PAT was absent.
+6. Run resumable cleanup: delete GitHub release if present, remote tag if present,
+   local tag if present; verify each repository-visible state independently.
+7. Reassert tag absence and `RELEASE_SHA` ancestry on main; create annotated v2.5.0.
+8. Push only `refs/tags/v2.5.0`; resolve/watch exact Release run and attempt.
+9. If the workflow is red after any external mutation, execute the recovery matrix.
+10. Verify assets in temp dirs; use clean Go caches and proxy-only module checks;
+    use isolated XDG state for forced update discovery.
+11. Verify Homebrew stable mutation; revert a bad tap commit with human credential.
+12. Create post-release docs PR updating roadmap to published v2.5.0 and adding
+    the completed plan/research files plus the planning journal; leave the user
+    punctuation/numbers journal untouched.
+13. Record URLs, SHAs, run IDs, asset count, tap commit and bounded proxy lag.
+14. Any content correction after real tag becomes v2.5.1; never retag.
+
+## Command Skeleton
+
+```sh
+DRY_TAG="v0.0.0-rc.test.$(date -u +%Y%m%d%H%M%S)"
+git tag -a "$DRY_TAG" "$RELEASE_SHA" -m "Typeburn disposable release test $DRY_TAG"
+git push origin "refs/tags/$DRY_TAG"
+# watch exact run, verify assets/body/latest/tap, then:
+gh release view "$DRY_TAG" -R bavanchun/Typeburn >/dev/null 2>&1 && \
+  gh release delete "$DRY_TAG" -R bavanchun/Typeburn --yes || true
+git ls-remote --exit-code --tags origin "refs/tags/$DRY_TAG" >/dev/null 2>&1 && \
+  git push origin ":refs/tags/$DRY_TAG" || true
+git rev-parse -q --verify "refs/tags/$DRY_TAG" >/dev/null && git tag -d "$DRY_TAG" || true
+
+TAG=v2.5.0
+git tag -a "$TAG" "$RELEASE_SHA" -m "Typeburn v2.5.0"
+test "$(git rev-parse "$TAG^{}")" = "$RELEASE_SHA"
+git push origin "refs/tags/$TAG"
+```
+
+## Success Criteria
+
+- [ ] Disposable publish passes every matrix row; GitHub release/git refs are removed,
+      tag is never reused, and possible external-cache observability is recorded.
+- [ ] Real annotated tag and release point to the proven main SHA.
+- [ ] Release is stable/latest with exactly 7 verified assets and exact notes.
+- [ ] Installer, Go module, Homebrew Cask and update discovery converge on v2.5.0.
+- [ ] Main CI and Release workflow are green; no unresolved release PR remains.
+- [ ] Journal remains untouched/untracked; no real tag is deleted or moved.
+- [ ] Post-release docs/plan PR is merged and does not alter the release tag SHA.
+
+## Partial-Publish Recovery Matrix
+
+| Observed state | Immediate containment | Recovery rule |
+|---|---|---|
+| Workflow fails before release exists | Preserve evidence; clean disposable refs idempotently | For real tag, preserve tag and rerun only unchanged transient failure |
+| GitHub release exists but assets/notes invalid or partial | Mark release draft if possible; stop announcements/install tests | Preserve real tag; correct content only in v2.5.1 |
+| Tap changed during disposable run | Block real tag; revert exact tap commit with human credential | Verify prior Cask commit restored before cleanup continues |
+| Stable release valid but tap step fails | Keep valid tag/release; repair/retry unchanged tap publication | Do not cut patch unless artifact/content changes |
+| Stable release and tap both bad | Draft/contain release, revert tap, publish incident note | Preserve v2.5.0; fix forward v2.5.1 |
+| Operator interrupted | Re-run state audit, not the full sequence blindly | Resume from observed GitHub/tag/tap state |
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Partial stable release before asset assertion | Public broken release | Disposable full proof; patch fix-forward incident path |
+| Reusing/deleting real tag | Permanent Go proxy breakage | Immutable-tag hard rule |
+| Prerelease mutates tap/latest | Users receive dry build | Verify `prerelease:auto` and `skip_upload:auto` empirically |
+| Homebrew Cask bad after stable | Breaks installs/upgrades | Human tap revert + v2.5.1 fix-forward |
+| Go proxy delay | False failure/re-tag temptation | Bounded retry; never retag |
+| Wrong workflow run observed | False evidence | Match exact tag and SHA |
+
+## Security Considerations
+
+- Keep `HOMEBREW_TAP_TOKEN` step-scoped and never inspect/log its value.
+- Release binaries remain unsigned; checksums detect corruption, not host compromise.
+- Download and inspect assets in temporary directories; verify checksums before execution.
+- “Verified” means checksum-consistent with the same unsigned release host, not
+  independent publisher authenticity.
+
+## Unresolved Questions
+
+None.
+
+## Supersession Outcome
+
+The GitHub/archive/installer/Homebrew/updater portions completed for v2.5.0,
+but `go install @v2.5.0` is impossible because that immutable tag has a v1-style
+module path. Its Go-module success criterion above intentionally remains
+unchecked. Corrective v2.5.1 migrated to `/v2`, published from merged SHA
+`8307ee6c`, and passed isolated public proxy installs for both exact and latest.

--- a/plans/260711-1434-v2-5-consolidated-release-recovery/plan.md
+++ b/plans/260711-1434-v2-5-consolidated-release-recovery/plan.md
@@ -1,0 +1,218 @@
+---
+title: Typeburn v2.5.0 Consolidated Release Recovery
+description: >-
+  Fix Code/Strict result metadata, restore documentation truth, merge PR #57,
+  and publish one verified v2.5.0 release.
+status: completed
+priority: P1
+branch: feat/punctuation-numbers-toggle
+tags:
+  - bugfix
+  - docs
+  - release
+  - critical
+blockedBy: []
+blocks: []
+created: '2026-07-11T07:39:23.409Z'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Typeburn v2.5.0 Consolidated Release Recovery
+
+## Overview
+
+Deliver one consolidated `v2.5.0` containing already-merged Strict Mode,
+PR #57 punctuation/numbers, the Code-mode label fix, best-marker consistency,
+and documentation reconciliation. Preserve protected-main and immutable-tag
+rules. Public stable remains `v2.4.1` until the real release workflow succeeds.
+
+## Locked Decisions
+
+- One release: `v2.5.0`; do not create or claim `v2.6.0`.
+- History and Result render Code exactly as `code`; no rune count in label.
+- Unknown persisted mode IDs render raw; empty renders `unknown`.
+- Code and Strict records remain stored but never show or set a personal-best star.
+- Extend existing PR #57; use a separate release-prep PR.
+- Keep `docs/journals/260702-1857-punctuation-numbers-toggle-feature-shipped.md`
+  untouched and untracked.
+- No storage migration, dependency addition, signing, or unrelated cleanup.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Code Mode Display and Best Marker TDD](./phase-01-code-mode-display-and-best-marker-tdd.md) | Completed |
+| 2 | [Pre-Release Documentation Truth](./phase-02-pre-release-documentation-truth.md) | Completed |
+| 3 | [PR 57 Integration and Main Verification](./phase-03-pr-57-integration-and-main-verification.md) | Completed |
+| 4 | [v2.5.0 Release Preparation](./phase-04-v2-5-0-release-preparation.md) | Completed |
+| 5 | [Disposable Dry Run Publish and Post-Release Verification](./phase-05-disposable-dry-run-publish-and-post-release-verification.md) | Completed |
+
+## Dependencies
+
+- Completion is blocked by corrective plan
+  `260711-1908-v2-5-1-go-module-v2-fix-forward`: the published v2.5.0 source
+  can never satisfy its original Go-install criterion. Close this plan as
+  superseded/recovered only after v2.5.1 passes clean proxy-only installation.
+- Sequential execution: Phase 1 → 2 → 3 → 4 → 5.
+- Prior Strict and punctuation/numbers plans are completed inputs, not blockers.
+- PR #57 must remain reviewable and CI-green before merge.
+- Real tag creation is blocked by a successful, cleaned disposable-tag publish.
+
+## Outcome / Supersession
+
+- v2.5.0 shipped successfully on GitHub, installer, Homebrew, archives, and updater.
+- Its original Go-install criterion failed permanently because the tagged
+  `go.mod` lacked the required `/v2` module suffix. That criterion is not
+  checked or rewritten as passed.
+- Corrective plan `260711-1908-v2-5-1-go-module-v2-fix-forward` completed the
+  recovery through immutable v2.5.1. Public proxy-only exact and latest installs
+  now succeed with lowercase `typeburn`.
+- This plan is terminally completed by documented fix-forward recovery, not by
+  claiming every original v2.5.0 channel gate succeeded.
+
+## Scope Challenge
+
+- **Existing reuse:** `storage.Record`, `IsNewBest`, semantic theme/config
+  authorities, PR #57, release workflow, and GoReleaser configuration.
+- **Minimum set:** one shared formatter, best eligibility consistency, regression
+  tests, named docs reconciliation, PR integration, release prep, publish proof.
+- **Complexity:** many files because release truth spans code, evergreen docs,
+  changelog, GitHub Actions, and distribution channels; no new service/package.
+- **Selected scope:** HOLD. No adjacent feature or historical journal rewrite.
+
+## Cross-Plan Dependencies
+
+| Relationship | Plan | Status |
+|---|---|---|
+| Input | `260626-2213-strict-stop-on-error-mode` | completed |
+| Input | `260702-1824-punctuation-numbers-toggle` | completed |
+
+## Whole-Plan Success Criteria
+
+- Code renders as `code` on History and Result; Time/Words/Quote unchanged.
+- Code/Strict records never display or earn ★; persisted schema unchanged.
+- Docs state 8 themes, 8 persisted/CLI keys, 7 TUI Settings rows, and distinguish
+  grayscale `mono` from attribute-only `NO_COLOR`.
+- Pre-release truth says stable `v2.4.1`, upcoming combined `v2.5.0`; no phantom
+  v2.5/v2.6 release claim.
+- PR #57 and release-prep PR squash-merge with required CI green.
+- Disposable release proves 7 assets, checksums, notes, prerelease isolation,
+  and no Homebrew tap mutation; GitHub release/tag cleanup is idempotently verified.
+- Annotated `v2.5.0` points to the proven `main` SHA and release workflow succeeds.
+- GitHub latest, assets, installer, Go module, Homebrew tap, and update check agree.
+- Full race, vet, format, installer, release-config, and size gates pass.
+- Untracked journal remains byte-untouched and unstaged.
+- Post-release docs PR records published v2.5.0 truth and commits the completed
+  plan artifacts plus this session's planning journal; the release tag itself
+  remains on the proven release SHA.
+
+## Research
+
+- [Code/display research](./research/code-mode-display-and-best-marker.md)
+- [Documentation truth research](./research/documentation-and-release-truth.md)
+- [Release-flow research](./research/release-flow.md)
+
+## Red Team Review
+
+### Session — 2026-07-11
+
+**Findings:** 15 deduplicated (11 accepted, 3 accepted with modification, 1 rejected)
+from 33 raw findings. **Severity:** 7 Critical, 7 High, 1 Medium.
+
+| # | Finding | Severity | Disposition | Applied To |
+|---|---|---|---|---|
+| 1 | Partial public release lacks recovery state machine | Critical | Accept | Completed |
+| 2 | Disposable cleanup is not resumable/idempotent | Critical | Accept | Completed |
+| 3 | Tap rollback operator/credential not preflighted | Critical | Accept | Completed |
+| 4 | Tag workflow does not enforce trusted-main ancestry | Critical | Accept | Completed |
+| 5 | Prerelease unnecessarily receives tap PAT | Critical | Accept | In Progress |
+| 6 | Post-release roadmap/plan truth would remain stale | Critical | Accept | Phase 5 |
+| 7 | Ineligible historical runs can suppress normal PB | High | Accept | Phase 1 |
+| 8 | Journal diff cannot prove untouched untracked content | High | Accept | All phases |
+| 9 | Exact workflow-run selection was underspecified | High | Accept | Phases 3, 5 |
+| 10 | Proxy and update checks can reuse stale caches | High | Accept | Phase 5 |
+| 11 | Release-note extraction and tool pin were ambiguous | High | Accept | Phase 4 |
+| 12 | Dry run cannot prove stable Homebrew write path | High | Accept (modified) | Phases 4–5 |
+| 13 | Disposable public tag cannot be made globally absent | High | Accept (modified) | Phase 5 |
+| 14 | Tie semantics and phase gate ownership unclear | High | Accept (modified) | Phases 1–3 |
+| 15 | Raw unknown mode needs sanitization/truncation | Critical | Reject | Locked UX/threat model |
+
+Rejected/modified rationale:
+
+- Unknown fallback remains the user-approved raw semantic identifier. History is
+  local 0600 XDG data, not network input. Layout/control-character hardening is
+  documented as accepted risk and requires a separate user decision.
+- History ★ means current eligible record-holder including ties; Result ★ means
+  a newly established strictly-greater PB. The distinction is now explicit.
+- Disposable tags are unique and never reused, but may remain observable in Go
+  proxy/sumdb/CDN history; cleanup claims only GitHub release and git refs.
+- Prerelease proves GitHub publish behavior, not stable-only Homebrew mutation.
+  Stable tap permission preflight and manual rollback readiness cover that gap.
+- CI mutable action tags remain outside scope: `CLAUDE.md` requires `ci.yml`
+  byte-identical for release-infra work, while the privileged tag workflow is
+  SHA-pinned. Revisit only with explicit user approval.
+
+### Whole-Plan Consistency Sweep
+
+- Files reread: `plan.md`, all five phase files, three research reports.
+- Decision deltas checked: trusted-main gate, prerelease PAT isolation, recovery
+  matrix, post-release docs, PB eligibility, artifact ownership, cache isolation.
+- Reconciled stale references: integration/release ownership, cleanup wording,
+  Homebrew proof boundary, release-date definition, caller-count invariant.
+- Unresolved contradictions: 0.
+
+## Validation Log
+
+### Session 1 — 2026-07-11
+
+**Trigger:** Automatic `--deep` post-red-team validation.
+**Questions recorded:** 3 prior user decisions; no new unresolved decision.
+
+#### Questions and Answers
+
+1. **[Release scope]** Should Strict and punctuation/numbers ship separately or
+   in one release?
+   - Options: sequential v2.5/v2.6 | one consolidated release
+   - **Answer:** one consolidated release.
+2. **[UX contract]** Should Code render as `code` or include rune count?
+   - Options: `code` | `code <rune-count>`
+   - **Answer:** `code`.
+3. **[Scope]** Should the untracked shipped journal be corrected/tracked?
+   - Options: keep untouched/untracked | edit wording and include
+   - **Answer:** keep untouched/untracked.
+
+#### Verification Results
+
+- **Tier:** Full (5 phases; Fact Checker, Flow Tracer, Scope Auditor,
+  Contract Verifier).
+- **Claims checked:** 78 across paths, symbols, callers, branch/PR state,
+  release workflow, config/theme authorities and release artifacts.
+- **Verified:** 77 | **Failed:** 1 | **Unverified:** 0.
+- Resolved failure: no global `goreleaser` binary exists. Phase 4 now installs
+  exact v2.15.4 into a temporary `GOBIN`, asserts GitVersion, and uses that path.
+- Live evidence: PR #57 open/mergeable; head `00286ed2`; base `55958224`;
+  latest public release `v2.4.1`; plan status `pending`.
+
+#### Confirmed Decisions
+
+- Target version: one combined `v2.5.0`; no phantom `v2.6.0`.
+- Code label: exact `code`; stored rune count unchanged.
+- Journal: hash-preserved, untracked, never staged.
+- Release-prep PR includes trusted-main/tag-token hardening discovered by red team.
+- Stable-only Homebrew write cannot be proven by prerelease; preflight and
+  fix-forward recovery are explicit.
+
+#### Whole-Plan Consistency Sweep
+
+- Files reread: `plan.md`, five phase files, three research reports.
+- Searched stale terms: metadata-only prep, total/global cleanup, two-caller
+  invariant, phantom v2.6, early release notes, unresolved placeholders.
+- Reconciled phase ownership: Phase 2 code/docs, Phase 3 PR/merge, Phase 4
+  workflow+release prep, Phase 5 publish/recovery/post-release docs.
+- Unresolved contradictions: 0.
+- Implementation eligibility: yes; verification failures remaining: 0.
+
+## Unresolved Questions
+
+None.

--- a/plans/260711-1434-v2-5-consolidated-release-recovery/research/code-mode-display-and-best-marker.md
+++ b/plans/260711-1434-v2-5-consolidated-release-recovery/research/code-mode-display-and-best-marker.md
@@ -1,0 +1,24 @@
+# Research: Code Mode Display and Best Marker
+
+## Summary
+
+Both UI formatters predate Code mode and map their default branch to Quote.
+Storage persists Code correctly. Separate scout evidence shows History computes
+stars for all records even though `IsNewBest` excludes Code and Strict.
+
+## Findings
+
+- `history_table.go` and `result_render_helpers.go` duplicate mode formatting.
+- One string-based UI formatter preserves forward-compatible raw history modes.
+- `BestWPMPerBucket` and History row comparison need the same eligibility rule
+  used by `IsNewBest`; bucket filtering alone is insufficient when WPM values tie.
+- Focused new test files avoid growing existing screen tests beyond 200 lines.
+
+## Recommendation
+
+Tests first. Add one UI formatter and one storage eligibility predicate. Reuse
+each at all production call sites. Keep schema, record length and PB buckets intact.
+
+## Unresolved Questions
+
+None.

--- a/plans/260711-1434-v2-5-consolidated-release-recovery/research/documentation-and-release-truth.md
+++ b/plans/260711-1434-v2-5-consolidated-release-recovery/research/documentation-and-release-truth.md
@@ -1,0 +1,25 @@
+# Research: Documentation and Release Truth
+
+## Summary
+
+Runtime has eight themes, eight persisted/CLI keys and seven Settings UI rows.
+`mono` is grayscale color; only `NO_COLOR` is attribute-only. Public stable is
+v2.4.1; Strict is merged/unreleased and punctuation/numbers is PR #57/unreleased.
+
+## Findings
+
+- README, CLI reference, architecture, codebase summary, PDR and roadmap contain
+  stale or ambiguous counts and theme semantics.
+- CHANGELOG cut v2.5.0 prematurely; release notes correctly remain v2.4.1.
+- Historical v1 statements must not be blindly rewritten as current product facts.
+- Release documentation needs integration, release-prep and published states.
+
+## Recommendation
+
+Normalize all unreleased work under CHANGELOG Unreleased during integration.
+Cut v2.5 and release notes only in the dedicated release-prep transaction.
+Exclude journals from global drift replacement and staging.
+
+## Unresolved Questions
+
+None.

--- a/plans/260711-1434-v2-5-consolidated-release-recovery/research/release-flow.md
+++ b/plans/260711-1434-v2-5-consolidated-release-recovery/research/release-flow.md
@@ -1,0 +1,26 @@
+# Research: Consolidated v2.5.0 Release Flow
+
+## Summary
+
+PR #57 is open, mergeable and CI-green. Protected main requires PRs and squash
+merges. The tag-triggered release workflow self-tests, publishes six archives
+plus checksums, and updates a separate Homebrew tap only for stable releases.
+
+## Findings
+
+- Extend PR #57 with Code/display and truth-doc changes; no force-push needed.
+- Use a focused release-prep PR for metadata plus privileged tag-workflow
+  hardening, then freeze its squash SHA.
+- Local snapshot does not prove auth, upload, notes or tap behavior.
+- A unique disposable prerelease must empirically prove full publish and cleanup.
+- Real tags are immutable because Go proxy/sumdb are append-only; fix forward.
+
+## Recommendation
+
+Execute strict sequential gates. Match workflow evidence by tag/SHA, assert seven
+assets and exact notes, verify prerelease isolation, then publish v2.5.0 on the
+same proven SHA and validate every distribution channel.
+
+## Unresolved Questions
+
+None.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-04-prepare-protected-corrective-release.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-04-prepare-protected-corrective-release.md
@@ -1,7 +1,7 @@
 ---
 phase: 4
 title: "Prepare protected corrective release"
-status: pending
+status: done
 effort: "M"
 ---
 
@@ -55,6 +55,6 @@ Land through protected main, freeze one release SHA, and prove archive release b
 
 ## Success Criteria
 
-- [ ] Frozen merged SHA passes local and disposable archive proofs.
-- [ ] Seven assets and isolation checks pass; cleanup is verified.
-- [ ] Commit requirement is satisfied by squash merge; no synthetic commit.
+- [x] Frozen merged SHA `8307ee6c` passes local and disposable archive proofs.
+- [x] Seven assets and isolation checks pass; cleanup is verified (run `29158988295`).
+- [x] Commit requirement is satisfied by PR #59 squash merge; no synthetic commit.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-05-publish-and-verify-v2-5-1-fix-forward.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/phase-05-publish-and-verify-v2-5-1-fix-forward.md
@@ -1,7 +1,7 @@
 ---
 phase: 5
 title: "Publish and verify v2.5.1 fix-forward"
-status: pending
+status: done
 effort: "L"
 ---
 
@@ -66,8 +66,8 @@ publish v2.5.2. Never move or delete the v2.5.1 tag.
 
 ## Success Criteria
 
-- [ ] Annotated v2.5.1 and exact workflow point to frozen main SHA.
-- [ ] GitHub, installer, Homebrew, updater, assets, and banners agree.
-- [ ] Proxy-only exact and latest installs create lowercase typeburn v2.5.1.
-- [ ] v2.5.0 stays immutable; old plan closes as superseded and recovered.
-- [ ] Commit completion metadata and journal through a post-release documentation PR.
+- [x] Annotated v2.5.1 and run `29159099750` point to frozen main SHA `8307ee6c`.
+- [x] GitHub, installer, Homebrew, updater, seven assets, and banners agree.
+- [x] Proxy-only exact and latest installs create lowercase typeburn v2.5.1.
+- [x] v2.5.0 stays immutable; old plan closes as superseded and recovered.
+- [x] Completion metadata and journal prepared for post-release documentation PR.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/plan.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "v2.5.1 Go module v2 fix-forward"
 description: "Repair the broken v2 Go-install channel without mutating v2.5.0."
-status: in-progress
+status: completed
 priority: P1
 branch: "fix/v2-module-path"
 tags: [release, go-modules, corrective]
@@ -38,8 +38,8 @@ proxy. Keep the published `v2.5.0` tag and release untouched.
 | 1 | [Lock module and command contract](./phase-01-lock-module-and-command-contract.md) | Done |
 | 2 | [Migrate module imports and command entrypoint](./phase-02-migrate-module-imports-and-command-entrypoint.md) | Done |
 | 3 | [Reconcile install documentation and release contracts](./phase-03-reconcile-install-documentation-and-release-contracts.md) | Done |
-| 4 | [Prepare protected corrective release](./phase-04-prepare-protected-corrective-release.md) | Pending |
-| 5 | [Publish and verify v2.5.1 fix-forward](./phase-05-publish-and-verify-v2-5-1-fix-forward.md) | Pending |
+| 4 | [Prepare protected corrective release](./phase-04-prepare-protected-corrective-release.md) | Done |
+| 5 | [Publish and verify v2.5.1 fix-forward](./phase-05-publish-and-verify-v2-5-1-fix-forward.md) | Done |
 
 ## Dependencies
 
@@ -110,3 +110,14 @@ must not change. Five phases preserve the immutable publish boundary.
 Before stable tagging, repair the corrective PR. After stable mutation, never
 move `v2.5.1`; use `v2.5.2` for any further correction. Treat proxy state as
 append-only.
+
+## Completion Evidence
+
+- Protected PR: #59, squash merge `8307ee6c9384dceb27aaa639bdac980b43906e0b`.
+- Main CI: run `29158912514`, success.
+- Disposable archive proof: run `29158988295`, seven assets verified, latest
+  and tap isolated, release/tag cleanup verified.
+- Stable release: annotated `v2.5.1` peels to the merged SHA; run
+  `29159099750` succeeded with seven assets.
+- Channels: pinned installer, Homebrew tap commit `eb517cdac4febeb3cbdf5496618edd46c7b15c73`,
+  updater discovery, and public proxy-only exact/latest installs all verified.

--- a/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/reports/pm-260711-2310-v2-5-1-completion.md
+++ b/plans/260711-1908-v2-5-1-go-module-v2-fix-forward/reports/pm-260711-2310-v2-5-1-completion.md
@@ -1,0 +1,31 @@
+# Plan Completion: v2.5.1 Go Module Fix-Forward
+
+## Summary
+
+| Metric | Result |
+|---|---|
+| Phases | 5/5 completed |
+| Protected PR | #59 merged |
+| Release SHA | `8307ee6c9384dceb27aaa639bdac980b43906e0b` |
+| Main CI | `29158912514` success |
+| Disposable run | `29158988295` success and cleaned |
+| Stable run | `29159099750` success |
+| Assets | 7/7, checksums verified |
+| Go proxy | exact and latest installs verified |
+| Other channels | installer, Homebrew, updater verified |
+
+## Achievements
+
+- Valid Go v2 module and lowercase command contract shipped as v2.5.1.
+- v2.5.0 kept immutable; recovery used fix-forward only.
+- Public proxy, GitHub assets, installer, Homebrew, and updater converge.
+- Old v2.5.0 plan closed with explicit supersession instead of false success.
+
+## Known Limitations
+
+- Release binaries/checksums remain unsigned; existing documented trust model unchanged.
+- Reconstructed Phase 1 RED evidence is transparent, not chronological.
+
+## Unresolved Questions
+
+None.


### PR DESCRIPTION
## Summary

- mark the v2.5.1 corrective plan 5/5 complete with release evidence
- close the v2.5.0 recovery plan through explicit fix-forward supersession
- update evergreen release truth to public stable v2.5.1
- add planning/release journals and final project-management report

## Verified release evidence

- PR #59 merged at 8307ee6c
- main CI run 29158912514 succeeded
- disposable release run 29158988295 succeeded and cleaned
- stable release run 29159099750 succeeded with seven verified assets
- installer, Homebrew, updater, and proxy-only exact/latest Go installs verified

The immutable v2.5.1 tag remains on 8307ee6c; this PR changes documentation only.