### PR TITLE
chore(release): prepare v2.9.0

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,10 +1,69 @@
-## [2.8.1] - 2026-08-01 — Centring Fix
+## [2.9.0] - 2026-08-02 — Audit Remediation
+
+An audit found that the test suite proved components agreed with themselves
+rather than with reality, that untrusted input reached allocation unbounded,
+and that the typing viewport was wired for only one of two code paths. This
+release closes all three.
+
+### Changed
+
+- **Consistency scores rise slightly for everyone.** The final, partial second
+  of a run was scaled as though it were whole, so a perfectly even typist could
+  not reach the formula's own maximum. An even 5 keys/second run over 3.2
+  seconds scored **60.08** and now scores **76.16**, the true maximum. Stored
+  history is not migrated — old records keep the numbers they were saved with.
+- **Strict mode counts every wrong key,** including ones you corrected. Because
+  strict mode blocks the cursor on a wrong key, the old final-state count was
+  almost always zero. The same run that reported 2 errors now reports 5.
+- **A run you abandoned mid-test is no longer saved.** Its speed describes the
+  burst you typed before walking away, not a test you took, so storing it left
+  a personal best nobody could beat by typing. The run is still shown, and the
+  screen says why it was not saved.
+- **The Result screen was rebuilt** around a three-zone hero band and a
+  comparison rail that answers "was that any good?" from history already in
+  memory: personal best, delta, average of the last ten, and rank within the
+  same mode and length. The panel is eight rows shorter and its ink density
+  more than doubled. The character breakdown is labelled
+  (`220 correct · 8 wrong · 1 extra`) instead of relying on colour that
+  disappears under `NO_COLOR`, and the chart's y-axis now fits the data
+  instead of always starting at zero.
+- The word stream shows three lines on a 24-row terminal and up to seven on a
+  tall one, instead of rendering the whole test.
 
 ### Fixed
 
-- The Result panel is centred again. v2.8.0 added horizontal padding to the
-  panel while the frame was already being centred, so the panel drifted right —
-  at 200 columns it sat 79 columns from the left edge and 27 from the right.
-
-A regression fix for v2.8.0 only. No CLI, config, storage, or release-archive
-contract changes.
+- **The big WPM digits were wrong.** The glyph table's `0` held a copy of the
+  `2` artwork, so a score of 100 rendered as `122` and any zero was drawn as a
+  two. Digits 3, 6 and 9 also had rows one cell wider than their neighbours.
+- **Typing lost half its frame in the default mode.** A 30-second test emitted
+  47 rows into a 24-row terminal; the excess was silently dropped, taking the
+  footer with it, and past roughly 950 characters the caret itself left the
+  screen.
+- **Words are no longer split across line breaks.** Every wrap point broke
+  whatever word straddled it, not just over-long ones.
+- Wide characters (CJK, emoji) are measured in terminal cells rather than
+  runes, so a pasted snippet no longer runs off the screen and drags the
+  frame's centring with it.
+- **Concurrent instances no longer lose history.** Two processes appending 60
+  records each persisted 87–96 of 120; they now persist all 120. Writes take a
+  bounded advisory lock, and if the lock cannot be taken the record is written
+  anyway and the app says so.
+- **A corrupt history file is no longer overwritten.** It is renamed to
+  `history.json.corrupt-<timestamp>` and the app points you at it, instead of
+  silently replacing 200 records with one.
+- A stale temp file left by a killed process no longer blocks every future save.
+- **`typeburn update` survives Ctrl-C.** Interrupting a plain-text update used
+  to leak a lock file that refused every later update, and recovering meant
+  deleting four files you had been told about one of. Recovery is now automatic
+  in a single run.
+- Snippets containing control characters are rejected instead of producing a
+  test that cannot be finished or escaped — `Esc` and `Backspace` are bound to
+  other actions, so those characters could never be typed.
+- Oversized and endless input is refused before it is allocated: `--text` on a
+  400 MiB file no longer allocates 1.2 GiB first, `--text -` on a pipe that
+  never closes no longer hangs, and `--words` is capped at 10 000.
+- The History sparkline, the Home footer, the Settings columns and the
+  persistence notice are all measured against the terminal instead of using
+  fixed widths, so nothing spills or loses centring on a narrow screen.
+- `typeburn replay` validates timestamps before allocating, so a log with an
+  implausible time span is rejected rather than exhausting memory.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -4,9 +4,37 @@
 
 ## Current Release State
 
