### PR TITLE
chore(release): prepare v2.8.1

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,25 +1,10 @@
-## [2.8.0] - 2026-08-01 — Result Responsive Layout
-
-### Changed
-
-- **Result screen now uses the width it has.** The panel is capped and centred
-  instead of stretching to fill the terminal, so a wide screen no longer shows a
-  near-empty box with everything crammed into the top-left corner.
-- The WPM chart fills its panel. It previously took its width from the data, so
-  an eight-second test drew an eight-cell chart no matter how much room it had.
-  Short runs now stretch across the full plot; long runs still downsample. No
-  additional samples are synthesized; the connecting line between two measured
-  seconds simply gets more pixels than it had.
-- The chart's right-hand error axis is omitted when the run had no errors,
-  instead of drawing a column of zeroes beside a clean result.
-- `raw` and `consistency` are no longer printed twice. They stay in the hero as
-  headline stats; the stats grid keeps `test type`, `characters`, and `time`,
-  now as one aligned column.
+## [2.8.1] - 2026-08-01 — Centring Fix
 
 ### Fixed
 
-- The Result panel under-counted its own border by two columns, which limited
-  how much width any section could safely use.
+- The Result panel is centred again. v2.8.0 added horizontal padding to the
+  panel while the frame was already being centred, so the panel drifted right —
+  at 200 columns it sat 79 columns from the left edge and 27 from the right.
 
-No CLI, config, storage, or release-archive contract changes. Existing history
-and settings files are fully compatible.
+A regression fix for v2.8.0 only. No CLI, config, storage, or release-archive
+contract changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release section is extracted verbatim and passed to GoReleaser via
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-08-01
+
 ### Fixed
 
 - The Result panel is centred again. v2.8.0 added horizontal padding to the

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -4,7 +4,7 @@
 
 ## Current Release State
 
-**Public stable:** `v2.8.0` (2026-08-01). The Result screen now adapts to the
+**Public stable:** `v2.8.1` (2026-08-01). The Result screen adapts to the
 terminal it is drawn in; the self-updater renders an animated progress block
 driven by real download bytes and stops cleanly when interrupted.
 
@@ -305,6 +305,12 @@ driven by real download bytes and stops cleanly when interrupted.
 - ✅ **v2.3.0 (Self-Update):** stdlib-only atomic self-updater via `typeburn update`, preflight managed-install check, redirect allowlist, O_EXCL locks, archive path-traversal safety, Windows move-aside rollback. Ship date: 2026-05-30.
 - ✅ **v2.4.0 (Update UX):** In-app hint directs to self-updater; download progress reporting. Ship date: 2026-05-30.
 - ✅ **v2.4.1 (UI Animations):** stdlib-only terminal motion layer (blink/fade caret, stats reveal count-up, sparkle personal best celebration, Typing→Result transition) with NO_COLOR adaptation and hot-path token cache. Ship date: 2026-06-20.
+- ✅ **v2.8.1 (Centring Fix):** corrects a v2.8.0 regression that centred the
+  Result panel twice — the width policy padded horizontally while the root was
+  already placing the frame, so the panel drifted right. The guarding test had
+  asserted the layout helper's own arithmetic rather than the rendered screen,
+  and passed throughout; it now measures the margins either side of the
+  rendered panel border. Ship date: 2026-08-01.
 - ✅ **v2.8.0 (Result Responsive Layout):** the Result panel is capped and
   centred instead of stretching with the terminal, the WPM chart fills its panel
   rather than matching the run's length, the error axis is dropped on clean


### PR DESCRIPTION
Release-prep for v2.8.1 — a regression fix for v2.8.0.

- CHANGELOG: `[Unreleased]` → `[2.8.1] - 2026-08-01`
- `.github/release-notes.md`: the 2.8.1 section for GoReleaser's `--release-notes`
- `docs/project-roadmap.md`: current-stable line and ship entry

No code changes. v2.8.0 stays published — the module proxy is append-only, so a defective release is fixed forward, never re-tagged.

https://claude.ai/code/session_017Zp94DisnjwRdkFofodUNn