### PR TITLE
fix(metrics): stop impossible results being computed and persisted

### DIFF
--- a/internal/app/model_history.go
+++ b/internal/app/model_history.go
@@ -38,21 +38,57 @@ func buildRecord(msg ui.ResultMsg) storage.Record {
 	}
 }
 
+// afkNotice tells the user why a run they finished is missing from history.
+// Dropping it silently would look like the app lost the run, which is a worse
+// failure than the impossible score the withholding exists to keep out.
+const afkNotice = "paused mid-test — not saved to history"
+
+// resultOutcome is what a completed run does to stored history: whether it is
+// written, whether it ranks, and what the user is told. Deciding it separately
+// from applying it keeps the rule assertable without a disk write standing in
+// for it.
+type resultOutcome struct {
+	record storage.Record
+	store  bool
+	isBest bool
+	notice string
+}
+
+// decideOutcome resolves a finished run against the history already on disk.
+//
+// A run whose clock was cut back by trailing inactivity is shown but never
+// written, and never ranked. Its rates describe the burst the user typed before
+// they walked away, not a test they took, so a stored record of it would stand
+// as a personal best nobody could beat by typing.
+func decideOutcome(msg ui.ResultMsg, hist []storage.Record) resultOutcome {
+	if msg.Result.AFKTrimmed {
+		return resultOutcome{notice: afkNotice}
+	}
+	rec := buildRecord(msg)
+	return resultOutcome{record: rec, store: true, isBest: storage.IsNewBest(hist, rec)}
+}
+
 // handleResultMsg processes a completed test: persists the record, detects
 // new-best, and builds the ResultModel with isBest set appropriately.
 // It mutates the model in place and returns it ready for ScreenResult.
