### PR TITLE
chore(release): prepare v2.8.0

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,28 +1,25 @@
-## [2.7.0] - 2026-08-01 — Animated Update CLI
-
-### Added
-
-- **`typeburn update` now animates.** On a terminal at least 56 columns wide,
-  the update renders a bordered checklist — checksums, downloading, verifying,
-  installing — with a spring-smoothed gradient progress bar driven by the real
-  byte count of the release archive. Built on `charm.land/bubbles/v2`.
-- The checksums fetch, which the updater always performed, is now reported as
-  its own step instead of happening invisibly.
-- Interrupting with `ctrl+c` during the download stops the update and waits for
-  it to unwind, so the update lock and the partial download are removed rather
-  than left behind. The interrupt is deliberately refused once installing
-  begins, because the remaining work is the atomic binary swap. Only the
-  download is cancellable, so an interrupt arriving during verification or the
-  swap reports `stopped too late — <from> → <to> was already installed` rather
-  than falsely claiming nothing changed.
+## [2.8.0] - 2026-08-01 — Result Responsive Layout
 
 ### Changed
 
-- Plain `typeburn update` output — used for pipes, redirects, CI, and terminals
-  too narrow for the frame — is unchanged apart from the new `checksums...`
-  line, and is now pinned by an exact-output test.
+- **Result screen now uses the width it has.** The panel is capped and centred
+  instead of stretching to fill the terminal, so a wide screen no longer shows a
+  near-empty box with everything crammed into the top-left corner.
+- The WPM chart fills its panel. It previously took its width from the data, so
+  an eight-second test drew an eight-cell chart no matter how much room it had.
+  Short runs now stretch across the full plot; long runs still downsample. No
+  additional samples are synthesized; the connecting line between two measured
+  seconds simply gets more pixels than it had.
+- The chart's right-hand error axis is omitted when the run had no errors,
+  instead of drawing a column of zeroes beside a clean result.
+- `raw` and `consistency` are no longer printed twice. They stay in the hero as
+  headline stats; the stats grid keeps `test type`, `characters`, and `time`,
+  now as one aligned column.
 
-No config, storage, or release-archive contract changes. The plain
-`typeburn update` output used by pipes, redirects, and CI is unchanged apart
-from the new `checksums...` line. Existing history and settings files are fully
-compatible.
+### Fixed
+
+- The Result panel under-counted its own border by two columns, which limited
+  how much width any section could safely use.
+
+No CLI, config, storage, or release-archive contract changes. Existing history
+and settings files are fully compatible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-08-01
+
 ### Changed
 
 - **Result screen now uses the width it has.** The panel is capped and centred

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -4,9 +4,9 @@
 
 ## Current Release State
 
-**Public stable:** `v2.7.0` (2026-08-01). The self-updater now renders an
-animated progress block driven by real download bytes, and stops cleanly when
-interrupted instead of leaking its update lock.
+**Public stable:** `v2.8.0` (2026-08-01). The Result screen now adapts to the
+terminal it is drawn in; the self-updater renders an animated progress block
+driven by real download bytes and stops cleanly when interrupted.
 
 ---
 
@@ -128,7 +128,7 @@ interrupted instead of leaking its update lock.
   cancellation, so the command never claims nothing changed while the binary
   was in fact replaced.
 
-#### Result Responsive Layout — ✅ SHIPPED
+#### Result Responsive Layout — ✅ SHIPPED in v2.8.0 (2026-08-01)
 - **Description:** the Result screen used the width it was given rather than the
   width its content happened to want. The panel is capped at
   `resultMaxContentW` and centred; the WPM chart fills its cell budget instead
@@ -305,6 +305,11 @@ interrupted instead of leaking its update lock.
 - ✅ **v2.3.0 (Self-Update):** stdlib-only atomic self-updater via `typeburn update`, preflight managed-install check, redirect allowlist, O_EXCL locks, archive path-traversal safety, Windows move-aside rollback. Ship date: 2026-05-30.
 - ✅ **v2.4.0 (Update UX):** In-app hint directs to self-updater; download progress reporting. Ship date: 2026-05-30.
 - ✅ **v2.4.1 (UI Animations):** stdlib-only terminal motion layer (blink/fade caret, stats reveal count-up, sparkle personal best celebration, Typing→Result transition) with NO_COLOR adaptation and hot-path token cache. Ship date: 2026-06-20.
+- ✅ **v2.8.0 (Result Responsive Layout):** the Result panel is capped and
+  centred instead of stretching with the terminal, the WPM chart fills its panel
+  rather than matching the run's length, the error axis is dropped on clean
+  runs, and `raw`/`consistency` are no longer printed twice. Ship date:
+  2026-08-01.
 - ✅ **v2.7.0 (Animated Update CLI):** `typeburn update` renders a bordered
   checklist with a spring-smoothed gradient bar driven by real byte-level
   download progress; plain output preserved for pipes/CI/narrow terminals;


### PR DESCRIPTION
Release-prep for v2.8.0 (Result Responsive Layout).

- CHANGELOG: `[Unreleased]` → `[2.8.0] - 2026-08-01`
- `.github/release-notes.md`: the 2.8.0 section extracted verbatim for GoReleaser's `--release-notes`
- `docs/project-roadmap.md`: current-stable line, ship entry, feature marked shipped

No code changes. After this merges, v2.8.0 is tagged on the merged commit and pushed separately.

**Note:** the manual visual pass on a real terminal (3 widths × 2 color modes) has still not been performed — this environment has no pty. The maintainer chose to proceed. A stable tag is immutable, so any defect is fixed forward with v2.8.1.

https://claude.ai/code/session_017Zp94DisnjwRdkFofodUNn