### PR TITLE
chore(release): prepare v2.7.0

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,20 +1,28 @@
-## [2.6.0] - 2026-07-31 — Result Screen Redesign
+## [2.7.0] - 2026-08-01 — Animated Update CLI
+
+### Added
+
+- **`typeburn update` now animates.** On a terminal at least 56 columns wide,
+  the update renders a bordered checklist — checksums, downloading, verifying,
+  installing — with a spring-smoothed gradient progress bar driven by the real
+  byte count of the release archive. Built on `charm.land/bubbles/v2`.
+- The checksums fetch, which the updater always performed, is now reported as
+  its own step instead of happening invisibly.
+- Interrupting with `ctrl+c` during the download stops the update and waits for
+  it to unwind, so the update lock and the partial download are removed rather
+  than left behind. The interrupt is deliberately refused once installing
+  begins, because the remaining work is the atomic binary swap. Only the
+  download is cancellable, so an interrupt arriving during verification or the
+  swap reports `stopped too late — <from> → <to> was already installed` rather
+  than falsely claiming nothing changed.
 
 ### Changed
 
-- **Result screen redesigned (Monkeytype-style)**:
-  - Hero shows two big numbers — ASCII big-digit WPM beside a prominent
-    accuracy block; `raw` and `consistency` move to a secondary card row.
-    The `★ new best` badge stays on WPM.
-  - The bar sparkline is replaced by a dual-axis line graph: a braille
-    sub-cell WPM line (left Y-axis) with red `x` per-second error markers
-    (right Y-axis, consuming previously unused per-second error data);
-    long runs downsample so the chart always fits the panel.
-  - Character counts and test metadata merge into a two-column stats grid
-    (test type / raw / characters | consistency / time) that stacks
-    vertically on narrow terminals.
-  - The most-missed-keys heatmap is unchanged. Reveal animation and
-    `NO_COLOR`/mono layout invariants are preserved.
+- Plain `typeburn update` output — used for pipes, redirects, CI, and terminals
+  too narrow for the frame — is unchanged apart from the new `checksums...`
+  line, and is now pinned by an exact-output test.
 
-No CLI, config, storage, or release-archive contract changes. Existing
-history and settings files are fully compatible.
+No config, storage, or release-archive contract changes. The plain
+`typeburn update` output used by pipes, redirects, and CI is unchanged apart
+from the new `checksums...` line. Existing history and settings files are fully
+compatible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-08-01
+
 ### Added
 
 - **`typeburn update` now animates.** On a terminal at least 56 columns wide,

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -4,9 +4,9 @@
 
 ## Current Release State
 
-**Public stable:** `v2.5.1` (2026-07-11). The corrective release migrated the
-Go module to its required `/v2` path and restored proxy-only `go install`.
-Protected merge, release publication, and public proxy validation are complete.
+**Public stable:** `v2.7.0` (2026-08-01). The self-updater now renders an
+animated progress block driven by real download bytes, and stops cleanly when
+interrupted instead of leaking its update lock.
 
 ---
 
@@ -100,7 +100,7 @@ Protected merge, release publication, and public proxy validation are complete.
 - **Deferred follow-ups:** code signing (cosign/Sigstore), delta updates,
   rollback-to-previous, `--version <tag>` pinned downgrade.
 
-#### Animated Update CLI — ✅ SHIPPED
+#### Animated Update CLI — ✅ SHIPPED in v2.7.0 (2026-08-01)
 - **Description:** `typeburn update` renders a bordered checklist with a
   spring-smoothed gradient bar driven by the real byte count of the release
   archive, replacing the flat stage lines from v2.4.0. Supersedes the
@@ -283,6 +283,11 @@ Protected merge, release publication, and public proxy validation are complete.
 - ✅ **v2.3.0 (Self-Update):** stdlib-only atomic self-updater via `typeburn update`, preflight managed-install check, redirect allowlist, O_EXCL locks, archive path-traversal safety, Windows move-aside rollback. Ship date: 2026-05-30.
 - ✅ **v2.4.0 (Update UX):** In-app hint directs to self-updater; download progress reporting. Ship date: 2026-05-30.
 - ✅ **v2.4.1 (UI Animations):** stdlib-only terminal motion layer (blink/fade caret, stats reveal count-up, sparkle personal best celebration, Typing→Result transition) with NO_COLOR adaptation and hot-path token cache. Ship date: 2026-06-20.
+- ✅ **v2.7.0 (Animated Update CLI):** `typeburn update` renders a bordered
+  checklist with a spring-smoothed gradient bar driven by real byte-level
+  download progress; plain output preserved for pipes/CI/narrow terminals;
+  interrupt now unwinds the update so the O_EXCL lock is released rather than
+  leaked. Ship date: 2026-08-01.
 - ✅ **v2.5.0 (Strict + Punctuation/Numbers):** Letter-strict typing blocks
   wrong forward keypresses and records them for keystroke-level accuracy;
   Strict runs are excluded from personal bests. Punctuation and Numbers


### PR DESCRIPTION
Release-prep for v2.7.0 (Animated Update CLI).

- CHANGELOG: `[Unreleased]` → `[2.7.0] - 2026-08-01`
- `.github/release-notes.md`: the 2.7.0 section extracted verbatim for GoReleaser's `--release-notes`
- `docs/project-roadmap.md`: current-stable line, ship entry, and the feature marked shipped

No code changes. After this merges, v2.7.0 is tagged on the merged commit and pushed separately.

**Note:** the maintainer chose to go straight to a stable tag rather than proving the pipeline with the disposable `v0.0.0-rc.test` dry-run first. A stable tag is immutable — the Go module proxy and sumdb are append-only — so any defect in the release is fixed forward with v2.7.1, never by re-tagging.

https://claude.ai/code/session_017Zp94DisnjwRdkFofodUNn