### PR TITLE
ci: exempt prerelease tags from the release-notes assertion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,13 @@ jobs:
       # tags are immutable, so there is no fixing it afterwards. Assert the tag
       # appears in the file's first heading before anything is published.
       # ref_name is read via env, never interpolated into the script body.
+      # Skipped for prerelease tags. The assertion exists to stop the previous
+      # release's notes being published under a new, immutable STABLE tag. The
+      # disposable dry-run tag (v0.0.0-rc.test) is deliberately a version no
+      # curated heading will ever name, so applying it there would make the
+      # documented dry-run impossible to run.
       - name: Verify release notes match the tag
+        if: ${{ !contains(github.ref_name, '-') }}
         env:
           TAG: ${{ github.ref_name }}
         run: |


### PR DESCRIPTION
Found while preparing to run the documented dry-run before tagging v2.9.0.

The release-notes assertion added with the supply-chain gates asserts that `${TAG#v}` appears in the first `## ` heading of `.github/release-notes.md`. That is correct for a stable tag — it stops the previous release's notes being published under a new, immutable one.

But the release runbook rehearses the publish path by pushing a **disposable prerelease tag**, `v0.0.0-rc.test`. That version will never appear in a curated heading, by design. So the check as written **fails every dry-run**, which would have quietly removed the only rehearsal of the real publish path — the step that exists precisely because tags cannot be withdrawn.

Fixed with the same prerelease predicate the surrounding steps already use (`!contains(github.ref_name, '-')`), so it sits alongside the Homebrew permission check and the stable GoReleaser step and behaves consistently with them.

Net effect: stable tags are still gated; dry-runs can run again.