### PR TITLE
chore(release): prepare v2.6.0

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,15 +1,20 @@
-## [2.5.1] - 2026-07-11 — Corrective Release
+## [2.6.0] - 2026-07-31 — Result Screen Redesign
 
-### Fixed
+### Changed
 
-- **Go module channel**: `go install github.com/bavanchun/Typeburn/v2/cmd/typeburn@latest`
-  now works correctly. The v2.5.0 release used a root module path that the Go
-  proxy could not resolve for install.
-- **Command binary**: moved entrypoint to `cmd/typeburn/` so `go install`
-  produces a lowercase `typeburn` binary matching all other install channels.
-- **Documentation**: all install, build, and update guidance now uses the
-  corrected `/v2/cmd/typeburn` path.
+- **Result screen redesigned (Monkeytype-style)**:
+  - Hero shows two big numbers — ASCII big-digit WPM beside a prominent
+    accuracy block; `raw` and `consistency` move to a secondary card row.
+    The `★ new best` badge stays on WPM.
+  - The bar sparkline is replaced by a dual-axis line graph: a braille
+    sub-cell WPM line (left Y-axis) with red `x` per-second error markers
+    (right Y-axis, consuming previously unused per-second error data);
+    long runs downsample so the chart always fits the panel.
+  - Character counts and test metadata merge into a two-column stats grid
+    (test type / raw / characters | consistency / time) that stacks
+    vertically on narrow terminals.
+  - The most-missed-keys heatmap is unchanged. Reveal animation and
+    `NO_COLOR`/mono layout invariants are preserved.
 
-No features or dependency changes. CLI, config, storage, and release-archive
-contracts remain compatible; Go module/import identity intentionally moves to
-the required `/v2` path. The v2.5.0 tag and release remain untouched.
+No CLI, config, storage, or release-archive contract changes. Existing
+history and settings files are fully compatible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-07-31
+
 ### Changed
 
 - **Result screen redesigned (Monkeytype-style)**:

--- a/docs/journals/260702-1857-punctuation-numbers-toggle-feature-shipped.md
+++ b/docs/journals/260702-1857-punctuation-numbers-toggle-feature-shipped.md
@@ -1,0 +1,56 @@
+---
+title: Punctuation & Numbers Toggle for Words/Time Mode (PR #57)
+date: 2026-07-02
+type: journal
+---
+
+# Punctuation & Numbers Toggle for Words/Time Mode
+
+## Context
+
+Shipped PR #57 (branch `feat/punctuation-numbers-toggle`, commit 00286ed2): two new persisted settings (`Punctuation` and `Numbers`, both bool, default `false`) for Words/Time mode word generation. Mirrors StrictMode wiring exactly — settings-only control surface (no new CLI flags), config-driven threading down through the call chain to the generator transform. Plan: `/plans/260702-1824-punctuation-numbers-toggle/`.
+
+## What Happened
+
+**Phase 1–3 execution:** Config fields added to `Settings`, generator transforms implemented (`applyPunctuation`/`applyNumbers` in `internal/words/generator.go` with deterministic seeding), threading through `runner.NewSession` → constructor chain → `TypingModel` fields, Settings UI rows added, CLI `config get/set punctuation|numbers` wired.
+
+**Validation gate earned its keep:** Before implementation, `/ck:plan validate` (Standard tier: Fact Checker + Contract Verifier) caught 4 factual errors in the Phase 2 "touchpoint list":
+- Claimed `internal/app/model.go` calls `words.ForMode` directly → FALSE (call chain is `ui.NewTyping() → newTypingWithSeed → runner.NewSession → words.ForMode`)
+- Claimed `internal/cli/cmd_run_validate.go` is a call site → FALSE (real site is `cmd_run_notui.go:54`)
+- Omitted `internal/ui/screen_typing_actions.go:30` (ctrl+r restart path also calls `newTypingWithSeed` and must carry punctuation/numbers forward)
+- Omitted `NewTyping`/`newTypingWithSeed` signature updates as required-edit files
+
+**These were corrected before implementation,** not after, preventing rework. Interview resolved 2 decisions: (a) yes, add `punctuation`/`numbers` fields to `TypingModel` to mirror `strict` behavior on restart, (b) two separate positional bools, not a struct, matching existing call-site style.
+
+**Post-implementation code review** (subagent) found 4 issues:
+
+| Severity | Finding | Resolution |
+|---|---|---|
+| HIGH | Quote-wrap feature spec'd in acceptance criteria but never coded. No test caught it. | Implemented: `applyPunctuation` now wraps ~3% of tokens in quotes. User chose to implement. |
+| MEDIUM | `applyNumbers` off-by-one: `rng.IntN(max)+1` could produce a 5-digit number when `digits==4` (e.g., `10000`). | Fixed: `rng.IntN(max-1)+1`. |
+| MEDIUM | Capitalization triggers after both `.` and `;`, not just `.` as literally spec'd. Undocumented deviation. | User chose to keep as-is (reasonable stylistic choice). Locked in with `TestApplyOptions_PunctuationCapitalizesAfterSemicolon`. |
+| LOW | Stale "5 fixed settings rows" doc comment in `settings_rows.go` (should be 7). | Fixed. |
+
+Full re-verification post-fixes: `go test ./... -race -count=1`, `gofmt -l .`, `go vet ./...` all green. Squash-merged to `main`.
+
+## The Friction Points
+
+The quote-wrap gap was the stinger. It was written into the acceptance criteria in the plan (`rare word wrapped in quotes`) and should have been caught during Phase 1 code review — but wasn't. This is a reminder that acceptance criteria in markdown and actual test assertions don't automatically sync. The test suite passed without it because no test explicitly checked for the feature; the logic was simply missing from the generator.
+
+The off-by-one in `applyNumbers` was a classic modulo mistake: `rng.IntN(max)` returns [0, max), so adding 1 shifts it to [1, max+1) — fine for max=10 (digits 1–10), catastrophic for max=10000 (digits 1–10001, i.e., 5 digits). The fix is trivial, but this is why deterministic seeding + explicit test cases for boundary values matter.
+
+The semicolon capitalization deviation sneaked in during implementation. The spec said "period only" but the code capitalized after both `.` and `;`. Rather than debate style, the user owned the call: keep it (semicolons are sentence-like terminators anyway), and test it so the behavior is locked in.
+
+## Why the Validation Gate Worked
+
+The plan's Phase 2 file list was detailed enough to fail productively — it made claims about call chains and file paths that could be verified by actually tracing the code. The validation agent didn't just check "are the files reasonable" but "do the actual call paths match the claim?" That's the difference between a weak gate and one that catches rework-sized mistakes before they compound.
+
+This is a lesson for future plans: specificity in the draft (exact file paths, exact function call chains, exact line numbers) creates testable claims. Vague plans ("update related screens") don't fail; specific plans can.
+
+## Next
+
+None. Feature shipped, all tests green, docs updated (README.md, project-roadmap.md).
+
+## Unresolved Questions
+
+None.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -269,7 +269,7 @@ Protected merge, release publication, and public proxy validation are complete.
   checks completed successfully. The published `v2.5.0` tag remains immutable;
   its broken Go-module install channel was fixed forward by `v2.5.1`.
   Ship date: 2026-07-11.
-- ✅ **Result-screen redesign (Monkeytype-style, unreleased on main):** hero
+- ✅ **v2.6.0 (Result-screen redesign, Monkeytype-style):** hero
   promotes accuracy to a second big number beside the wpm digits (raw +
   consistency drop to a secondary card row); the bar sparkline is replaced by
   a dual-axis line graph — braille WPM line (left Y) + red `x` error markers
@@ -277,7 +277,7 @@ Protected merge, release publication, and public proxy validation are complete.
   long-run downsampling; char counts and meta merge into a 2-column stats
   grid (test type / raw / characters | consistency / time) that stacks on
   narrow panels; heatmap unchanged. Reveal animation and NO_COLOR/mono layout
-  invariants preserved. Implemented: 2026-07-30.
+  invariants preserved. Ship date: 2026-07-31.
 
 
 ### Next (Optional)


### PR DESCRIPTION
## Summary

Release-prep for **v2.6.0** (Result-screen Monkeytype-style redesign, merged in #61):

- `CHANGELOG.md`: rolls `[Unreleased]` → `[2.6.0] - 2026-07-31` (empty Unreleased heading kept).
- `.github/release-notes.md`: verbatim 2.6.0 extract for GoReleaser `--release-notes` (diff-verified against the CHANGELOG section) + compat note per 2.5.1 precedent.
- `docs/project-roadmap.md`: redesign entry updated from "unreleased on main" to shipped v2.6.0.
- Adds the outstanding v2.5.0 punctuation/numbers journal (finished docs, previously untracked).

Docs-only — no code changes. After squash-merge, the tag runbook (dry-run → `v2.6.0`) runs on the merged SHA per `plans/260731-1004-v260-release-closure/`.

https://claude.ai/code/session_01BEChRegMspNqiG8DwnBQoi