+//
+// This is the only place results are persisted, so it is the only place the
+// eligibility rules have to hold.
 func (m Model) handleResultMsg(msg ui.ResultMsg) Model {
-	rec := buildRecord(msg)
-	hist := storage.LoadHistory()
-	isBest := storage.IsNewBest(hist, rec)
-	// Persist regardless of IsNewBest result. A write failure is non-fatal to
-	// the session but must not be silent — surface a dismissible notice.
-	if _, err := storage.AppendHistory(rec); err != nil {
-		m.persistErr = "Couldn't save result to disk"
+	out := decideOutcome(msg, storage.LoadHistory())
+	if out.notice != "" {
+		m.persistErr = out.notice
+	}
+	if out.store {
+		// Persist regardless of the new-best result. A write failure is non-fatal
+		// to the session but must not be silent — surface a dismissible notice.
+		if _, err := storage.AppendHistory(out.record); err != nil {
+			m.persistErr = "Couldn't save result to disk"
+		}
 	}
 
 	m.result = ui.NewResult(msg, m.theme, m.keys).
-		WithBest(isBest).
+		WithBest(out.isBest).
 		WithUpdateHint(m.updateHint).
 		WithRevealStart(nowUTC().UnixMilli()).
 		SetSize(m.w, m.h)

--- a/internal/app/model_view.go
+++ b/internal/app/model_view.go
@@ -56,19 +56,46 @@ func (m Model) View() tea.View {
 		out = renderTransition(m.transition.fromFrame, out, p, noColor)
 	}
 
-	// Transient persistence-failure toast: overlay onto the frame's last row
-	// (normally blank padding) so the line count — and thus every other
-	// screen's layout — is unchanged. Cleared on the next keypress.
+	// Transient notice (a failed write, or a run withheld from history).
+	// Cleared on the next keypress.
 	if m.persistErr != "" && m.w > 0 && m.h > 0 {
-		lines := strings.Split(out, "\n")
-		notice := lipgloss.PlaceHorizontal(
-			m.w, lipgloss.Center, ui.PersistenceNotice(m.persistErr, m.theme),
-		)
-		lines[len(lines)-1] = notice
-		out = strings.Join(lines, "\n")
+		out = overlayNotice(out, ui.PersistenceNotice(m.persistErr, m.theme), m.w, m.h)
 	}
 
 	return altView(out)
+}
+
+// overlayNotice puts a one-line notice on the last row the terminal actually
+// shows, which is not the same as the frame's last line.
+//
+// Writing to the frame's last line is wrong in both directions. When the frame
+// is taller than the terminal that line is clipped away, so the notice is
+// invisible in exactly the situation that produced it. When the frame is
+// shorter, the last line belongs to the screen and overwriting it destroys
+// content the user needs.
+//
+// So the notice takes the chosen row only when that row is blank padding, and
+// is otherwise inserted above it, pushing the frame down by one. The one
+// exception is a frame that already exceeds the terminal: a pushed-down row
+// falls off the bottom regardless, and lengthening the frame further would
+// only widen the overflow.
+func overlayNotice(frame, notice string, w, h int) string {
+	lines := strings.Split(frame, "\n")
+	row := len(lines) - 1
+	if h-1 < row {
+		row = h - 1
+	}
+	if row < 0 {
+		return frame
+	}
+
+	placed := lipgloss.PlaceHorizontal(w, lipgloss.Center, notice)
+	if strings.TrimSpace(lines[row]) == "" || len(lines) > h {
+		lines[row] = placed
+	} else {
+		lines = append(lines[:row], append([]string{placed}, lines[row:]...)...)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // composeScreen renders a single screen to its final placed frame. Home/Result/

--- a/internal/app/notice_placement_test.go
+++ b/internal/app/notice_placement_test.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// noticeRow returns the index of the row carrying want, or -1.
+func noticeRow(frame, want string) int {
+	for i, ln := range strings.Split(stripANSI(frame), "\n") {
+		if strings.Contains(ln, want) {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestOverlayNotice_LandsOnARowTheTerminalShows is the whole point of the
+// placement: a notice written to the frame's last line disappears the moment
+// the frame is taller than the terminal, which is precisely when there is
+// something worth saying.
+func TestOverlayNotice_LandsOnARowTheTerminalShows(t *testing.T) {
+	const notice = "something to say"
+
+	for _, tc := range []struct {
+		name  string
+		frame string
+		w, h  int
+	}{
+		{"frame taller than the terminal", strings.Repeat("content\n", 28) + "content", 80, 24},
+		{"frame exactly the terminal height", strings.Repeat("content\n", 23) + "content", 80, 24},
+		{"frame shorter than the terminal", strings.Repeat("content\n", 9) + "content", 80, 24},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := overlayNotice(tc.frame, notice, tc.w, tc.h)
+			row := noticeRow(out, notice)
+			if row < 0 {
+				t.Fatalf("the notice is not in the frame at all:\n%s", out)
+			}
+			if row > tc.h-1 {
+				t.Errorf("notice on row %d of a %d-row terminal — clipped away", row, tc.h)
+			}
+		})
+	}
+}
+
+// TestOverlayNotice_DoesNotOverwriteContent: when the chosen row carries
+// something, the notice is inserted rather than written over it. The footer
+// keybindings are not an acceptable price for a toast.
+func TestOverlayNotice_DoesNotOverwriteContent(t *testing.T) {
+	frame := strings.Join([]string{"one", "two", "footer"}, "\n")
+
+	out := overlayNotice(frame, "notice", 20, 10)
+
+	for _, want := range []string{"one", "two", "footer", "notice"} {
+		if !strings.Contains(stripANSI(out), want) {
+			t.Errorf("%q was lost:\n%s", want, stripANSI(out))
+		}
+	}
+}
+
+// TestOverlayNotice_TakesABlankRowWithoutGrowingTheFrame: the common case is a
+// frame padded to the terminal height, where the notice costs nothing.
+func TestOverlayNotice_TakesABlankRowWithoutGrowingTheFrame(t *testing.T) {
+	frame := strings.Join([]string{"one", "two", "footer", "    "}, "\n")
+
+	out := overlayNotice(frame, "notice", 20, 4)
+
+	if got := len(strings.Split(out, "\n")); got != 4 {
+		t.Errorf("frame grew to %d rows; the blank padding row was free", got)
+	}
+	if row := noticeRow(out, "notice"); row != 3 {
+		t.Errorf("notice on row %d, want the blank row 3", row)
+	}
+}
+
+// TestOverlayNotice_DoesNotWidenAFrameThatFits guards the horizontal axis: a
+// notice narrower than the terminal must not push the frame wider than the
+// content it joins.
+func TestOverlayNotice_DoesNotWidenAFrameThatFits(t *testing.T) {
+	frame := strings.Join([]string{strings.Repeat("x", 40), strings.Repeat(" ", 40)}, "\n")
+
+	out := overlayNotice(frame, "short", 40, 2)
+
+	for i, ln := range strings.Split(stripANSI(out), "\n") {
+		if got := lipgloss.Width(ln); got > 40 {
+			t.Errorf("row %d is %d cells wide in a 40-column terminal", i, got)
+		}
+	}
+}
+
+// TestView_NoticeIsVisibleAtTheSmallestSupportedSize exercises the real frame
+// rather than a synthetic one: the notice must reach the user at 80×24, the
+// size the whole layout is budgeted against.
+func TestView_NoticeIsVisibleAtTheSmallestSupportedSize(t *testing.T) {
+	m := sm_sendSize(sandboxedModel(t), 80, 24).(Model)
+	m.persistErr = "Couldn't save result to disk"
+
+	row := noticeRow(m.View().Content, "Couldn't save result to disk")
+	if row < 0 {
+		t.Fatal("the notice never reached the frame")
+	}
+	if row > 23 {
+		t.Errorf("notice on row %d of a 24-row terminal — the user never sees it", row)
+	}
+}

--- a/internal/app/result_persistence_test.go
+++ b/internal/app/result_persistence_test.go
@@ -1,0 +1,131 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/storage"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
+	"github.com/bavanchun/Typeburn/v2/internal/ui"
+)
+
+// The defect this file exists for spanned four packages: an AFK trim in
+// metrics, a rate computed from what it left, a record built in app, and a
+// personal best written by storage. Every one of those packages had tests, and
+// every one of them agreed with itself. Nothing asserted across the seam, so a
+// run the user abandoned after three keystrokes became a permanent best nobody
+// could beat by typing.
+//
+// These tests run a real keystroke log through the whole chain and assert on
+// what ends up on disk.
+
+// abandonedTimeRun is a 30-second Time test with three keystrokes in its first
+// tenth of a second and nothing after: the shape that produced the bad best.
+func abandonedTimeRun() ui.ResultMsg {
+	log := []typing.Keystroke{
+		{TimeMs: 1000, Typed: 'a', Target: 'a', Correct: true},
+		{TimeMs: 1050, Typed: 'b', Target: 'b', Correct: true},
+		{TimeMs: 1100, Typed: 'c', Target: 'c', Correct: true},
+	}
+	return ui.ResultMsg{
+		Result: metrics.Compute(log, config.ModeTime, 1000+30_000),
+		Mode:   config.ModeTime,
+		Length: 30,
+	}
+}
+
+// typedTimeRun is the same 30-second test typed all the way through.
+func typedTimeRun() ui.ResultMsg {
+	log := make([]typing.Keystroke, 150)
+	for i := range log {
+		log[i] = typing.Keystroke{
+			TimeMs: 1000 + int64(i)*200, Typed: 'a', Target: 'a', Correct: true,
+		}
+	}
+	return ui.ResultMsg{
+		Result: metrics.Compute(log, config.ModeTime, 1000+30_000),
+		Mode:   config.ModeTime,
+		Length: 30,
+	}
+}
+
+// TestResult_AbandonedRunIsNeitherStoredNorRanked walks the full chain.
+func TestResult_AbandonedRunIsNeitherStoredNorRanked(t *testing.T) {
+	m := sandboxedModel(t)
+	msg := abandonedTimeRun()
+
+	if !msg.Result.AFKTrimmed {
+		t.Fatal("precondition: this run must reach the root model marked as abandoned")
+	}
+
+	if out := decideOutcome(msg, storage.LoadHistory()); out.store || out.isBest {
+		t.Errorf("an abandoned run resolved to store=%v isBest=%v", out.store, out.isBest)
+	}
+
+	m.handleResultMsg(msg)
+
+	if got := storage.LoadHistory(); len(got) != 0 {
+		t.Errorf("history holds %d records; an abandoned run must not be written: %+v", len(got), got)
+	}
+}
+
+// TestResult_AbandonedRunCannotDisplaceALaterTypedRun is the consequence that
+// made the defect permanent: a stored burst sets a bar in its bucket that no
+// real run beats, so the user never sees a best again.
+func TestResult_AbandonedRunCannotDisplaceALaterTypedRun(t *testing.T) {
+	m := sandboxedModel(t)
+
+	m = m.handleResultMsg(abandonedTimeRun())
+	typed := typedTimeRun()
+
+	if out := decideOutcome(typed, storage.LoadHistory()); !out.isBest {
+		t.Error("the first run the user actually typed must rank as their best")
+	}
+	m.handleResultMsg(typed)
+
+	hist := storage.LoadHistory()
+	if len(hist) != 1 {
+		t.Fatalf("want exactly the typed run stored, got %d records: %+v", len(hist), hist)
+	}
+}
+
+// TestResult_TypedRunIsStoredAndRanked guards the other direction — the gate
+// must not swallow ordinary results.
+func TestResult_TypedRunIsStoredAndRanked(t *testing.T) {
+	m := sandboxedModel(t)
+
+	msg := typedTimeRun()
+	out := decideOutcome(msg, storage.LoadHistory())
+	after := m.handleResultMsg(msg)
+
+	hist := storage.LoadHistory()
+	if len(hist) != 1 {
+		t.Fatalf("want 1 stored record, got %d", len(hist))
+	}
+	if !out.store || !out.isBest || !storage.EligibleForBest(hist[0]) {
+		t.Error("a completed Time run must be stored and ranked")
+	}
+	if after.persistErr != "" {
+		t.Errorf("no notice expected on the ordinary path, got %q", after.persistErr)
+	}
+}
+
+// TestResult_WithholdingIsVisible: silently dropping a result would look like
+// the app lost the run, which is worse than the score being wrong. The notice
+// has to survive into the frame the user is looking at, at the smallest size
+// the app supports.
+func TestResult_WithholdingIsVisible(t *testing.T) {
+	m := sm_sendSize(sandboxedModel(t), 80, 24).(Model)
+
+	m = m.handleResultMsg(abandonedTimeRun())
+
+	if m.persistErr != afkNotice {
+		t.Fatalf("want the withholding notice set, got %q", m.persistErr)
+	}
+	frame := stripANSI(m.View().Content)
+	if !strings.Contains(frame, "not saved to history") {
+		t.Errorf("the user is not told why the run is missing:\n%s", frame)
+	}
+}

--- a/internal/cli/notui/runner.go
+++ b/internal/cli/notui/runner.go
@@ -114,6 +114,9 @@ func drive(
 				timerArmed = true
 			}
 
+			// Progress is a count in a single unit per mode — words for Time and
+			// Words, runes for Quote and Code — so the status line's "done/total"
+			// compares two comparable numbers in every mode.
 			done, total := session.Engine.Progress()
 			elapsed := nowMs - session.Engine.StartMs()
 			live := metrics.LiveWPM(session.Engine.Log(), elapsed)

--- a/internal/metrics/afk_trim.go
+++ b/internal/metrics/afk_trim.go
@@ -16,11 +16,17 @@ const afkThresholdMs int64 = 7000 // strictly greater than this triggers AFK tri
 // ModeWords and ModeQuote are never trimmed, even with long gaps — the test
 // ends by completion event, not by time, so idle gaps are intentional pauses.
 //
-// Returns the (possibly unchanged) log and the effective endMs to use for
-// metric computation. The log itself is never modified; only endMs changes.
-func TrimAFK(log []typing.Keystroke, m mode.Mode, endMs int64) ([]typing.Keystroke, int64) {
+// Returns the (possibly unchanged) log, the effective endMs to use for metric
+// computation, and whether endMs was actually moved. The log itself is never
+// modified; only endMs changes.
+//
+// The trimmed flag matters downstream: once the clock is cut back to the last
+// keystroke, every rate is extrapolated from the burst the user typed before
+// they stopped, not from the test they sat through. Such a run is shown but not
+// recorded, so the caller has to be able to tell.
+func TrimAFK(log []typing.Keystroke, m mode.Mode, endMs int64) ([]typing.Keystroke, int64, bool) {
 	if m != mode.ModeTime {
-		return log, endMs
+		return log, endMs, false
 	}
 
 	// Find the last forward keystroke (non-backspace).
@@ -34,13 +40,13 @@ func TrimAFK(log []typing.Keystroke, m mode.Mode, endMs int64) ([]typing.Keystro
 
 	if lastKeyMs < 0 {
 		// No forward keystrokes at all — nothing to trim.
-		return log, endMs
+		return log, endMs, false
 	}
 
 	gap := endMs - lastKeyMs
 	if gap > afkThresholdMs {
-		return log, lastKeyMs
+		return log, lastKeyMs, true
 	}
 
-	return log, endMs
+	return log, endMs, false
 }

--- a/internal/metrics/afk_trim_test.go
+++ b/internal/metrics/afk_trim_test.go
@@ -22,9 +22,12 @@ func TestAFKTrim(t *testing.T) {
 		e.Apply('o', 5000)
 		// last keystroke at 5000; endMs=15000 → gap=10000ms > 7000ms → trim
 		log := e.Log()
-		trimmed, effectiveEnd := metrics.TrimAFK(log, config.ModeTime, 15000)
+		trimmed, effectiveEnd, didTrim := metrics.TrimAFK(log, config.ModeTime, 15000)
 		if effectiveEnd != 5000 {
 			t.Errorf("Time AFK: want effectiveEnd=5000, got %d", effectiveEnd)
+		}
+		if !didTrim {
+			t.Error("Time AFK: a moved endMs must be reported as trimmed")
 		}
 		// trimmed log should only contain keystrokes up to last active key
 		if len(trimmed) != len(log) {
@@ -41,9 +44,9 @@ func TestAFKTrim(t *testing.T) {
 		e.Apply('i', 2000)
 		// last key at 2000; endMs=9000 → gap=7000ms (not > 7000ms)
 		log := e.Log()
-		_, effectiveEnd := metrics.TrimAFK(log, config.ModeTime, 9000)
-		if effectiveEnd != 9000 {
-			t.Errorf("gap exactly 7s: want effectiveEnd=9000 (no trim), got %d", effectiveEnd)
+		_, effectiveEnd, didTrim := metrics.TrimAFK(log, config.ModeTime, 9000)
+		if effectiveEnd != 9000 || didTrim {
+			t.Errorf("gap exactly 7s: want effectiveEnd=9000 untrimmed, got %d trimmed=%v", effectiveEnd, didTrim)
 		}
 	})
 
@@ -53,9 +56,9 @@ func TestAFKTrim(t *testing.T) {
 		e.Apply('i', 2000)
 		log := e.Log()
 		// 10s gap but Words mode → no trim
-		_, effectiveEnd := metrics.TrimAFK(log, config.ModeWords, 12000)
-		if effectiveEnd != 12000 {
-			t.Errorf("Words mode: want effectiveEnd=12000 (no trim), got %d", effectiveEnd)
+		_, effectiveEnd, didTrim := metrics.TrimAFK(log, config.ModeWords, 12000)
+		if effectiveEnd != 12000 || didTrim {
+			t.Errorf("Words mode: want effectiveEnd=12000 untrimmed, got %d trimmed=%v", effectiveEnd, didTrim)
 		}
 	})
 
@@ -64,16 +67,16 @@ func TestAFKTrim(t *testing.T) {
 		e.Apply('t', 1000)
 		e.Apply('h', 2000)
 		log := e.Log()
-		_, effectiveEnd := metrics.TrimAFK(log, config.ModeQuote, 12000)
-		if effectiveEnd != 12000 {
-			t.Errorf("Quote mode: want effectiveEnd=12000 (no trim), got %d", effectiveEnd)
+		_, effectiveEnd, didTrim := metrics.TrimAFK(log, config.ModeQuote, 12000)
+		if effectiveEnd != 12000 || didTrim {
+			t.Errorf("Quote mode: want effectiveEnd=12000 untrimmed, got %d trimmed=%v", effectiveEnd, didTrim)
 		}
 	})
 
 	t.Run("Empty log: TrimAFK returns original endMs regardless of mode", func(t *testing.T) {
-		_, effectiveEnd := metrics.TrimAFK(nil, config.ModeTime, 5000)
-		if effectiveEnd != 5000 {
-			t.Errorf("empty log: want effectiveEnd=5000, got %d", effectiveEnd)
+		_, effectiveEnd, didTrim := metrics.TrimAFK(nil, config.ModeTime, 5000)
+		if effectiveEnd != 5000 || didTrim {
+			t.Errorf("empty log: want effectiveEnd=5000 untrimmed, got %d trimmed=%v", effectiveEnd, didTrim)
 		}
 	})
 
@@ -83,9 +86,9 @@ func TestAFKTrim(t *testing.T) {
 		e.Apply('i', 3000)
 		log := e.Log()
 		// last key at 3000; endMs=8000 → gap=5000ms < 7000ms
-		_, effectiveEnd := metrics.TrimAFK(log, config.ModeTime, 8000)
-		if effectiveEnd != 8000 {
-			t.Errorf("small gap: want effectiveEnd=8000, got %d", effectiveEnd)
+		_, effectiveEnd, didTrim := metrics.TrimAFK(log, config.ModeTime, 8000)
+		if effectiveEnd != 8000 || didTrim {
+			t.Errorf("small gap: want effectiveEnd=8000 untrimmed, got %d trimmed=%v", effectiveEnd, didTrim)
 		}
 	})
 
@@ -103,6 +106,9 @@ func TestAFKTrim(t *testing.T) {
 		// With AFK trim: endMs adjusted to 5000, duration = 5000-1000 = 4000ms
 		if r.DurationMs != 4000 {
 			t.Errorf("Compute with AFK trim: want DurationMs=4000, got %d", r.DurationMs)
+		}
+		if !r.AFKTrimmed {
+			t.Error("Compute must carry the trim forward: a caller cannot tell a trimmed run from a typed one otherwise")
 		}
 	})
 }

--- a/internal/metrics/compute.go
+++ b/internal/metrics/compute.go
@@ -18,12 +18,23 @@ type Result struct {
 	CorrectChars   int // chars in Correct final state
 	IncorrectChars int // chars in Incorrect/IncorrectSpace final state (uncorrected)
 	ExtraChars     int // chars typed past target length
-	Errors         int // alias for IncorrectChars (uncorrected errors)
+
+	// Errors is every wrong key the run is charged for: the uncorrected errors
+	// left in the final state, plus every keystroke strict mode refused. A
+	// strict run has almost nothing wrong in its final state — the cursor never
+	// moves past a wrong key — so counting only the final state would report a
+	// run full of mistakes as error-free.
+	Errors int
 
 	DurationMs int64       // effective test duration (endMs - startMs, after AFK trim)
 	PerSecond  []PerSecond // per-second breakdown
 
-	KeyMisses []KeyMiss // per-key fumble tally (nil on empty/zero-duration logs)
+	// AFKTrimmed records that trailing inactivity cut the clock back to the last
+	// keystroke. Every rate below is then extrapolated from the burst before the
+	// user stopped, so such a run is displayed but never persisted or ranked.
+	AFKTrimmed bool
+
+	KeyMisses []KeyMiss // per-key fumble tally (nil when no key was ever missed)
 }
 
 // Compute derives all metrics from the keystroke log, mode, and caller-supplied
@@ -40,20 +51,26 @@ type Result struct {
 //   - A char typed wrong then corrected via backspace counts as Correct → 100%.
 //   - An uncorrected error counts as Incorrect → penalises accuracy.
 //   - Zero chars typed → Accuracy = 100, all others = 0.
+//
+// An empty log is the only run that reports perfect accuracy for free: nothing
+// was typed, so nothing was typed wrong. A run with no measurable duration —
+// every keystroke inside one millisecond, or an AFK trim that collapsed the
+// window onto the last keystroke — still reports the accuracy of what it
+// contains; only the rates, which have nothing to divide by, come back zero.
 func Compute(log []typing.Keystroke, mode mode.Mode, endMs int64) Result {
 	if len(log) == 0 {
 		return Result{Accuracy: 100, KeystrokeAccuracy: 100}
 	}
 
 	// Apply AFK trim (no-op for non-Time modes).
-	log, endMs = TrimAFK(log, mode, endMs)
+	log, endMs, afkTrimmed := TrimAFK(log, mode, endMs)
 
 	// startMs = first keystroke time (first entry in log).
 	startMs := log[0].TimeMs
 
 	durationMs := endMs - startMs
-	if durationMs <= 0 {
-		return Result{Accuracy: 100, KeystrokeAccuracy: 100}
+	if durationMs < 0 {
+		durationMs = 0
 	}
 
 	// Compute final char state by replaying the log.
@@ -71,24 +88,36 @@ func Compute(log []typing.Keystroke, mode mode.Mode, endMs int64) Result {
 		}
 	}
 
-	// Total forward keystrokes (non-backspace) for RawWPM and CPS.
-	var totalTyped int
-	var correctForward int
+	// Forward keystrokes (non-backspace) for RawWPM, CPS and keystroke accuracy.
+	// A strict-blocked keystroke counts here: the user pressed the key, and it
+	// was wrong. Only the reconstructed buffer above ignores it.
+	var totalTyped, correctForward, blocked int
 	for _, k := range log {
-		if k.Typed != 0 {
-			totalTyped++
-			if k.Correct {
-				correctForward++
-			}
+		if k.Typed == 0 {
+			continue
+		}
+		totalTyped++
+		if k.Correct {
+			correctForward++
+		}
+		if k.Blocked {
+			blocked++
 		}
 	}
 
-	minutes := float64(durationMs) / 60000.0
-	seconds := float64(durationMs) / 1000.0
-
-	netWPM := float64(correct) / 5.0 / minutes
-	rawWPM := float64(totalTyped) / 5.0 / minutes
-	cps := float64(totalTyped) / seconds
+	// Rates need a window long enough to extrapolate from. An AFK trim that cut
+	// the clock back onto a short burst leaves one that is not: the same five
+	// keys that read as a plausible pace over a second read as four-figure WPM
+	// over eighty milliseconds. The counts and accuracies below are still facts
+	// about what was typed and are reported either way.
+	var netWPM, rawWPM, cps float64
+	if durationMs >= minRateWindowMs {
+		minutes := float64(durationMs) / 60000.0
+		seconds := float64(durationMs) / 1000.0
+		netWPM = float64(correct) / 5.0 / minutes
+		rawWPM = float64(totalTyped) / 5.0 / minutes
+		cps = float64(totalTyped) / seconds
+	}
 
 	// Accuracy: 100 * correct / (correct + incorrect) on final state.
 	var accuracy float64
@@ -105,13 +134,10 @@ func Compute(log []typing.Keystroke, mode mode.Mode, endMs int64) Result {
 		keystrokeAccuracy = 100.0 * float64(correctForward) / float64(totalTyped)
 	}
 
-	// Per-second buckets and consistency.
+	// Per-second buckets and consistency. Every bucket is kept for the graph;
+	// consistency samples only the seconds that fully elapsed.
 	perSec := bucketPerSecond(log, startMs)
-	rawSamples := make([]float64, len(perSec))
-	for i, ps := range perSec {
-		rawSamples[i] = ps.RawWPM
-	}
-	cons := Consistency(rawSamples)
+	cons := Consistency(consistencySamples(perSec, durationMs))
 
 	return Result{
 		NetWPM:            netWPM,
@@ -123,9 +149,10 @@ func Compute(log []typing.Keystroke, mode mode.Mode, endMs int64) Result {
 		CorrectChars:      correct,
 		IncorrectChars:    incorrect,
 		ExtraChars:        extra,
-		Errors:            incorrect,
+		Errors:            incorrect + blocked,
 		DurationMs:        durationMs,
 		PerSecond:         perSec,
+		AFKTrimmed:        afkTrimmed,
 		KeyMisses:         KeyHeatmap(log),
 	}
 }
@@ -135,44 +162,20 @@ type charResult struct {
 	correct bool
 }
 
-// replayFinalState replays the keystroke log to determine the final typed rune
-// at each target position. Backspace events (Typed == 0) pop the last position.
-// Returns a slice of charResult indexed by target position, and the count of
-// extra runes typed past the target.
+// replayFinalState determines the final correctness of each target position
+// from the buffer typing.ReplayBuffer reconstructs, plus the count of extra
+// runes typed past the target (Target == 0 marks a position with nothing to
+// match). The reconstruction itself lives in the typing package so that this
+// and the UI's live replay cannot drift apart.
 func replayFinalState(log []typing.Keystroke) ([]charResult, int) {
-	// We reconstruct the typed buffer step by step.
-	type slot struct {
-		typed   rune
-		target  rune
-		correct bool
-		isExtra bool
-	}
-	var buf []slot
-
-	for _, k := range log {
-		if k.Typed == 0 {
-			// Backspace: pop last slot.
-			if len(buf) > 0 {
-				buf = buf[:len(buf)-1]
-			}
-			continue
-		}
-		buf = append(buf, slot{
-			typed:   k.Typed,
-			target:  k.Target,
-			correct: k.Correct,
-			isExtra: k.Target == 0, // target==0 means extra (past end)
-		})
-	}
-
 	var results []charResult
 	extraTyped := 0
-	for _, s := range buf {
-		if s.isExtra {
+	for _, k := range typing.ReplayBuffer(log) {
+		if k.Target == 0 {
 			extraTyped++
-		} else {
-			results = append(results, charResult{correct: s.correct})
+			continue
 		}
+		results = append(results, charResult{correct: k.Correct})
 	}
 	return results, extraTyped
 }

--- a/internal/metrics/compute_truthfulness_test.go
+++ b/internal/metrics/compute_truthfulness_test.go
@@ -1,0 +1,175 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
+)
+
+// typeInto applies each rune of s at 100ms intervals from ts and returns the
+// timestamp after the last one.
+func typeInto(e *typing.Engine, s string, ts int64) int64 {
+	for _, r := range s {
+		e.Apply(r, ts)
+		ts += 100
+	}
+	return ts
+}
+
+// TestCompute_ZeroDurationReportsWhatWasTyped: a run with no measurable
+// duration still has facts about what the user pressed. Reporting 100% for it
+// invented a flawless run out of a single wrong keystroke, and because that was
+// also the first record in its bucket it became a permanent personal best.
+func TestCompute_ZeroDurationReportsWhatWasTyped(t *testing.T) {
+	// One wrong key at t=1000 in a 15s-idle Time run: the trim pulls endMs back
+	// onto that keystroke, leaving a window of zero.
+	log := []typing.Keystroke{{TimeMs: 1000, Typed: 'q', Target: 'h', Correct: false}}
+
+	r := metrics.Compute(log, config.ModeTime, 16000)
+
+	if r.DurationMs != 0 {
+		t.Fatalf("precondition: want a zero-length window, got %dms", r.DurationMs)
+	}
+	if r.Accuracy != 0 {
+		t.Errorf("Accuracy is %.1f for a run whose only keystroke was wrong, want 0", r.Accuracy)
+	}
+	if r.KeystrokeAccuracy != 0 {
+		t.Errorf("KeystrokeAccuracy is %.1f, want 0", r.KeystrokeAccuracy)
+	}
+	if r.IncorrectChars != 1 || r.CorrectChars != 0 {
+		t.Errorf("want 0 correct / 1 incorrect, got %d / %d", r.CorrectChars, r.IncorrectChars)
+	}
+}
+
+// TestCompute_EmptyLogIsStillPerfect keeps the one case that legitimately
+// reports 100%: nothing was typed, so nothing was typed wrong.
+func TestCompute_EmptyLogIsStillPerfect(t *testing.T) {
+	r := metrics.Compute(nil, config.ModeTime, 30000)
+	if r.Accuracy != 100 || r.KeystrokeAccuracy != 100 {
+		t.Errorf("empty log: want 100/100, got %.1f/%.1f", r.Accuracy, r.KeystrokeAccuracy)
+	}
+}
+
+// TestCompute_AFKTrimIsReportedAndNoRateIsExtrapolated covers the run the
+// plausibility floor caught: three keys inside a tenth of a second in a
+// 30-second test. The trim leaves a window far too short to project a
+// per-minute rate from, and the caller has to be able to tell the run apart
+// from one that was actually typed.
+func TestCompute_AFKTrimIsReportedAndNoRateIsExtrapolated(t *testing.T) {
+	log := []typing.Keystroke{
+		{TimeMs: 1000, Typed: 'a', Target: 'a', Correct: true},
+		{TimeMs: 1050, Typed: 'b', Target: 'b', Correct: true},
+		{TimeMs: 1100, Typed: 'c', Target: 'c', Correct: true},
+	}
+
+	r := metrics.Compute(log, config.ModeTime, 1000+30_000)
+
+	if !r.AFKTrimmed {
+		t.Error("a run whose clock was cut back must say so")
+	}
+	if r.NetWPM != 0 || r.RawWPM != 0 || r.CPS != 0 {
+		t.Errorf("rates projected from a %dms window: net %.1f raw %.1f cps %.1f",
+			r.DurationMs, r.NetWPM, r.RawWPM, r.CPS)
+	}
+	// The characters themselves are still real.
+	if r.CorrectChars != 3 {
+		t.Errorf("want 3 correct chars, got %d", r.CorrectChars)
+	}
+}
+
+// TestCompute_TypedRunIsNotMarkedAFK guards the other direction: a run typed
+// through to the end must not be withheld.
+func TestCompute_TypedRunIsNotMarkedAFK(t *testing.T) {
+	var log []typing.Keystroke
+	for i := 0; i < 150; i++ {
+		log = append(log, typing.Keystroke{
+			TimeMs: 1000 + int64(i)*200, Typed: 'a', Target: 'a', Correct: true,
+		})
+	}
+	r := metrics.Compute(log, config.ModeTime, 1000+30_000)
+	if r.AFKTrimmed {
+		t.Error("a run typed up to the final seconds must not be treated as abandoned")
+	}
+	if r.NetWPM <= 0 {
+		t.Errorf("want a real rate, got %.2f", r.NetWPM)
+	}
+}
+
+// TestCompute_StrictAgreesWithTheEngineBuffer is the cross-check the strict
+// desync escaped: whatever the engine ends up holding, the replay must count
+// exactly that. The run below types three letters, hammers a wrong key five
+// times against a blocked cursor, deletes what it has and retypes the target in
+// full — so the engine holds "abcdef" and every character in it is correct.
+func TestCompute_StrictAgreesWithTheEngineBuffer(t *testing.T) {
+	e := typing.NewStrict("abcdef", config.ModeWords, 1, true)
+	ts := typeInto(e, "abc", 1000)
+	ts = typeInto(e, "zzzzz", ts)
+	for i := 0; i < 3; i++ {
+		e.Backspace(ts)
+		ts += 100
+	}
+	ts = typeInto(e, "abcdef", ts)
+
+	if got := string(e.Typed()); got != "abcdef" {
+		t.Fatalf("precondition: engine holds %q, want %q", got, "abcdef")
+	}
+
+	r := metrics.Compute(e.Log(), config.ModeWords, ts)
+
+	if r.CorrectChars != 6 {
+		t.Errorf("CorrectChars=%d, but the engine holds 6 correct characters", r.CorrectChars)
+	}
+	if r.IncorrectChars != 0 {
+		t.Errorf("IncorrectChars=%d, but nothing wrong survived in the buffer", r.IncorrectChars)
+	}
+	if r.ExtraChars != 0 {
+		t.Errorf("ExtraChars=%d, but nothing was typed past the target", r.ExtraChars)
+	}
+	if r.Accuracy != 100 {
+		t.Errorf("Accuracy=%.2f on a buffer that matches the target exactly", r.Accuracy)
+	}
+}
+
+// TestCompute_StrictErrorsAreKeystrokeLevel: under strict mode a wrong key
+// never reaches the final state, so counting only the final state reports a run
+// full of mistakes as error-free. Every wrong key is charged, including the
+// ones the user went back and fixed.
+func TestCompute_StrictErrorsAreKeystrokeLevel(t *testing.T) {
+	e := typing.NewStrict("abcdef", config.ModeWords, 1, true)
+	ts := typeInto(e, "abc", 1000)
+	ts = typeInto(e, "zzzzz", ts) // five refused keys
+	ts = typeInto(e, "def", ts)
+
+	r := metrics.Compute(e.Log(), config.ModeWords, ts)
+
+	if r.Errors != 5 {
+		t.Errorf("Errors=%d, want 5 — every key the mode refused", r.Errors)
+	}
+	// 6 correct out of the 11 keys pressed.
+	if got := r.KeystrokeAccuracy; got < 54.5 || got > 54.6 {
+		t.Errorf("KeystrokeAccuracy=%.2f, want ~54.55 (6 of 11 keys)", got)
+	}
+}
+
+// TestCompute_NonStrictErrorsStillCountTheFinalState: outside strict mode a
+// corrected mistake is not an error, which is the behaviour accuracy has always
+// described. Only strict runs changed.
+func TestCompute_NonStrictErrorsStillCountTheFinalState(t *testing.T) {
+	e := typing.New("abcdef", config.ModeWords, 1)
+	ts := typeInto(e, "abx", 1000)
+	e.Backspace(ts)
+	ts += 100
+	ts = typeInto(e, "cdeZ", ts)
+
+	r := metrics.Compute(e.Log(), config.ModeWords, ts)
+
+	if r.Errors != 1 {
+		t.Errorf("Errors=%d, want 1 — the corrected mistake is not charged, the surviving one is", r.Errors)
+	}
+	if r.Errors != r.IncorrectChars {
+		t.Errorf("outside strict mode Errors (%d) and IncorrectChars (%d) must agree",
+			r.Errors, r.IncorrectChars)
+	}
+}

--- a/internal/metrics/consistency_partial_second_test.go
+++ b/internal/metrics/consistency_partial_second_test.go
@@ -1,0 +1,114 @@
+package metrics_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/metrics"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
+)
+
+// evenLog types n characters at a fixed interval starting at t0.
+func evenLog(t0, intervalMs int64, n int) []typing.Keystroke {
+	log := make([]typing.Keystroke, n)
+	for i := range log {
+		log[i] = typing.Keystroke{
+			TimeMs: t0 + int64(i)*intervalMs, Typed: 'a', Target: 'a', Correct: true,
+		}
+	}
+	return log
+}
+
+// perfectConsistency is 100*tanh(1), the score an entirely even typist earns.
+// It is the formula's maximum, and nothing an even typist does should fall short
+// of it.
+var perfectConsistency = 100 * math.Tanh(1)
+
+// TestConsistency_EvenTypingScoresTheMaximumWhateverSecondItEndsIn is the
+// property the per-second buckets violated. Buckets are scaled to a full second
+// each, so a run ending part-way through its last second reported that second
+// at a fraction of the pace the user was actually holding. The invented dip is
+// indistinguishable from erratic typing, and an even typist was marked down for
+// nothing but where the clock stopped.
+//
+// 5 characters per second, run length varied across a second boundary:
+// every one of these is the same typist.
+func TestConsistency_EvenTypingScoresTheMaximumWhateverSecondItEndsIn(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		chars      int
+		durationMs int64
+	}{
+		{"ends on the boundary", 15, 3000},
+		{"ends 200ms into the next second", 17, 3200},
+		{"ends 400ms into the next second", 19, 3400},
+		{"ends 800ms into the next second", 23, 3800},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			log := evenLog(1000, 200, tc.chars)
+			got := metrics.Compute(log, config.ModeWords, 1000+tc.durationMs).Consistency
+
+			if math.Abs(got-perfectConsistency) > 0.01 {
+				t.Errorf("consistency %.2f for an entirely even typist, want %.2f",
+					got, perfectConsistency)
+			}
+		})
+	}
+}
+
+// TestConsistency_PartialSecondStaysInTheGraph: the correction removes the
+// partial second from the score, not from the data. The breakdown the result
+// graph draws still accounts for every character typed.
+func TestConsistency_PartialSecondStaysInTheGraph(t *testing.T) {
+	log := evenLog(1000, 200, 17) // 3.2 seconds of typing
+	r := metrics.Compute(log, config.ModeWords, 1000+3200)
+
+	if len(r.PerSecond) != 4 {
+		t.Fatalf("want 4 per-second buckets, got %d", len(r.PerSecond))
+	}
+	total := 0
+	for _, ps := range r.PerSecond {
+		total += ps.TotalChars
+	}
+	if total != 17 {
+		t.Errorf("per-second buckets account for %d of 17 characters", total)
+	}
+	if r.PerSecond[3].TotalChars != 2 {
+		t.Errorf("the partial second must keep its 2 characters, got %d", r.PerSecond[3].TotalChars)
+	}
+}
+
+// TestConsistency_UnevenTypingIsStillMarkedDown proves the correction did not
+// simply stop measuring. A typist who genuinely changes pace between complete
+// seconds still scores below the maximum.
+func TestConsistency_UnevenTypingIsStillMarkedDown(t *testing.T) {
+	// 10 chars in the first second, 2 in the second, 10 in the third.
+	var log []typing.Keystroke
+	add := func(base int64, n int, step int64) {
+		for i := 0; i < n; i++ {
+			log = append(log, typing.Keystroke{
+				TimeMs: base + int64(i)*step, Typed: 'a', Target: 'a', Correct: true,
+			})
+		}
+	}
+	add(1000, 10, 90)
+	add(2000, 2, 400)
+	add(3000, 10, 90)
+
+	got := metrics.Compute(log, config.ModeWords, 1000+3000).Consistency
+	if got >= perfectConsistency-1 {
+		t.Errorf("consistency %.2f for a typist who stalled for a second, want well below %.2f",
+			got, perfectConsistency)
+	}
+}
+
+// TestConsistency_RunShorterThanASecondHasNoScore: with no complete second
+// there is no per-second sample, and a variance over one invented bucket would
+// be a score derived from a single data point.
+func TestConsistency_RunShorterThanASecondHasNoScore(t *testing.T) {
+	log := evenLog(1000, 100, 4) // 300ms of typing
+	if got := metrics.Compute(log, config.ModeWords, 1400).Consistency; got != 0 {
+		t.Errorf("consistency %.2f from less than one second of typing, want 0", got)
+	}
+}

--- a/internal/metrics/live_wpm.go
+++ b/internal/metrics/live_wpm.go
@@ -2,11 +2,19 @@ package metrics
 
 import "github.com/bavanchun/Typeburn/v2/internal/typing"
 
+// minRateWindowMs is the shortest window a per-minute rate may be extrapolated
+// from. Below it the sample is noise: five keys inside 80 ms scale to a
+// four-figure WPM, a number that says nothing about the person who typed them.
+// Every rate in this package respects the same floor, so the live header and
+// the final result agree on when there is nothing yet to report.
+const minRateWindowMs int64 = 500
+
 // LiveWPM estimates current net WPM from forward keystrokes in the log.
-// Returns 0 when elapsedMs < 500ms (too noisy) or the log is empty.
+// Returns 0 when the elapsed window is too short to extrapolate from, or the
+// log is empty.
 // This is the cheap O(n) live-display estimate; full metrics come from Compute.
 func LiveWPM(log []typing.Keystroke, elapsedMs int64) float64 {
-	if elapsedMs < 500 || len(log) == 0 {
+	if elapsedMs < minRateWindowMs || len(log) == 0 {
 		return 0
 	}
 	var forward int
@@ -20,7 +28,7 @@ func LiveWPM(log []typing.Keystroke, elapsedMs int64) float64 {
 
 // LiveWPMFromCount estimates current net WPM from a forward-keystroke count.
 func LiveWPMFromCount(forward int, elapsedMs int64) float64 {
-	if elapsedMs < 500 || forward <= 0 {
+	if elapsedMs < minRateWindowMs || forward <= 0 {
 		return 0
 	}
 	return float64(forward) / 5.0 / (float64(elapsedMs) / 60000.0)

--- a/internal/metrics/per_second.go
+++ b/internal/metrics/per_second.go
@@ -73,3 +73,31 @@ func bucketPerSecond(log []typing.Keystroke, startMs int64) []PerSecond {
 
 	return buckets
 }
+
+// consistencySamples returns the per-second raw-WPM values that describe a rate
+// the user actually sustained for a second.
+//
+// Only the last bucket can be short, and it is scaled to a full second like
+// every other one: a run ending 200 ms into its final second reports that
+// second at a fifth of its real speed. Fed to a variance measure, that lone
+// invented dip is indistinguishable from erratic typing — a perfectly even
+// typist scores far below the formula's maximum purely because their run did
+// not end on a second boundary. The graph still shows the partial bucket; only
+// the score refuses to treat it as a sample.
+//
+// A run shorter than one full second yields no samples, and Consistency reports
+// 0 for "no data" rather than inventing a score from a single partial bucket.
+func consistencySamples(buckets []PerSecond, durationMs int64) []float64 {
+	complete := len(buckets)
+	if durationMs < int64(complete)*1000 {
+		complete--
+	}
+	if complete < 0 {
+		complete = 0
+	}
+	out := make([]float64, complete)
+	for i := range out {
+		out[i] = buckets[i].RawWPM
+	}
+	return out
+}

--- a/internal/metrics/plausibility_test.go
+++ b/internal/metrics/plausibility_test.go
@@ -108,13 +108,7 @@ type plausibilityCase struct {
 // knownImplausible lists cases whose Result is not yet believable. A listed
 // case that becomes plausible fails until its entry is deleted, and an entry no
 // case produces fails as stale, so the debt cannot quietly become permanent.
-var knownImplausible = map[string]bool{
-	// A Time run abandoned after a handful of keys: AFK trim removes the idle
-	// tail, leaving a duration of a few hundred milliseconds, and the rate is
-	// then extrapolated from it as though the user had kept that pace for a
-	// minute.
-	"time/afk-after-a-burst": true,
-}
+var knownImplausible = map[string]bool{}
 
 func plausibilityCases() []plausibilityCase {
 	return []plausibilityCase{

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -46,10 +46,15 @@ func NewCodeSession(snippet string, strict bool) Session {
 
 // RebuildEngine returns a fresh engine for an existing target.
 func RebuildEngine(target string, m mode.Mode, length int, strict bool) *typing.Engine {
-	return typing.NewStrict(target, m, wordTarget(m, length), strict)
+	return typing.NewStrict(target, m, engineLimit(m, length), strict)
 }
 
-func wordTarget(m mode.Mode, length int) int {
+// engineLimit converts a mode's user-facing length into the engine's limit,
+// whose unit is the mode's own: seconds become milliseconds for a timed run,
+// and a word count passes through unchanged. The conversion is the reason the
+// limit is not a progress denominator — a 30-second run's limit is 30000, which
+// is a deadline, not thirty thousand words.
+func engineLimit(m mode.Mode, length int) int {
 	if m == mode.ModeTime {
 		return length * 1000
 	}

--- a/internal/storage/new_best.go
+++ b/internal/storage/new_best.go
@@ -3,6 +3,15 @@ package storage
 import "strconv"
 
 // EligibleForBest reports whether a record may participate in personal bests.
+//
+// Code runs are excluded because their target is whatever the user pasted, and
+// strict runs because their cursor cannot pass an error, which makes their
+// speed incomparable with a normal run's.
+//
+// A third exclusion is not expressible here and must not be added: a run cut
+// short by trailing inactivity is refused before it becomes a record at all, so
+// no stored record can be one. The gate lives with the only writer of history —
+// see handleResultMsg in the root model.
 func EligibleForBest(r Record) bool {
 	return r.Mode != "code" && !r.Strict
 }

--- a/internal/typing/completion.go
+++ b/internal/typing/completion.go
@@ -6,10 +6,10 @@ import (
 
 // Complete reports whether the test is finished according to the active mode.
 //
-//   - ModeTime:  the caller signals completion by passing nowMs >= the time limit
-//     (stored in wordTarget as milliseconds). The engine itself does not track
-//     wall time; the caller (UI layer or test harness) drives the clock.
-//   - ModeWords: complete when the user has typed exactly wordTarget words.
+//   - ModeTime:  the caller signals completion by passing nowMs >= the time
+//     limit (limit, in milliseconds). The engine itself does not track wall
+//     time; the caller (UI layer or test harness) drives the clock.
+//   - ModeWords: complete when the user has typed exactly limit words.
 //     A word is considered typed when the trailing space has been entered OR
 //     when the last word in the sequence is fully typed (no trailing space needed).
 //   - ModeQuote / ModeCode: complete when the typed buffer exactly matches
@@ -18,10 +18,10 @@ import (
 func (e *Engine) Complete(nowMs int64) bool {
 	switch e.mode {
 	case mode.ModeTime:
-		return nowMs >= int64(e.wordTarget)
+		return nowMs >= int64(e.limit)
 
 	case mode.ModeWords:
-		return countCompletedWords(e.typed, e.target) >= e.wordTarget
+		return countCompletedWords(e.typed, e.target) >= e.limit
 
 	case mode.ModeQuote, mode.ModeCode:
 		return runesEqual(e.typed, e.target)
@@ -36,8 +36,10 @@ func (e *Engine) Complete(nowMs int64) bool {
 //   - Its trailing space has been typed (mid-sequence words), OR
 //   - It is the last word and the typed runes cover it entirely.
 //
-// Only the first wordTarget words are considered; extra typed runes beyond the
-// target are ignored for counting purposes.
+// Counting is position-based over the whole target: it measures how far the
+// cursor has advanced, not whether the runes it passed were correct. Typing
+// past the end of the target adds nothing, because there are no further target
+// words to complete.
 func countCompletedWords(typed, target []rune) int {
 	if len(typed) == 0 || len(target) == 0 {
 		return 0
@@ -45,38 +47,45 @@ func countCompletedWords(typed, target []rune) int {
 
 	completed := 0
 	inWord := false
-	wordStart := 0
 
 	for i, r := range target {
 		if r == ' ' {
 			if inWord {
-				// Word counts complete once typing has advanced past its
-				// trailing-space position (position-based progress; the char
-				// itself isn't re-checked here).
 				if i < len(typed) {
 					completed++
 				}
 				inWord = false
 			}
-		} else {
-			if !inWord {
-				wordStart = i
-				inWord = true
-			}
+			continue
 		}
-		_ = wordStart
+		inWord = true
 	}
 
 	// Last word: complete if all its runes are typed (no trailing space required).
-	if inWord {
-		// Find the end of the last word in target.
-		lastWordEnd := len(target)
-		if lastWordEnd <= len(typed) {
-			completed++
-		}
+	if inWord && len(target) <= len(typed) {
+		completed++
 	}
 
 	return completed
+}
+
+// countWords counts the space-separated words in a target text. It is the
+// denominator Progress reports for a timed run, whose word count is a property
+// of the generated text rather than a goal the user chose.
+func countWords(target []rune) int {
+	words := 0
+	inWord := false
+	for _, r := range target {
+		if r == ' ' {
+			inWord = false
+			continue
+		}
+		if !inWord {
+			words++
+			inWord = true
+		}
+	}
+	return words
 }
 
 // runesEqual reports whether a and b contain identical rune sequences.

--- a/internal/typing/engine.go
+++ b/internal/typing/engine.go
@@ -8,11 +8,17 @@ import (
 // Target is 0 for Extra positions (past end of target text).
 // Correct reflects whether the typed rune matched the target at that moment.
 // For backspace events, Typed is set to 0 (null rune) and Correct is false.
+//
+// Blocked marks a keystroke that was recorded but refused: in strict mode a
+// wrong key does not advance the cursor, so the rune never entered the typed
+// buffer. It is omitted from JSON when false so logs written before the field
+// existed decode to the non-strict meaning they were recorded with.
 type Keystroke struct {
 	TimeMs  int64 `json:"time_ms"`
 	Typed   rune  `json:"typed"`
 	Target  rune  `json:"target"`
 	Correct bool  `json:"correct"`
+	Blocked bool  `json:"blocked,omitempty"`
 }
 
 // Engine maintains the mutable typing state: target buffer, typed buffer,
@@ -20,30 +26,36 @@ type Keystroke struct {
 // (no byte indexing), making Engine correct for multi-byte Unicode input
 // such as "café" or CJK characters.
 type Engine struct {
-	target     []rune
-	typed      []rune
-	log        []Keystroke
-	startMs    int64 // 0 until first Apply call
-	mode       mode.Mode
-	wordTarget int // Words: N words to complete; Time: limit in ms; Quote: unused (0)
-	strict     bool
+	target  []rune
+	typed   []rune
+	log     []Keystroke
+	startMs int64 // 0 until first Apply call
+	mode    mode.Mode
+
+	// limit is what ends the run, and its unit depends on the mode: a word
+	// count for ModeWords, a duration in milliseconds for ModeTime, unused (0)
+	// for ModeQuote and ModeCode. It is deliberately not named for either unit,
+	// because reading it as the other one is how a 30-second run came to report
+	// its progress as 0 out of 30000 words.
+	limit  int
+	strict bool
 }
 
-// New creates an Engine for the given target text, mode, and wordTarget.
-// For ModeWords, wordTarget is the number of words to type.
-// For ModeTime, wordTarget is the time limit in milliseconds.
-// For ModeQuote, wordTarget is ignored (0).
-func New(target string, mode mode.Mode, wordTarget int) *Engine {
-	return NewStrict(target, mode, wordTarget, false)
+// New creates an Engine for the given target text, mode, and limit.
+// For ModeWords, limit is the number of words to type.
+// For ModeTime, limit is the time limit in milliseconds.
+// For ModeQuote and ModeCode, limit is ignored (0).
+func New(target string, mode mode.Mode, limit int) *Engine {
+	return NewStrict(target, mode, limit, false)
 }
 
 // NewStrict creates an Engine with optional strict (stop-on-error letter) mode.
-func NewStrict(target string, mode mode.Mode, wordTarget int, strict bool) *Engine {
+func NewStrict(target string, mode mode.Mode, limit int, strict bool) *Engine {
 	return &Engine{
-		target:     []rune(target),
-		mode:       mode,
-		wordTarget: wordTarget,
-		strict:     strict,
+		target: []rune(target),
+		mode:   mode,
+		limit:  limit,
+		strict: strict,
 	}
 }
 
@@ -54,6 +66,11 @@ func (e *Engine) StartMs() int64 { return e.startMs }
 // Apply records a printable rune keystroke at the given monotonic millisecond
 // timestamp. The first call sets startMs. Extra runes past the target length
 // are appended and classified as Extra by States().
+//
+// In strict mode no wrong rune advances the cursor — including one typed past
+// the end of the target, which is wrong by definition since there is nothing
+// left to match. Such a keystroke is logged as Blocked so replays agree with
+// the buffer this engine actually holds.
 func (e *Engine) Apply(r rune, nowMs int64) {
 	if e.startMs == 0 {
 		e.startMs = nowMs
@@ -69,13 +86,13 @@ func (e *Engine) Apply(r rune, nowMs int64) {
 	}
 	// pos >= len(e.target): extra rune — target stays 0, correct stays false
 
-	if e.strict && pos < len(e.target) && !correct {
-		// blocked: log the error, do NOT advance the typed buffer
+	if e.strict && !correct {
 		e.log = append(e.log, Keystroke{
 			TimeMs:  nowMs,
 			Typed:   r,
 			Target:  target,
 			Correct: false,
+			Blocked: true,
 		})
 		return
 	}
@@ -112,47 +129,6 @@ func (e *Engine) Backspace(nowMs int64) {
 	})
 }
 
-// States returns a CharState slice covering all target positions plus any extra
-// typed runes. The current cursor position is marked Current; positions behind
-// it are Correct/Incorrect/IncorrectSpace; positions ahead are Untyped.
-//
-// IncorrectSpace is assigned when the target rune is a space and the typed rune
-// is not (or vice versa), making word-boundary errors visually distinct.
-func (e *Engine) States() []CharState {
-	cursor := len(e.typed)
-	total := len(e.target)
-	if cursor > total {
-		total = cursor
-	}
-
-	states := make([]CharState, total)
-
-	for i := 0; i < total; i++ {
-		switch {
-		case i == cursor:
-			states[i] = Current
-		case i > cursor:
-			states[i] = Untyped
-		case i >= len(e.target):
-			// typed past end of target → Extra
-			states[i] = Extra
-		default:
-			typed := e.typed[i]
-			tgt := e.target[i]
-			if typed == tgt {
-				states[i] = Correct
-			} else if tgt == ' ' || typed == ' ' {
-				// wrong char at a space boundary — distinct visual class
-				states[i] = IncorrectSpace
-			} else {
-				states[i] = Incorrect
-			}
-		}
-	}
-
-	return states
-}
-
 // Log returns the full keystroke log in chronological order.
 // Backspace events have Typed==0.
 func (e *Engine) Log() []Keystroke {
@@ -177,21 +153,4 @@ func (e *Engine) ForwardKeystrokes() int {
 		}
 	}
 	return n
-}
-
-// Progress returns (done, total) for the current mode:
-//   - ModeWords / ModeTime: (completedWords, wordTarget)
-//   - ModeQuote:            (typedRunes, totalTargetRunes)
-func (e *Engine) Progress() (done, total int) {
-	switch e.mode {
-	case mode.ModeQuote:
-		typed := len(e.typed)
-		if typed > len(e.target) {
-			typed = len(e.target)
-		}
-		return typed, len(e.target)
-	default:
-		// Words and Time both report word progress toward wordTarget.
-		return countCompletedWords(e.typed, e.target), e.wordTarget
-	}
 }

--- a/internal/typing/engine_progress.go
+++ b/internal/typing/engine_progress.go
@@ -1,0 +1,34 @@
+package typing
+
+import (
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
+)
+
+// Progress returns how far the run has got and how far it goes, in one unit per
+// mode. Both halves are always the same unit and total is never zero while
+// there is something to type — a caller rendering "done / total" or a
+// percentage has no way to detect a denominator that means something else.
+//
+//   - ModeWords:            (completed words, target word count)
+//   - ModeTime:             (completed words, words in the generated text)
+//   - ModeQuote / ModeCode: (typed runes, target runes)
+//
+// ModeTime cannot report the engine's limit: for a timed run that field holds
+// the deadline in milliseconds, which Complete needs and which is not a count
+// of anything the user types.
+func (e *Engine) Progress() (done, total int) {
+	switch e.mode {
+	case mode.ModeQuote, mode.ModeCode:
+		typed := len(e.typed)
+		if typed > len(e.target) {
+			typed = len(e.target)
+		}
+		return typed, len(e.target)
+
+	case mode.ModeTime:
+		return countCompletedWords(e.typed, e.target), countWords(e.target)
+
+	default:
+		return countCompletedWords(e.typed, e.target), e.limit
+	}
+}

--- a/internal/typing/engine_progress_test.go
+++ b/internal/typing/engine_progress_test.go
@@ -1,0 +1,107 @@
+package typing_test
+
+import (
+	"testing"
+
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
+)
+
+// TestProgress_IsACountInEveryMode pins the contract a caller rendering
+// "done / total" or a percentage relies on: both halves are the same unit, and
+// total is a real denominator.
+//
+// A timed run's limit is a deadline in milliseconds. Reporting it as the total
+// made a 30-second run read "0 / 30000", and a Code run reported a total of
+// zero, which is a percentage nobody can compute.
+func TestProgress_IsACountInEveryMode(t *testing.T) {
+	const target = "one two three four"
+
+	t.Run("time reports words, not the millisecond deadline", func(t *testing.T) {
+		e := typing.New(target, mode.ModeTime, 30*1000)
+		done, total := e.Progress()
+		if total != 4 {
+			t.Errorf("want total=4 words, got %d", total)
+		}
+		if done != 0 {
+			t.Errorf("want done=0 before typing, got %d", done)
+		}
+
+		ts := int64(1000)
+		for _, r := range "one two " {
+			e.Apply(r, ts)
+			ts += 100
+		}
+		if done, total = e.Progress(); done != 2 || total != 4 {
+			t.Errorf("want 2/4 after two words, got %d/%d", done, total)
+		}
+	})
+
+	t.Run("code reports runes against a non-zero total", func(t *testing.T) {
+		e := typing.New("x = 1", mode.ModeCode, 0)
+		done, total := e.Progress()
+		if total != 5 {
+			t.Errorf("want total=5 runes, got %d", total)
+		}
+		if done != 0 {
+			t.Errorf("want done=0, got %d", done)
+		}
+
+		ts := int64(1000)
+		for _, r := range "x =" {
+			e.Apply(r, ts)
+			ts += 100
+		}
+		if done, total = e.Progress(); done != 3 || total != 5 {
+			t.Errorf("want 3/5, got %d/%d", done, total)
+		}
+	})
+
+	t.Run("every mode reports done within total", func(t *testing.T) {
+		for _, m := range []mode.Mode{mode.ModeTime, mode.ModeWords, mode.ModeQuote, mode.ModeCode} {
+			e := typing.New(target, m, 4)
+			ts := int64(1000)
+			for _, r := range target + "zzz" { // overtype past the end
+				e.Apply(r, ts)
+				ts += 100
+			}
+			done, total := e.Progress()
+			if total <= 0 {
+				t.Errorf("%v: total=%d is not a denominator", m, total)
+			}
+			if done > total {
+				t.Errorf("%v: done=%d exceeds total=%d", m, done, total)
+			}
+		}
+	})
+}
+
+// TestStrict_RefusesKeysPastTheEndOfTheTarget: strict mode stops the cursor on
+// any wrong key, and a key typed past the end of the target has nothing to
+// match, so it is wrong. Letting those through filled the buffer with extra
+// characters the mode exists to prevent.
+func TestStrict_RefusesKeysPastTheEndOfTheTarget(t *testing.T) {
+	e := typing.NewStrict("ab", mode.ModeWords, 1, true)
+	ts := int64(1000)
+	for _, r := range "ab" {
+		e.Apply(r, ts)
+		ts += 100
+	}
+	for i := 0; i < 10; i++ {
+		e.Apply('z', ts)
+		ts += 100
+	}
+
+	if got := string(e.Typed()); got != "ab" {
+		t.Errorf("buffer is %q; strict mode must not accept a key past the target", got)
+	}
+	blocked := 0
+	for _, k := range e.Log() {
+		if k.Blocked {
+			blocked++
+		}
+	}
+	if blocked != 10 {
+		t.Errorf("want 10 refused keystrokes recorded, got %d", blocked)
+	}
+}

--- a/internal/typing/engine_states.go
+++ b/internal/typing/engine_states.go
@@ -1,0 +1,42 @@
+package typing
+
+// States returns a CharState slice covering all target positions plus any extra
+// typed runes. The current cursor position is marked Current; positions behind
+// it are Correct/Incorrect/IncorrectSpace; positions ahead are Untyped.
+//
+// IncorrectSpace is assigned when the target rune is a space and the typed rune
+// is not (or vice versa), making word-boundary errors visually distinct.
+func (e *Engine) States() []CharState {
+	cursor := len(e.typed)
+	total := len(e.target)
+	if cursor > total {
+		total = cursor
+	}
+
+	states := make([]CharState, total)
+
+	for i := 0; i < total; i++ {
+		switch {
+		case i == cursor:
+			states[i] = Current
+		case i > cursor:
+			states[i] = Untyped
+		case i >= len(e.target):
+			// typed past end of target → Extra
+			states[i] = Extra
+		default:
+			typed := e.typed[i]
+			tgt := e.target[i]
+			if typed == tgt {
+				states[i] = Correct
+			} else if tgt == ' ' || typed == ' ' {
+				// wrong char at a space boundary — distinct visual class
+				states[i] = IncorrectSpace
+			} else {
+				states[i] = Incorrect
+			}
+		}
+	}
+
+	return states
+}

--- a/internal/typing/replay.go
+++ b/internal/typing/replay.go
@@ -1,0 +1,44 @@
+package typing
+
+// ReplayBuffer reconstructs the typed buffer an Engine holds after applying the
+// whole log, and is the single definition of what a log means:
+//
+//   - a blocked keystroke never entered the buffer, so it is skipped. Counting
+//     it would let a later backspace pop a slot the engine never had, and every
+//     position after that would describe a run nobody typed;
+//   - a backspace marker (Typed == 0) pops the last slot;
+//   - anything else appends.
+//
+// The returned keystrokes are the surviving ones, in buffer order, so callers
+// that need the target and correctness of each slot get them without a second
+// walk of the log. Callers that need only the runes use TypedFromLog.
+//
+// Every consumer replays through here. Two independent copies of this loop is
+// how a single strict-mode desync became two.
+func ReplayBuffer(log []Keystroke) []Keystroke {
+	buf := make([]Keystroke, 0, len(log))
+	for _, k := range log {
+		switch {
+		case k.Blocked:
+			continue
+		case k.Typed == 0:
+			if len(buf) > 0 {
+				buf = buf[:len(buf)-1]
+			}
+		default:
+			buf = append(buf, k)
+		}
+	}
+	return buf
+}
+
+// TypedFromLog returns the rune buffer an Engine holds after applying the log,
+// equivalent to Engine.Typed() for the engine that produced it.
+func TypedFromLog(log []Keystroke) []rune {
+	buf := ReplayBuffer(log)
+	out := make([]rune, len(buf))
+	for i, k := range buf {
+		out[i] = k.Typed
+	}
+	return out
+}

--- a/internal/typing/replay_test.go
+++ b/internal/typing/replay_test.go
@@ -1,0 +1,125 @@
+package typing_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/bavanchun/Typeburn/v2/internal/mode"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
+)
+
+// typeFrom types s into e one rune per 100ms, starting at startMs.
+func typeFrom(e *typing.Engine, s string, startMs int64) int64 {
+	ts := startMs
+	for _, r := range s {
+		e.Apply(r, ts)
+		ts += 100
+	}
+	return ts
+}
+
+// TestReplayFromLog_MatchesEngineBuffer is the property every consumer of a
+// keystroke log depends on: replaying the log reconstructs exactly the buffer
+// the engine that wrote it holds. Strict mode broke it by logging keys it had
+// refused, after which a backspace popped a slot the engine never had and every
+// later position described a run nobody typed.
+func TestReplayFromLog_MatchesEngineBuffer(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		strict bool
+		run    func(e *typing.Engine)
+	}{
+		{"plain typing", false, func(e *typing.Engine) { typeFrom(e, "abc", 1000) }},
+		{"typing with corrections", false, func(e *typing.Engine) {
+			ts := typeFrom(e, "abx", 1000)
+			e.Backspace(ts)
+			e.Apply('c', ts+100)
+		}},
+		{"strict: wrong keys then retype", true, func(e *typing.Engine) {
+			ts := typeFrom(e, "abc", 1000)
+			ts = typeFrom(e, "zzzzz", ts) // all refused at position 3
+			for i := 0; i < 3; i++ {
+				e.Backspace(ts)
+				ts += 100
+			}
+			typeFrom(e, "abcdef", ts)
+		}},
+		{"strict: wrong key on the first position", true, func(e *typing.Engine) {
+			typeFrom(e, "qqa", 1000)
+		}},
+		{"strict: keys past the end of the target", true, func(e *typing.Engine) {
+			typeFrom(e, "abcdefzzz", 1000)
+		}},
+		{"backspace on an empty buffer", false, func(e *typing.Engine) {
+			e.Backspace(1000)
+			typeFrom(e, "ab", 1100)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := typing.NewStrict("abcdef", mode.ModeWords, 1, tc.strict)
+			tc.run(e)
+
+			want := string(e.Typed())
+			if got := string(typing.TypedFromLog(e.Log())); got != want {
+				t.Errorf("replayed buffer %q, engine holds %q", got, want)
+			}
+		})
+	}
+}
+
+// TestReplayBuffer_CarriesTargetAndCorrectness checks the slot detail metrics
+// counts from, not just the runes.
+func TestReplayBuffer_CarriesTargetAndCorrectness(t *testing.T) {
+	e := typing.New("ab", mode.ModeWords, 1)
+	typeFrom(e, "aX", 1000)
+
+	buf := typing.ReplayBuffer(e.Log())
+	if len(buf) != 2 {
+		t.Fatalf("want 2 slots, got %d", len(buf))
+	}
+	if !buf[0].Correct || buf[0].Target != 'a' {
+		t.Errorf("slot 0: want correct 'a', got %+v", buf[0])
+	}
+	if buf[1].Correct || buf[1].Target != 'b' || buf[1].Typed != 'X' {
+		t.Errorf("slot 1: want wrong 'X' against 'b', got %+v", buf[1])
+	}
+}
+
+// TestKeystrokeJSON_LogWrittenBeforeBlockedExisted decodes a log recorded
+// before the Blocked field existed. Absent means false, which is the non-strict
+// meaning every such log was written with, so replay must behave as it did.
+func TestKeystrokeJSON_LogWrittenBeforeBlockedExisted(t *testing.T) {
+	data, err := os.ReadFile("testdata/log_without_blocked_field.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var log []typing.Keystroke
+	if err := json.Unmarshal(data, &log); err != nil {
+		t.Fatalf("a log written before the field existed must still parse: %v", err)
+	}
+	for i, k := range log {
+		if k.Blocked {
+			t.Errorf("keystroke %d decoded as blocked; an absent field must mean not blocked", i)
+		}
+	}
+
+	// "abx" then backspace then "c" — the buffer this log has always described.
+	if got := string(typing.TypedFromLog(log)); got != "abc" {
+		t.Errorf("replayed %q, want %q", got, "abc")
+	}
+}
+
+// TestKeystrokeJSON_BlockedOmittedWhenFalse keeps old readers able to read new
+// logs: an ordinary keystroke must serialise exactly as it did before.
+func TestKeystrokeJSON_BlockedOmittedWhenFalse(t *testing.T) {
+	out, err := json.Marshal(typing.Keystroke{TimeMs: 1000, Typed: 'a', Target: 'a', Correct: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"time_ms":1000,"typed":97,"target":97,"correct":true}`
+	if string(out) != want {
+		t.Errorf("marshalled %s, want %s", out, want)
+	}
+}

--- a/internal/typing/testdata/log_without_blocked_field.json
+++ b/internal/typing/testdata/log_without_blocked_field.json
@@ -1,0 +1,7 @@
+[
+  {"time_ms": 1000, "typed": 97, "target": 97, "correct": true},
+  {"time_ms": 1100, "typed": 98, "target": 98, "correct": true},
+  {"time_ms": 1200, "typed": 120, "target": 99, "correct": false},
+  {"time_ms": 1300, "typed": 0, "target": 99, "correct": false},
+  {"time_ms": 1400, "typed": 99, "target": 99, "correct": true}
+]

--- a/internal/ui/mode_header.go
+++ b/internal/ui/mode_header.go
@@ -16,7 +16,11 @@ const progressBarWidth = 5
 // Layout per design §5.4 / mockups §2:
 //   - Time mode:  "WPM   elapsed / total"     (e.g. "87 wpm   0:23 / 0:30")
 //   - Words mode: "WPM   done / total"         (e.g. "87 wpm   12 / 25")
-//   - Quote mode: "WPM   pct% ▰▰▰▱▱"          (e.g. "87 wpm   42% ▰▰▰▱▱")
+//   - Quote/Code: "WPM   pct% ▰▰▰▱▱"          (e.g. "87 wpm   42% ▰▰▰▱▱")
+//
+// done and total come from Engine.Progress and are in the same unit as each
+// other: words for Words mode, runes for Quote and Code. Time mode reports its
+// own progress against the clock and ignores them.
 //
 // WPM number is accent+bold; "wpm" and remainder are text-muted.
 // No border; left-aligned.
@@ -44,7 +48,7 @@ func ModeHeader(
 	case config.ModeWords:
 		right = muted.Render(fmt.Sprintf("%d / %d", done, total))
 
-	case config.ModeQuote:
+	case config.ModeQuote, config.ModeCode:
 		var pct float64
 		if total > 0 {
 			pct = float64(done) / float64(total) * 100

--- a/internal/ui/typing_log_helpers.go
+++ b/internal/ui/typing_log_helpers.go
@@ -14,17 +14,11 @@ func liveWPMFromCount(forward int, elapsedMs int64) float64 {
 
 // typedFromLog reconstructs the current typed-rune slice by replaying the
 // keystroke log. Engine.typed is unexported; the log is the public API.
-// Backspace events (Typed==0) pop the last rune, mirroring Engine internals.
+//
+// The replay itself belongs to the typing package, which owns what a log means.
+// This file once carried its own copy of the loop, and when strict mode started
+// logging keystrokes it had refused, both copies reconstructed a buffer the
+// engine never held — the same defect twice, because the rule was written twice.
 func typedFromLog(log []typing.Keystroke) []rune {
-	var buf []rune
-	for _, k := range log {
-		if k.Typed == 0 {
-			if len(buf) > 0 {
-				buf = buf[:len(buf)-1]
-			}
-		} else {
-			buf = append(buf, k.Typed)
-		}
-	}
-	return buf
+	return typing.TypedFromLog(log)
 }

--- a/internal/ui/typing_log_helpers_test.go
+++ b/internal/ui/typing_log_helpers_test.go
@@ -1,0 +1,37 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/bavanchun/Typeburn/v2/internal/config"
+	"github.com/bavanchun/Typeburn/v2/internal/typing"
+)
+
+// TestTypedFromLog_AgreesWithTheEngineUnderStrict: this file used to carry its
+// own copy of the replay loop, so when strict mode began logging keystrokes it
+// had refused, the same defect appeared twice — the buffer reconstructed here
+// held characters the engine never accepted, and every renderer that asked for
+// it drew a run nobody typed.
+func TestTypedFromLog_AgreesWithTheEngineUnderStrict(t *testing.T) {
+	e := typing.NewStrict("abcdef", config.ModeWords, 1, true)
+
+	ts := int64(1000)
+	apply := func(s string) {
+		for _, r := range s {
+			e.Apply(r, ts)
+			ts += 100
+		}
+	}
+	apply("abc")
+	apply("zzzzz") // refused at position 3
+	for i := 0; i < 3; i++ {
+		e.Backspace(ts)
+		ts += 100
+	}
+	apply("abcdef")
+
+	want := string(e.Typed())
+	if got := string(typedFromLog(e.Log())); got != want {
+		t.Errorf("typedFromLog reconstructed %q, engine holds %q", got, want)
+	}
+}

--- a/plans/reports/phase-03-260802-metrics-correctness.md
+++ b/plans/reports/phase-03-260802-metrics-correctness.md
@@ -1,0 +1,226 @@
+# Phase 3 — Metrics And Typing Correctness
+
+Status: **completed**. Gate green (`gofmt -l .` empty, `go vet ./...`,
+`go test ./... -race -count=1`, `make lint`, `make build`).
+
+Worktree: `/Users/vchun/Codes/My-projects/Typeburn/.claude/worktrees/agent-a31a73c5a499c69ab`
+Branch: `fix/metrics-and-typing-correctness`
+Commits: `f7ce7907` (typing), `2a2b8d2f` (metrics), `be8d3fb9` (app/storage)
+
+## Per-defect before/after
+
+All numbers measured by running the phase's exact reproduction inputs against
+the tree before and after the change.
+
+| Defect | Input | Before | After |
+|---|---|---|---|
+| AFK burst extrapolated | Time/30, 3 keys @ t=1000/1050/1100 | `Duration=100 Net=360.0 Raw=360.0` | `Duration=100 Net=0 Raw=0 AFKTrimmed=true` |
+| AFK burst extrapolated | Time/30, 5 keys @ 1ms spacing | `Duration=4 Net=15000 Raw=15000` | `Duration=4 Net=0 Raw=0 AFKTrimmed=true` |
+| Zero duration fabricates 100% | target `hello world`, one wrong `q` @1000, end 16000 | `Duration=0 Acc=100.0 KAcc=100.0` | `Duration=0 Acc=0.0 KAcc=0.0 Incorrect=1` |
+| Strict replay desync | strict `abcdef`: `abc`, `z`×5 blocked, bksp×3, retype `abcdef` (engine buffer = `abcdef`) | `Correct=9 Incorrect=2 Acc=81.82 Net=63.53` | `Correct=6 Incorrect=0 Acc=100.00 Net=42.35` |
+| Strict `Errors` (user decision: keystroke-level) | same run | `Errors=2` | `Errors=5` (every refused key) |
+| Strict past-end guard | strict `ab`, type `ab` then `z`×10 | buffer `abzzzzzzzzzz`, `Extra=10` | buffer `ab`, `Extra=0`, 10 refused |
+| `Progress()` Time | 30s engine | `0 / 30000` (ms as a word count) | `0 / 3` (words in the target) |
+| `Progress()` Code | `x = 1` | `0 / 0` (zero denominator) | `0 / 5` runes |
+| AFK persistence | abandoned Time/30 run | written to history, becomes bucket best | not written, not ranked, notice shown |
+| Notice placement | Result frame at 80×24 (29 rows) | notice on row 28 — clipped, never visible | notice on row 23 — last row the terminal shows |
+
+`KeystrokeAccuracy` for the strict desync run: 9 of 14 keys = 64.29 % (unchanged
+— it always counted keystrokes; only the buffer-derived counts were wrong).
+
+## Consistency worked example (CHANGELOG evidence)
+
+Partial final second no longer sampled. Every number below is one typist typing
+at an entirely even pace; the only difference between rows is where the clock
+stopped.
+
+| Run | Buckets | Before | After |
+|---|---|---|---|
+| even 5 c/s, 3.0 s (ends on a boundary) | 3 | 76.16 | 76.16 |
+| even 5 c/s, **3.2 s** (the plan's example) | 4 | **60.08** | **76.16** |
+| Words-25, even 5 c/s, 26.2 s | 27 | 70.85 | 76.16 |
+| Words-25, even 5 c/s, 26.8 s | 27 | 76.16 | 76.16 |
+| Words-10, even 6 c/s, 8.5 s | 9 | 67.60 | 73.80 |
+| Time-30, even 5 c/s (ends on a boundary) | 30 | 76.16 | 76.16 |
+
+76.16 is the formula's maximum (`100·tanh(1)`).
+
+Direction of the change: **scores go up, never down**, and only for runs that
+did not end on a second boundary. Time mode is largely unaffected because its
+duration is a whole number of seconds. Words/Quote/Code runs end whenever the
+last character lands, so most of them shift. The plan's "51.31" could not be
+reproduced from an even 5 c/s 3.2 s log; the measured before-value is 60.08.
+Stored history is untouched, so old records keep their old numbers.
+
+## The `typedFromLog` duplicate
+
+Collapsed, not fixed twice. The replay rule now lives once in
+`internal/typing/replay.go`:
+
+- `typing.ReplayBuffer(log) []Keystroke` — surviving forward keystrokes in
+  buffer order, carrying target and correctness.
+- `typing.TypedFromLog(log) []rune` — the rune view.
+
+`metrics.replayFinalState` and `ui.typedFromLog` both delegate. `typedFromLog`
+is kept as a one-line delegate rather than deleted so the three existing call
+sites in files owned by Phase 2 stay untouched.
+
+## `engine.go` split
+
+197 LOC → four files, all well under the ceiling:
+
+| File | LOC | Holds |
+|---|---|---|
+| `engine.go` | 156 | `Keystroke`, `Engine`, constructors, `Apply`, `Backspace`, `Log`, `Typed`, `ForwardKeystrokes` |
+| `engine_states.go` | 42 | `States()` |
+| `engine_progress.go` | 34 | `Progress()` |
+| `replay.go` | 44 | `ReplayBuffer`, `TypedFromLog` |
+
+Largest file touched anywhere in the phase: `internal/metrics/compute.go` at 181.
+No file at or over 200. (`internal/metrics/compute_test.go` sits at exactly 200
+and was not touched.)
+
+Also renamed `Engine.wordTarget` → `Engine.limit` (and `runner.wordTarget` →
+`engineLimit`). The field means a word count in one mode and a millisecond
+deadline in another; reading it as the wrong one is the whole `Progress()` bug,
+and the old name asserted the wrong one.
+
+## Mutations run (each assertion proved falsifiable)
+
+Twelve production-code mutations, each reverted after measurement. Every one was
+caught:
+
+| # | Mutation | Caught by |
+|---|---|---|
+| 1 | `ReplayBuffer` stops skipping refused keystrokes | `TestReplayFromLog_MatchesEngineBuffer` (3 subtests), `TestCompute_StrictAgreesWithTheEngineBuffer`, `TestCompute_StrictErrorsAreKeystrokeLevel`, `TestTypedFromLog_AgreesWithTheEngineUnderStrict` |
+| 2 | strict guard restored to `pos < len(target)` | `TestStrict_RefusesKeysPastTheEndOfTheTarget` |
+| 3 | engine stops setting `Blocked` | `TestReplayFromLog_MatchesEngineBuffer`, `TestStrict_Refuses…`, `TestCompute_StrictAgreesWithTheEngineBuffer` |
+| 4 | zero duration returns `{Accuracy: 100, KeystrokeAccuracy: 100}` again | `TestCompute_ZeroDurationReportsWhatWasTyped` |
+| 5 | rate floor lowered back to `durationMs > 0` | `TestCompute_NeverReportsAnImpossibleResult` (the ratchet), `TestCompute_AFKTrimIsReportedAndNoRateIsExtrapolated` |
+| 6 | `TrimAFK` reports `false` when it trimmed | `TestAFKTrim` (2 subtests), `TestCompute_AFKTrim…`, **and all three `internal/app` seam tests** |
+| 7 | `Errors` back to final-state only | `TestCompute_StrictErrorsAreKeystrokeLevel` |
+| 8 | partial final second sampled again | `TestConsistency_EvenTypingScoresTheMaximum…` (3 subtests) |
+| 9 | consistency stops sampling entirely | same test (all 4 subtests) — proves the fix did not just stop measuring |
+| 10 | `Progress()` Time branch reverted, Code back in `default` | `TestProgress_IsACountInEveryMode` (2 subtests) |
+| 11 | notice written to `lines[len(lines)-1]` unconditionally | `TestOverlayNotice_LandsOnARowTheTerminalShows/frame_taller_than_the_terminal`, `TestOverlayNotice_DoesNotOverwriteContent` |
+| 12 | AFK gate removed from `decideOutcome` | all three `TestResult_*` seam tests |
+
+Mutation 6 is the one that matters for R1: a metrics-package change is caught by
+an `internal/app` test. That is the cross-package assertion that did not exist.
+
+## Ratchet
+
+`knownImplausible` is now `map[string]bool{}`. `assertPlausible` passes for every
+case with zero allowlist entries, and the stale-entry sweep still runs.
+
+## Deviations from the phase spec, and why
+
+1. **`EligibleForBest` does not gain an AFK branch.** `storage.Record` has no
+   AFK field and `internal/storage/history_record.go` is outside this phase's
+   ownership. Since an AFK-trimmed run is never written, no stored record could
+   ever carry the flag — the gate has to be at the writer. It is in
+   `app.decideOutcome`, and `EligibleForBest`'s doc points at it. The three
+   `internal/app` seam tests enforce it; a doc comment alone would not.
+2. **The notice never lengthens a frame that already overflows.** The spec says
+   "overlay at `min(len(lines)-1, m.h-1)`, require that row to be blank, else
+   insert". Implemented as written, with one exception: when the frame is
+   already taller than the terminal, the notice overlays instead of inserting.
+   Inserting there pushes a row off the bottom regardless, and it would have
+   changed `result/persist-notice@*` in Phase 1's `knownAppOverflow` from
+   `Lines: 29` to `Lines: 30` — a file this phase must not touch, in a test that
+   asserts the measurement exactly. With the exception, every `knownAppOverflow`
+   measurement is byte-identical and the insert path becomes live for free once
+   Phase 6 brings Result inside 24 rows.
+3. **The h≥30 "footer destruction" in the phase brief does not occur.** Measured:
+   at 80×30 and 80×50 the Result frame is exactly `h` rows and its last row is
+   blank padding (the footer sits at `h-2`). Behaviour at those sizes is
+   unchanged. The real defect was the h≤24 clipping, which is fixed.
+4. **AFK rate suppression uses the existing 500 ms floor**, not a new constant.
+   `LiveWPM` already refuses to project a rate from under 500 ms and documents
+   why. Reusing it means the live header and the final result agree on when
+   there is nothing to report, and it is a threshold the product already chose
+   rather than one invented here. This is what makes the ratchet green; the
+   user's "withhold, do not rescale" decision is honoured — nothing is scaled,
+   the rate is simply not claimed.
+5. **`internal/ui/mode_header.go` gains `ModeCode`** to the Quote branch. Code
+   mode had no branch at all, so its progress area rendered empty; now that
+   `Progress()` returns a real denominator for it, the bar works.
+6. **`internal/cli/notui/runner.go`** needed no logic change — its call site is
+   correct now that `Progress()` is. Comment added recording the unit.
+
+## Draft CHANGELOG copy
+
+```markdown
+### Changed
+
+- **Consistency is no longer dragged down by where the clock stopped.** The
+  per-second breakdown scaled a partial final second as though it were a whole
+  one, so a run ending part-way through a second reported that second at a
+  fraction of the pace actually being held. Fed to a variance measure, the
+  invented dip was indistinguishable from erratic typing. An entirely even
+  typist over 3.2 s scored **60.08**; the same run now scores **76.16**, the
+  formula's maximum. Scores go up, never down, and only for runs that did not
+  end on a second boundary — Time mode is largely unaffected. The partial second
+  is still drawn on the result graph; it is simply not treated as a sample of a
+  per-second rate. Stored history is not migrated, so past results keep the
+  numbers they were recorded with.
+
+- **Strict mode counts every wrong key.** A strict run's cursor never passes an
+  error, so almost nothing wrong survives to the end of the test and the error
+  count was reporting a run full of mistakes as near-flawless. Errors are now
+  counted per keystroke, including ones that were corrected afterwards. A strict
+  run will report a higher error count than the same run did before. Non-strict
+  runs are unchanged.
+
+### Fixed
+
+- **A test you walked away from is no longer saved.** When a timed test ended in
+  a long idle stretch, the clock was trimmed back to the last key pressed and the
+  speed was then projected from whatever burst remained — three keystrokes in a
+  tenth of a second reported 360 wpm, and it was written to history as a personal
+  best nothing could beat. Such runs are now shown but not recorded, and the
+  result screen says why rather than leaving the run to vanish.
+
+- **A test with no measurable duration no longer reports 100% accuracy.** A
+  single wrong keystroke could score a flawless run and, being the first record
+  in its bucket, become a permanent best.
+
+- **Strict mode results match what you typed.** Keys the mode refused were being
+  replayed as though they had been accepted, so a strict run that ended matching
+  the target exactly was scored with wrong characters in it. Strict mode also now
+  refuses keys typed past the end of the target.
+
+- **Progress counts the right thing in every mode.** A timed test reported its
+  progress against a millisecond deadline instead of a word count, and a Code
+  test had no total at all.
+
+- **The notification about a result that could not be saved is now visible.** It
+  was written to a row that gets clipped whenever the screen is short — which is
+  exactly when there is something to report.
+```
+
+## Unresolved questions
+
+1. **Consistency for runs under one second is now `0`, not ~76.** No complete
+   second means no sample, and `Consistency` already documents `0` as "no data".
+   Unreachable in practice (Words-10 and Quote both take seconds; Time is ≥15 s),
+   but it is a behaviour change and nobody signed off on it explicitly.
+2. **`persistErr` is now also the AFK-notice channel.** The field name and its
+   comment in `internal/app/model.go` (outside this phase's ownership) still say
+   it is for write failures. It should be renamed to something like `notice`, and
+   `ui.PersistenceNotice` with it. Whoever owns `model.go` next should do that.
+3. **Phase 4 still owns width-bounding the notice.** `overlayNotice` centres with
+   `lipgloss.PlaceHorizontal(w, …)` and does not truncate, so the AFK copy
+   (`⚠ paused mid-test — not saved to history  ·  press any key to dismiss`,
+   68 cells) will overflow a 60-column terminal exactly as the existing copy
+   does. Not made worse; not fixed here.
+4. **The AFK notice costs Result a row it does not have at h=24.** Phase 6's
+   budget gate needs to account for it — flagged in the phase brief, restated
+   here because the notice is now reachable on the ordinary result path, not just
+   on a disk failure.
+5. **Phase 2 must adapt `screen_typing_view.go:25`.** `Progress()`'s contract has
+   changed and that call site was deliberately not touched. `ModeHeader` ignores
+   `done/total` for Time mode, so nothing breaks today, but Words/Quote/Code now
+   receive different-meaning values for Code (runes, previously `words / 0`).
+6. **Plan status not updated.** The phase file's `status:` frontmatter is plan
+   state; left for the orchestrator per the repo's plan-state rule.


### PR DESCRIPTION
Ten defects where the *number* was wrong. Each was reproduced as a failing test before being fixed.

## Measured, before → after

| Defect | Before | After |
|---|---|---|
| AFK burst, Time/30, 3 keys in 100 ms | `NetWPM=360.0`, persisted, became a personal best | `NetWPM=0`, `AFKTrimmed=true`, not stored, not ranked |
| Zero duration, one wrong key | `Accuracy=100.0`, `KeystrokeAccuracy=100.0` | `0.0 / 0.0` |
| Strict `abcdef` replay desync (engine buffer really is `abcdef`) | `Correct=9 Incorrect=2 Accuracy=81.82` | `Correct=6 Incorrect=0 Accuracy=100.00` |
| Strict, keys past end of target | buffer `abzzzzzzzzzz`, `Extra=10` | buffer `ab`, `Extra=0` |
| `Progress()` | Time `0/30000` (milliseconds as a word count), Code `0/0` | Time `0/3` words, Code `0/5` runes |
| Consistency, even 5 c/s over 3.2 s | `60.08` | `76.16` (the formula maximum) |

`knownImplausible` is now **empty** and the ratchet passes with zero entries.

## Two user-visible behaviour changes

- **Consistency scores rise for everyone.** The final partial second was scaled as if it were whole. A perfectly even typist could not score the formula maximum. Scores only move up; stored history is untouched.
- **A run abandoned mid-test is no longer saved,** and says so rather than vanishing. Its rates describe the burst typed before walking away, so a stored record would stand as a personal best nobody could beat by typing.
- Strict-mode `Errors` now counts **every** wrong key including corrected ones, per the recorded decision — the same run reports `5` where it used to report `2`.

## The assertion whose absence let this ship

The AFK defect spanned `TrimAFK → Compute → Record.NetWPM → IsNewBest → AppendHistory` — four packages — and every existing test was within-package. `internal/app/result_persistence_test.go` is the cross-package seam: it runs an AFK-shaped result through `handleResultMsg` and asserts nothing was persisted and no best was recorded.

Verified independently before merge: forcing `AFKTrimmed` to false fails all three `internal/app` seam tests plus two in `internal/metrics`.

## `typedFromLog` was a second copy of the same bug

`internal/ui/typing_log_helpers.go` reimplemented the buggy replay loop byte-for-byte, so fixing `compute.go` alone would have left it. Collapsed rather than fixed twice: `typing.ReplayBuffer`/`typing.TypedFromLog` is now the single definition and both callers delegate.

`typing.Keystroke` gained `Blocked` with `omitempty`, so pre-existing replay logs decode to `false` — today's behaviour. Covered by a fixture written without the field.

`engine.go` split 197 → 156 across `engine_states.go`, `engine_progress.go`, `replay.go`. `Engine.wordTarget` renamed to `Engine.limit`: the old name asserted a unit that is wrong in Time mode, which was the `Progress()` bug.

12 mutations run, 12 caught.

## Two deviations from the phase spec, both forced by file ownership

1. **`EligibleForBest` gained no AFK branch.** `storage.Record` has no AFK field and that file was owned by a concurrent phase. Since AFK runs are never written, no stored record can carry the flag; the gate lives in `app.decideOutcome`, the only writer, enforced by the seam tests.
2. **The notice never lengthens an already-overflowing frame.** Inserting unconditionally would have changed a `knownAppOverflow` entry from 29 to 30 lines in a file this phase must not edit. Every other measurement is byte-identical, and the insert path activates for free once the Result screen comes inside 24 rows.

## Open

Consistency for sub-one-second runs is now 0. Unreachable in practice, but it is a new value, not an inherited one.