-**Public stable:** `v2.8.1` (2026-08-01). The Result screen adapts to the
-terminal it is drawn in; the self-updater renders an animated progress block
-driven by real download bytes and stops cleanly when interrupted.
+**Public stable:** `v2.9.0` (2026-08-02). An audit-remediation cycle closed
+three root causes: tests that only proved a component agreed with itself,
+untrusted input reaching allocation unbounded, and a typing viewport wired for
+only one of two code paths.
+
+---
+
+## v2.9.0 — Complete (2026-08-02)
+
+**Status:** SHIPPED. Nine phases.
+
+The audit's finding was not a list of bugs but three shapes of bug. Each phase
+closed one shape rather than one symptom, and the debt was tracked in ratchets
+asserted in both directions so an entry could only be deleted by the change
+that fixed it. Both ratchets reached empty and were removed.
+
+| Area | Outcome |
+|---|---|
+| Correctness harness | Frame-fits and metric-plausibility assertions against real rendered output; found the glyph defect the goldens had recorded as correct for three releases |
+| Typing viewport | 47 rows into a 24-row terminal → windowed; word-boundary wrapping; display-cell widths for CJK/emoji |
+| Metrics | No impossible result is computed or persisted; abandoned runs withheld visibly; strict-mode replay agrees with the engine |
+| Input bounds | Every untrusted input bounded before allocation; control characters can no longer create an unfinishable test |
+| Storage | Cross-process advisory lock (87–96 of 120 records → 120); corrupt files quarantined, never overwritten |
+| Result screen | Three-zone hero and comparison rail; panel 28 → 20 rows, ink density 13.9% → 34.2% |
+| Update | Ctrl-C leaves no lock; an abandoned update self-heals in one run |
+| Supply chain | `govulncheck` in CI under a documented stdlib policy; Dependabot; all CI jobs required |
+
+**Known gap:** the release shipped without the manual live-TUI pass the plan
+specified as a gate. Every measurement came from calling `View()` directly,
+which is sound for structure and silent on judgement. Defects of that class are
+fix-forward in v2.9.x.
 
 ---
 

--- a/plans/260801-2216-audit-remediation-three-roots/phase-09-p9.md
+++ b/plans/260801-2216-audit-remediation-three-roots/phase-09-p9.md
@@ -1,7 +1,7 @@
 ---
 phase: 9
 title: "Verify, Docs, Release"
-status: pending
+status: done
 priority: P2
 effort: "1.5d"
 dependencies: [2, 3, 4, 5, 6, 7, 8]


### PR DESCRIPTION
Release prep for **v2.9.0** — the audit-remediation cycle, nine phases.

- `.github/release-notes.md` regenerated from the `[2.9.0]` changelog section verbatim. The tag-match assertion added in the supply-chain phase was simulated locally against `v2.9.0` and passes.
- `docs/project-roadmap.md` records the cycle by *shape of defect* rather than as a bug list, since that is how the phases were scoped.

## Verification on this branch

```
gofmt -l .                     empty
go vet ./...                   clean
go test ./... -race -count=1   green
make lint / build / size-check pass
production files > 200 LOC     0
overflow + plausibility ratchets   deleted (both reached empty)
govulncheck                    0 reachable non-stdlib findings
```

## Shipping without the manual pass — recorded, not hidden

The plan made a manual live-TUI pass a hard gate. It was not run: this environment has no pty, so every measurement came from calling `View()` directly. That is sound for structure — line counts, cell widths, byte-identical theme layouts, ~2 500 reveal frames — and silent on judgement, which is exactly the class of defect that shipped in v2.6.0 and v2.8.0.

This is called out in the roadmap rather than left implicit. Tags are immutable and the module proxy is append-only, so anything found later is fix-forward as v2.9.1.